### PR TITLE
Initial implementation of doubles to replace tests using the engine

### DIFF
--- a/src/TestCentric/tests/RecentFileMenuHandlerTests.cs
+++ b/src/TestCentric/tests/RecentFileMenuHandlerTests.cs
@@ -27,6 +27,7 @@ using System.Windows.Forms;
 using NSubstitute;
 using NUnit.Engine;
 using NUnit.Framework;
+using NUnit.TestUtilities.Fakes;
 using TestCentric.Gui.Model;
 using TestCentric.Gui.Model.Settings;
 
@@ -35,130 +36,95 @@ namespace TestCentric.Gui.Tests
     [TestFixture]
     public class RecentFileMenuHandlerTests
     {
-        private MenuItem menu;
-        private IRecentFiles files;
-        private RecentFileMenuHandler handler;
-        private int maxFiles;
-        private bool checkFilesExist;
+        private ITestModel _model;
+        private RecentProjectsSettings _settings;
+        private IRecentFiles _recentFiles;
+
+        private MenuItem _menu;
+        private RecentFileMenuHandler _handler;
 
         [SetUp]
         public void SetUp()
         {
-            menu = new MenuItem();
-            var testModel = Substitute.For<ITestModel>();
-            var settings = Substitute.For<ISettings>();
-            maxFiles = 24;
-            settings.GetSetting("Gui.RecentProjects.MaxFiles", Arg.Any<int>()).Returns(_ => maxFiles);
-            checkFilesExist = false;
-            settings.GetSetting("Gui.RecentProjects.CheckFilesExist", Arg.Any<bool>()).Returns(_ => checkFilesExist);
-            var userSettings = new UserSettings(settings);
-            testModel.Services.UserSettings.Returns(userSettings);
+            _model = new TestModel(new MockTestEngine());
+            _settings = _model.Services.UserSettings.Gui.RecentProjects;
+            _recentFiles = _model.Services.RecentFiles;
 
-            files = new FakeRecentFiles();
-            testModel.Services.RecentFiles.Returns(files);
-
-            handler = new RecentFileMenuHandler(menu, testModel, f => !f.StartsWith("_"));
+            _menu = new MenuItem();
+            _handler = new RecentFileMenuHandler(_menu, _model, f => !f.StartsWith("_"));
         }
 
         [Test]
         public void DisableOnLoadWhenEmpty()
         {
-            handler.Load();
-            Assert.IsFalse(menu.Enabled);
+            _handler.Load();
+            Assert.IsFalse(_menu.Enabled);
         }
 
         [Test]
         public void EnableOnLoadWhenNotEmpty()
         {
-            files.SetMostRecent("Test");
-            handler.Load();
-            Assert.IsTrue(menu.Enabled);
+            _recentFiles.SetMostRecent("Test");
+            _handler.Load();
+            Assert.IsTrue(_menu.Enabled);
         }
 
         [Test]
         public void LoadMenuItems()
         {
-            files.SetMostRecent("Third");
-            files.SetMostRecent("Second");
-            files.SetMostRecent("First");
-            handler.Load();
-            Assert.AreEqual(3, menu.MenuItems.Count);
-            Assert.AreEqual("1 First", menu.MenuItems[0].Text);
+            _recentFiles.SetMostRecent("Third");
+            _recentFiles.SetMostRecent("Second");
+            _recentFiles.SetMostRecent("First");
+            _handler.Load();
+            Assert.AreEqual(3, _menu.MenuItems.Count);
+            Assert.AreEqual("1 First", _menu.MenuItems[0].Text);
         }
 
         [Test]
         public void LoadMoreMenuItemsThanMaxFiles([Values(1, 2, 3)] int numMaxFiles)
         {
-            maxFiles = numMaxFiles;
-            files.SetMostRecent("Fourth");
-            files.SetMostRecent("Third");
-            files.SetMostRecent("Second");
-            files.SetMostRecent("First");
-            handler.Load();
-            Assert.That(menu.MenuItems.Count, Is.EqualTo(numMaxFiles));
+            _settings.MaxFiles = numMaxFiles;
+
+            _recentFiles.SetMostRecent("Fourth");
+            _recentFiles.SetMostRecent("Third");
+            _recentFiles.SetMostRecent("Second");
+            _recentFiles.SetMostRecent("First");
+            _handler.Load();
+            Assert.That(_menu.MenuItems.Count, Is.EqualTo(numMaxFiles));
         }
 
         [TestCase(true, new[] { "1 First", "2 Second", "3 Third" })]
         [TestCase(false, new[] { "1 First", "2 _ First filter", "3 Second", "4 _ Second filter", "5 Third" })]
         public void LoadMenuItemsFilteringWorks(bool checkFiles, string[] expectedItems)
         {
-            checkFilesExist = checkFiles;
-            files.SetMostRecent("Third");
-            files.SetMostRecent("_ Second filter");
-            files.SetMostRecent("Second");
-            files.SetMostRecent("_ First filter");
-            files.SetMostRecent("First");
-            handler.Load();
-            Assert.AreEqual(expectedItems.Count(), menu.MenuItems.Count);
-            CollectionAssert.AreEqual(expectedItems, menu.MenuItems.Cast<MenuItem>().Select(m => m.Text));
+            _settings.MaxFiles = 24;
+            _settings.CheckFilesExist = checkFiles;
+
+            _recentFiles.SetMostRecent("Third");
+            _recentFiles.SetMostRecent("_ Second filter");
+            _recentFiles.SetMostRecent("Second");
+            _recentFiles.SetMostRecent("_ First filter");
+            _recentFiles.SetMostRecent("First");
+            _handler.Load();
+            Assert.AreEqual(expectedItems.Count(), _menu.MenuItems.Count);
+            CollectionAssert.AreEqual(expectedItems, _menu.MenuItems.Cast<MenuItem>().Select(m => m.Text));
         }
 
         [TestCase(true, new[] { "1 First", "2 Second" })]
         [TestCase(false, new[] { "1 First", "2 _ First filter" })]
         public void LoadMenuItemsFilteringWorksWithTooManyElements(bool checkFiles, string[] expectedItems)
         {
-            maxFiles = 2;
-            checkFilesExist = checkFiles;
-            files.SetMostRecent("Third");
-            files.SetMostRecent("_ Second filter");
-            files.SetMostRecent("Second");
-            files.SetMostRecent("_ First filter");
-            files.SetMostRecent("First");
-            handler.Load();
-            Assert.AreEqual(expectedItems.Count(), menu.MenuItems.Count);
-            CollectionAssert.AreEqual(expectedItems, menu.MenuItems.Cast<MenuItem>().Select(m => m.Text));
-        }
+            _settings.MaxFiles = 2;
+            _settings.CheckFilesExist = checkFiles;
 
-        private class FakeRecentFiles : IRecentFiles
-        {
-            private IList<string> files = new List<string>();
-            private int maxFiles = 24;
-
-            public int Count
-            {
-                get { return files.Count; }
-            }
-
-            public int MaxFiles
-            {
-                get { return maxFiles; }
-                set { maxFiles = value; }
-            }
-
-            public void SetMostRecent(string fileName)
-            {
-                files.Insert(0, fileName);
-            }
-
-            public IList<string> Entries
-            {
-                get { return files; }
-            }
-
-            public void Remove(string fileName)
-            {
-                files.Remove(fileName);
-            }
+            _recentFiles.SetMostRecent("Third");
+            _recentFiles.SetMostRecent("_ Second filter");
+            _recentFiles.SetMostRecent("Second");
+            _recentFiles.SetMostRecent("_ First filter");
+            _recentFiles.SetMostRecent("First");
+            _handler.Load();
+            Assert.AreEqual(expectedItems.Count(), _menu.MenuItems.Count);
+            CollectionAssert.AreEqual(expectedItems, _menu.MenuItems.Cast<MenuItem>().Select(m => m.Text));
         }
 
         // TODO: Need mock loader to test clicking

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -96,6 +96,10 @@
       <Project>{2e368281-3ba8-4050-b05e-0e0e43f8f446}</Project>
       <Name>mock-assembly</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\tests\test-utilities\test-utilities.csproj">
+      <Project>{3e63ad0f-24d4-46be-bee4-5a3299847d86}</Project>
+      <Name>test-utilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\model\TestCentric.Gui.Model.csproj">
       <Project>{e978a8d7-e4a4-4de9-94df-d82bd764936b}</Project>
       <Name>TestCentric.Gui.Model</Name>

--- a/src/TestModel/tests/TestModelPackageTests.cs
+++ b/src/TestModel/tests/TestModelPackageTests.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using NSubstitute;
 using NUnit.Engine;
 using NUnit.Framework;
+using NUnit.TestUtilities.Fakes;
 
 namespace TestCentric.Gui.Model
 {
@@ -35,8 +36,7 @@ namespace TestCentric.Gui.Model
         [SetUp]
         public void CreateModel()
         {
-            var engine = Substitute.For<ITestEngine>();
-            _model = new TestModel(engine);
+            _model = new TestModel(new MockTestEngine());
         }
 
         [TestCase("my.test.assembly.dll")]

--- a/src/tests/test-utilities/Fakes/AvailableRuntimesService.cs
+++ b/src/tests/test-utilities/Fakes/AvailableRuntimesService.cs
@@ -24,25 +24,21 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class AvailableRuntimesService : IAvailableRuntimes
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        private List<IRuntimeFramework> _availableRuntimes = new List<IRuntimeFramework>();
+
+        public void AddRuntimes(params IRuntimeFramework[] runtimes)
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
+            _availableRuntimes.AddRange(runtimes);
+        }
 
-            var model = new TestModel(mockEngine);
-
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+        public IList<IRuntimeFramework> AvailableRuntimes
+        {
+            get { return _availableRuntimes; }
         }
     }
 }

