### PR TITLE
Make the code robust wrt multiple newlines

### DIFF
--- a/src/GuiException/UiException/DefaultTextManager.cs
+++ b/src/GuiException/UiException/DefaultTextManager.cs
@@ -121,7 +121,7 @@ namespace NUnit.UiException
             _lines.Clear();
             _maxLength = 0;
 
-            while ((newIndex = text.IndexOf("\n", textIndex, StringComparison.Ordinal)) > textIndex)
+            while ((newIndex = text.IndexOf("\n", textIndex, StringComparison.Ordinal)) >= textIndex)
             {
                 line = text.Substring(textIndex, newIndex - textIndex).TrimEnd();
                 _maxLength = Math.Max(_maxLength, line.Length);

--- a/src/GuiException/tests/CodeFormatters/TestPlainTextCodeFormatter.cs
+++ b/src/GuiException/tests/CodeFormatters/TestPlainTextCodeFormatter.cs
@@ -110,5 +110,28 @@ namespace NUnit.UiException.Tests.CodeFormatters
 
             return;
         }
+
+        [TestCase("\n\nStart")]
+        [TestCase("Start\n\nEnd")]
+        [TestCase("End\n\n")]
+        [TestCase("\n\n\nStart")]
+        [TestCase("Start\n\n\nEnd")]
+        [TestCase("End\n\n\n")]
+        public void Format_Lines_MultipleLinuxNewLines(string input)
+        {
+            Assert.DoesNotThrow(() => _formatter.Format(input));
+        }
+
+        [TestCase("\r\n\r\nStart")]
+        [TestCase("Start\r\n\r\nEnd")]
+        [TestCase("End\r\n\r\n")]
+        [TestCase("\r\n\r\n\r\nStart")]
+        [TestCase("Start\r\n\r\n\r\nEnd")]
+        [TestCase("End\r\n\r\n\r\n")]
+
+        public void Format_Lines_MultipleWindowsNewLines(string input)
+        {
+            Assert.DoesNotThrow(() => _formatter.Format(input));
+        }
     }    
 }


### PR DESCRIPTION
This change makes it possible to successfully read
multiple consecutive (linux) newlines without
throwing an exception.