### PR TITLE
Remove NRE when changing ShowCheckBoxes

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestTree.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestTree.cs
@@ -114,8 +114,6 @@ namespace TestCentric.Gui.Controls
 
         private ITestModel Model { get; set; }
 
-        private UserSettings UserSettings { get; set; }
-
 		[Browsable(false)]
 		public bool ShowCheckBoxes
 		{
@@ -692,8 +690,8 @@ namespace TestCentric.Gui.Controls
         //}
 
         private void checkBoxesMenuItem_Click(object sender, System.EventArgs e)
-		{
-            UserSettings.TestCentric.TestTree.ShowCheckBoxes = ShowCheckBoxes = !checkBoxesMenuItem.Checked;
+        {
+            ShowCheckBoxes = !checkBoxesMenuItem.Checked;
         }
 
         private void UpdateCategorySelection()
@@ -713,9 +711,9 @@ namespace TestCentric.Gui.Controls
         }
 
         private void tests_CheckBoxesChanged(object sender, System.EventArgs e)
-		{
-			ShowCheckBoxes = tests.CheckBoxes;
-		}
+        {
+            ShowCheckBoxes = tests.CheckBoxes;
+        }
 
         //private void UserSettings_Changed(object sender, SettingsEventArgs args)
         //{


### PR DESCRIPTION
Fixes #52

Note, I've decided not to update the setting `TestTreeSettings.ShowCheckBoxes` when changing  `Show CheckBoxes` via the menu or via the context menu. This can be done via `Model`, if we choose so. The reason for this, is it seems that most changes in menus do not update the "default" settings in `Tools => Settings` (except for Full GUI vs Mini GUI).

Also note that we do not change the user interface, if we change the setting `TestTreeSettings.ShowCheckBoxes`. This will first have effect when we restart the program. We could do this by commenting in the method `UserSettings_Changed` (and do some more changes), but it does not seem like we update the UI immediately when changing settings in `Tools => Settings`.

So before making the above mentioned changes I think we should decide upon the connection between the settings in `Tools => Settings` and settings we can set directly in the GUI (in menus and context-menues). I think of them as the "default" vs. the "current" settings, but it can be that this is just my interpretation.