--- a/src/tests/test-utilities/Fakes/ExtensionService.cs
+++ b/src/tests/test-utilities/Fakes/ExtensionService.cs
@@ -1,0 +1,123 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using NUnit.Engine;
+using NUnit.Engine.Extensibility;
+
+namespace NUnit.TestUtilities.Fakes
+{
+    public class ExtensionService : IExtensionService
+    {
+        private List<IExtensionPoint> _extensionPoints;
+        private List<IExtensionNode> _extensions;
+
+        public ExtensionService()
+        {
+            _extensionPoints = new List<IExtensionPoint>();
+
+            // ExtensionPoints are all known, so we add in constructor. Extensions
+            // may vary, so we use a method to add them.
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/NUnitV2Driver", "NUnit.Engine.Extensibility.IDriverFactory", "Driver for NUnit tests using the V2 framework."));
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/TypeExtensions/IService", "NUnit.Engine.Extensibility.IService", "Provides a service within the engine and possibly externally as well."));
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/TypeExtensions/ITestEventListener", "NUnit.Engine.Extensibility.ITestEventListener", "Allows an extension to process progress reports and other events from the test."));
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/TypeExtensions/IDriverFactory", "NUnit.Engine.Extensibility.IDriverFactory", "Supplies a driver to run tests that use a specific test framework."));
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/TypeExtensions/IProjectLoader", "NUnit.Engine.Extensibility.IProjectLoader", "Recognizes and loads assemblies from various types of project formats."));
+            _extensionPoints.Add(new ExtensionPoint(
+                "/NUnit/Engine/TypeExtensions/IResultWriter", "NUnit.Engine.Extensibility.IResultWriter", "Supplies a writer to write the result of a test to a file using a specific format."));
+        }
+
+        public void AddExtensions(params IExtensionNode[] extensions)
+        {
+            _extensions.AddRange(extensions);
+        }
+
+        public IEnumerable<IExtensionPoint> ExtensionPoints { get { return _extensionPoints; } }
+
+        public IEnumerable<IExtensionNode> Extensions { get; } = new List<IExtensionNode>();
+
+        public void EnableExtension(string typeName, bool enabled)
+        {
+        }
+
+        public IEnumerable<IExtensionNode> GetExtensionNodes(string path)
+        {
+            return new IExtensionNode[0];
+        }
+
+        public IExtensionPoint GetExtensionPoint(string path)
+        {
+            return null;
+        }
+
+        // ExtensionPoint class is nested since the list of extension points is fixed
+        public class ExtensionPoint : IExtensionPoint
+        {
+            public ExtensionPoint(string path, string typeName, string description)
+            {
+                Path = path;
+                TypeName = typeName;
+                Description = description;
+            }
+
+            public string Description { get; }
+
+            public IEnumerable<IExtensionNode> Extensions { get; } = new List<IExtensionNode>();
+
+            public string Path { get; }
+
+            public string TypeName { get; }
+        }
+    }
+
+    public class ExtensionNode : IExtensionNode
+    {
+        public ExtensionNode(string path, string typeName, string description)
+        {
+            Path = path;
+            TypeName = typeName;
+            Description = description;
+        }
+
+        public string Description { get; }
+
+        public bool Enabled { get; }
+
+        public string Path { get; }
+
+        public IEnumerable<string> PropertyNames { get; }
+
+        public string TypeName { get; }
+
+        public IEnumerable<string> GetValues(string name)
+        {
+            return new string[0];
+        }
+    }
+}

