### PR TITLE
Restore results correctly after reload

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestSuiteTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestSuiteTreeView.cs
@@ -646,15 +646,14 @@ namespace TestCentric.Gui.Controls
         /// <param name="test">Test suite to be loaded</param>
         public void Reload(TestNode test)
         {
-            ResultNode result = ((TestSuiteTreeNode)Nodes[0]).Result;
             VisualState visualState = new VisualState(this);
 
             Load(test);
 
             visualState.Restore(this);
 
-            if (result != null && !UserSettings.Gui.ClearResultsOnReload)
-                RestoreResults(result);
+            if (!UserSettings.Gui.ClearResultsOnReload)
+                RestoreResults(test);
         }
 
         /// <summary>
@@ -1044,15 +1043,13 @@ namespace TestCentric.Gui.Controls
             }
         }
 
-        private void RestoreResults(ResultNode resultNode)
+        private void RestoreResults(TestNode testNode)
         {
-            foreach (TestNode child in resultNode.Children)
-            {
-                if (child is ResultNode)
-                    RestoreResults(child as ResultNode);
-            }
 
-            SetTestResult(resultNode);
+            foreach (TestNode child in testNode.Children)
+                RestoreResults(child);
+
+            SetTestResult(Model.GetResultForTest(testNode));
         }
 
         private void LoadAlternateImages()

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -194,18 +194,11 @@ namespace TestCentric.Gui.Model
 
         public void ReloadTests()
         {
-            Runner.Unload();
-            Results.Clear();
-            Tests = null;
-
-            TestPackage = MakeTestPackage(TestFiles);
-
-            Runner = TestEngine.GetRunner(TestPackage);
-
             Tests = new TestNode(Runner.Explore(TestFilter.Empty));
             AvailableCategories = GetAvailableCategories();
 
-            Results.Clear();
+            if (Services.UserSettings.Gui.ClearResultsOnReload)
+                Results.Clear();
 
             _events.FireTestReloaded(Tests);
         }


### PR DESCRIPTION
Fixes #14 

It turns out that the reload code was the same as the load code. It got a completely new runner and started from scratch, rather than reusing the runner. The fix that's in causes us to reload the results when called for after reloading the tests. It does not fix any problems in __how__ the reloading works. We will need to create issues for any specific problems in matching old results to the newly reloaded test. Examples of situations we have yet to deal with include deleting or renaming a test.