--- a/src/tests/test-utilities/Fakes/MockTestEngine.cs
+++ b/src/tests/test-utilities/Fakes/MockTestEngine.cs
@@ -1,0 +1,116 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Engine;
+
+namespace NUnit.TestUtilities.Fakes
+{
+    public class MockTestEngine : ITestEngine
+    {
+        #region Instance Variables
+
+        private ServiceLocator _services = new ServiceLocator();
+
+        // Simulate Engine internal services, which are always present
+        private SettingsService _settings = new SettingsService();
+        private RecentFilesService _recentFiles = new RecentFilesService();
+        private ExtensionService _extensions = new ExtensionService();
+        private ResultService _resultService = new ResultService();
+        private AvailableRuntimesService _availableRuntimes = new AvailableRuntimesService();
+
+        #endregion
+
+        #region Constructor
+
+        public MockTestEngine()
+        {
+            _services.AddService<ISettings>(_settings);
+            _services.AddService<IRecentFiles>(_recentFiles);
+            _services.AddService<IExtensionService>(_extensions);
+            _services.AddService<IResultService>(_resultService);
+            _services.AddService<IAvailableRuntimes>(_availableRuntimes);
+        }
+
+        #endregion
+
+        #region Fluent Engine Setup Methods
+
+        public MockTestEngine WithService<TService>(TService service)
+        {
+            _services.AddService<TService>(service);
+            return this;
+        }
+
+        public MockTestEngine WithSetting(string key, object value)
+        {
+            _settings.SaveSetting(key, value);
+            return this;
+        }
+
+        public MockTestEngine WithExtension()
+        {
+            return this;
+        }
+
+        public MockTestEngine WithResultWriter(string name)
+        {
+            return this;
+        }
+
+        public MockTestEngine WithRuntimes(params RuntimeFramework[] runtimes)
+        {
+            _availableRuntimes.AddRuntimes(runtimes);
+            return this;
+        }
+
+        #endregion
+
+        #region ITestEngine Explicit Implementation
+
+        InternalTraceLevel ITestEngine.InternalTraceLevel { get; set; }
+
+        IServiceLocator ITestEngine.Services { get { return _services; } }
+
+        string ITestEngine.WorkDirectory { get; set; }
+
+        ITestRunner ITestEngine.GetRunner(TestPackage package)
+        {
+            throw new NotImplementedException();
+        }
+
+        void ITestEngine.Initialize()
+        {
+        }
+
+        #endregion
+
+        #region IDisposable explicit implementation
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        #endregion
+    }
+}

--- a/src/tests/test-utilities/Fakes/RecentFilesService.cs
+++ b/src/tests/test-utilities/Fakes/RecentFilesService.cs
@@ -24,25 +24,36 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class RecentFilesService : IRecentFiles
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        private List<string> files = new List<string>();
+        private int maxFiles = 24;
+
+        public int MaxFiles
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
+            get { return maxFiles; }
+            set { maxFiles = value; }
+        }
 
-            var model = new TestModel(mockEngine);
+        public void SetMostRecent(string fileName)
+        {
+            files.Insert(0, fileName);
+        }
 
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+        public IList<string> Entries
+        {
+            get { return files; }
+        }
+
+        public void Remove(string fileName)
+        {
+            files.Remove(fileName);
         }
     }
+
+    // TODO: Need mock loader to test clicking
 }
+

--- a/src/tests/test-utilities/Fakes/ResultService.cs
+++ b/src/tests/test-utilities/Fakes/ResultService.cs
@@ -22,27 +22,24 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
+using NUnit.Engine.Extensibility;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class ResultService : IResultService
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        public string[] Formats
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-            var model = new TestModel(mockEngine);
-
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+        public IResultWriter GetResultWriter(string format, object[] args)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/tests/test-utilities/Fakes/RuntimeFramework.cs
+++ b/src/tests/test-utilities/Fakes/RuntimeFramework.cs
@@ -22,27 +22,30 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class RuntimeFramework : IRuntimeFramework
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        public RuntimeFramework(string id, Version version)
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
-
-            var model = new TestModel(mockEngine);
-
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+            Id = id;
+            FrameworkVersion = version.Build >= 0
+                ? new Version(version.Major, version.Minor)
+                : version;
+            ClrVersion = version;
+            DisplayName = id;
         }
+
+        public string Id { get; }
+
+        public Version FrameworkVersion { get; }
+
+        public Version ClrVersion { get; }
+
+        public string DisplayName { get; set; }
+
+        public string Profile { get; set; }
     }
 }

--- a/src/tests/test-utilities/Fakes/ServiceLocator.cs
+++ b/src/tests/test-utilities/Fakes/ServiceLocator.cs
@@ -24,25 +24,28 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class ServiceLocator : IServiceLocator
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        private Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        public void AddService<T>(T service)
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
+            _services.Add(typeof(T), service);
+        }
 
-            var model = new TestModel(mockEngine);
+        public object GetService(Type serviceType)
+        {
+            return _services.ContainsKey(serviceType)
+                ? _services[serviceType]
+                : null;
+        }
 
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+        public T GetService<T>() where T : class
+        {
+           return (T)GetService(typeof(T));
         }
     }
 }

--- a/src/tests/test-utilities/Fakes/SettingsService.cs
+++ b/src/tests/test-utilities/Fakes/SettingsService.cs
@@ -24,25 +24,44 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Engine;
-using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
 
-namespace TestCentric.Gui.Model
+namespace NUnit.TestUtilities.Fakes
 {
-    public class AvailableRuntimesTest
+    public class SettingsService : ISettings
     {
-        [Test]
-        public void RuntimesSupportedByEngineAreAvailable()
+        private Dictionary<string, object> _storage = new Dictionary<string, object>();
+
+        public event SettingsEventHandler Changed;
+
+        public object GetSetting(string settingName)
         {
-            var mockEngine = new MockTestEngine().WithRuntimes(
-                new RuntimeFramework("net-4.5", new Version(4, 5)),
-                new RuntimeFramework("net-4.0", new Version(4, 0)));
+            return _storage.ContainsKey(settingName)
+                ? _storage[settingName]
+                : null;
+        }
 
-            var model = new TestModel(mockEngine);
+        public T GetSetting<T>(string settingName, T defaultValue)
+        {
+            return _storage.ContainsKey(settingName)
+                ? (T)_storage[settingName]
+                : defaultValue;
+        }
 
-            Assert.That(model.AvailableRuntimes.Count, Is.EqualTo(2));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.5"));
-            Assert.That(model.AvailableRuntimes, Has.One.Property("Id").EqualTo("net-4.0"));
+        public void RemoveGroup(string groupName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveSetting(string settingName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SaveSetting(string settingName, object settingValue)
+        {
+            _storage[settingName] = settingValue;
+
+            Changed?.Invoke(this, new SettingsEventArgs(settingName));
         }
     }
 }

--- a/src/tests/test-utilities/packages.config
+++ b/src/tests/test-utilities/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.9.0" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/src/tests/test-utilities/test-utilities.csproj
+++ b/src/tests/test-utilities/test-utilities.csproj
@@ -80,6 +80,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.8.0\lib\nunit.engine.api.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -101,6 +105,14 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Fakes\ExtensionService.cs" />
+    <Compile Include="Fakes\RecentFilesService.cs" />
+    <Compile Include="Fakes\AvailableRuntimesService.cs" />
+    <Compile Include="Fakes\ResultService.cs" />
+    <Compile Include="Fakes\ServiceLocator.cs" />
+    <Compile Include="Fakes\SettingsService.cs" />
+    <Compile Include="Fakes\MockTestEngine.cs" />
+    <Compile Include="Fakes\RuntimeFramework.cs" />
     <Compile Include="FormTester.cs" />
     <Compile Include="TempResourceFile.cs" />
   </ItemGroup>


### PR DESCRIPTION
This is really only a start, with some of the implementations still throwing NYI on unused methods. I think we should commit it and start to enhance it as needed for other tests.

Where I revised some tests, they ran much faster than when the actual engine was used - obviously - and were also much easier to set up than tests that use NSubstitute to mock the engine.

I'll leave this for a day before merging in hopes that someone gets a chance to look it over.