### PR TITLE
Use MVP for TextOutputPresenter

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2015 Charlie Poole
+// Copyright (c) 2015-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/TestCentric/testcentric.gui/Presenters/TextOutputPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TextOutputPresenter.cs
@@ -1,0 +1,190 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestCentric.Gui.Presenters
+{
+    using Model;
+    using Views;
+
+    public class TextOutputPresenter
+    {
+        public static  Color WarningColor = Color.Yellow;
+        static readonly Color ErrorColor = Color.Red;
+        static readonly Color LabelColor = Color.Green;
+        static readonly Color OutputColor = Color.Black;
+
+        ITextOutputView _view;
+        ITestModel _model;
+
+        private string _labels;
+        private bool _displayBeforeOutput = true;
+        private bool _displayBeforeTest = false;
+        private bool _displayAfterTest = false;
+
+        private string _currentLabel = null;
+        private string _lastTestOutput = null;
+
+        bool _wantNewLine = false;
+
+        public TextOutputPresenter(ITextOutputView view, ITestModel model)
+        {
+            _view = view;
+            _model = model;
+
+            Initialize();
+
+            WireUpEvents();
+        }
+
+        private void WireUpEvents()
+        {
+            _model.Events.RunStarting += (RunStartingEventArgs e) =>
+            {
+                Initialize();
+            };
+
+            _model.Events.TestStarting += (TestNodeEventArgs e) =>
+            {
+                if (_displayBeforeTest)
+                    WriteLabelLine(e.Test.FullName);
+            };
+
+            _model.Events.TestFinished += (TestResultEventArgs e) =>
+            {
+                if (e.Result.Output != null)
+                {
+                    if (_displayBeforeOutput)
+                        WriteLabelLine(e.Result.FullName);
+
+                    WriteOutputLine(e.Result.FullName, e.Result.Output, OutputColor);
+                }
+
+                if (_displayAfterTest)
+                {
+                    var status = e.Result.Outcome.Label;
+                    if (string.IsNullOrEmpty(status))
+                        status = e.Result.Outcome.Status.ToString();
+                    WriteLabelLineAfterTest(e.Result.FullName, status);
+                }
+            };
+
+            _model.Events.SuiteFinished += (TestResultEventArgs e) =>
+            {
+                if (e.Result.Output != null)
+                {
+                    if (_displayBeforeOutput)
+                        WriteLabelLine(e.Result.FullName);
+
+                    FlushNewLineIfNeeded();
+                    WriteOutputLine(e.Result.FullName, e.Result.Output, OutputColor);
+                }
+            };
+
+            _model.Events.TestOutput += (TestOutputEventArgs e) =>
+            {
+                if (_displayBeforeOutput && e.TestName != null)
+                    WriteLabelLine(e.TestName);
+
+                WriteOutputLine(e.TestName, e.Text,
+                    e.Stream == "Error" ? ErrorColor : OutputColor);
+            };
+        }
+
+        private void Initialize()
+        {
+            _labels = _model.Services.UserSettings.Gui.TextOutput.Labels;
+            _displayBeforeTest = _labels == "ALL" || _labels == "BEFORE";
+            _displayAfterTest = _labels == "AFTER";
+            _displayBeforeOutput = _displayBeforeTest || _displayAfterTest || _labels == "ON";
+
+            _currentLabel = _lastTestOutput = null;
+            _wantNewLine = false;
+        }
+
+        private void WriteLabelLine(string label)
+        {
+            if (label != _currentLabel)
+            {
+                FlushNewLineIfNeeded();
+                _lastTestOutput = label;
+
+                WriteLine($"=> {label}", LabelColor);
+
+                _currentLabel = label;
+            }
+        }
+
+        private void WriteOutputLine(string testName, string text, Color color)
+        {
+            if (_lastTestOutput != testName)
+            {
+                FlushNewLineIfNeeded();
+                _lastTestOutput = testName;
+            }
+
+            _view.Write(text, color);
+
+            // If the text we just wrote did not have a new line, flag that we should eventually emit one.
+            if (!text.EndsWith("\n"))
+            {
+                _wantNewLine = true;
+            }
+        }
+
+        private void WriteLabelLineAfterTest(string label, string status)
+        {
+            FlushNewLineIfNeeded();
+            _lastTestOutput = label;
+
+            WriteLine($"{status} => {label}", LabelColor);
+
+            _currentLabel = label;
+        }
+
+        public void WriteLine(string text)
+        {
+            _view.Write(text + Environment.NewLine);
+        }
+
+        public void WriteLine(string text, Color color)
+        {
+            _view.Write(text + Environment.NewLine, color);
+        }
+
+        private void FlushNewLineIfNeeded()
+        {
+            if (_wantNewLine)
+            {
+                _view.Write(Environment.NewLine);
+                _wantNewLine = false;
+            }
+        }
+    }
+}

--- a/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
+++ b/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Presenters\TestsNotRunPresenter.cs" />
     <Compile Include="Presenters\ProgressBarPresenter.cs" />
     <Compile Include="Presenters\StatusBarPresenter.cs" />
+    <Compile Include="Presenters\TextOutputPresenter.cs" />
     <Compile Include="TestNodeFilters.cs" />
     <Compile Include="IMessageDisplay.cs" />
     <Compile Include="InternalTrace.cs" />
@@ -233,6 +234,7 @@
     <Compile Include="Views\ITestsNotRunView.cs" />
     <Compile Include="Views\IProgressBarView.cs" />
     <Compile Include="Views\IStatusBarView.cs" />
+    <Compile Include="Views\ITextOutputView.cs" />
     <Compile Include="Views\ProgressBarView.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/TestCentric/testcentric.gui/Views/ITextOutputView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITextOutputView.cs
@@ -1,0 +1,33 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Drawing;
+
+namespace TestCentric.Gui.Views
+{
+    public interface ITextOutputView
+    {
+        void Write(string text);
+        void Write(string text, Color color);
+    }
+}

--- a/src/TestCentric/tests/Presenters/PresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/PresenterTestBase.cs
@@ -26,7 +26,6 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters
 {
-    using Views;
     using Model;
 
     /// <summary>
@@ -47,6 +46,31 @@ namespace TestCentric.Gui.Presenters
             _model.Services.UserSettings.Returns(_settings);
         }
 
+        protected void FireTestLoadedEvent(TestNode testNode)
+        {
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+        }
+
+        protected void FireTestReloadedEvent(TestNode testNode)
+        {
+            _model.Events.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+        }
+
+        protected void FireTestUnloadedEvent()
+        {
+            _model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs());
+        }
+
+        protected void FireRunStartingEvent(int testCount)
+        {
+            _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(testCount));
+        }
+
+        protected void FireRunFinishedEvent(ResultNode result)
+        {
+            _model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+        }
+
         protected void FireTestStartingEvent(string testName)
         {
             var start = new TestNode($"<test-start fullname='{testName}'/>");
@@ -61,16 +85,23 @@ namespace TestCentric.Gui.Presenters
 
         protected void FireTestFinishedEvent(string testName, string result, string output = null)
         {
-            ResultNode resultNode = CreateResultNode("test-case", testName, result, output);
+            FireTestFinishedEvent( CreateResultNode("test-case", testName, result, output) );
 
-            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
+        }
+
+        protected void FireTestFinishedEvent(ResultNode result)
+        {
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
         }
 
         protected void FireSuiteFinishedEvent(string testName, string result, string output = null)
         {
-            ResultNode resultNode = CreateResultNode("test-suite", testName, result, output);
+            FireSuiteFinishedEvent( CreateResultNode("test-suite", testName, result, output) );
+        }
 
-            _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
+        protected void FireSuiteFinishedEvent(ResultNode result)
+        {
+            _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
         }
 
         private static ResultNode CreateResultNode(string element, string testName, string result, string output = null)

--- a/src/TestCentric/tests/Presenters/PresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/PresenterTestBase.cs
@@ -1,0 +1,103 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NSubstitute;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Presenters
+{
+    using Views;
+    using Model;
+
+    /// <summary>
+    /// Base class for presenter tests, providing utiity methods
+    /// </summary>
+    public class PresenterTestBase<TView> where TView : class
+    {
+        protected TView _view;
+        protected ITestModel _model;
+        protected FakeUserSettings _settings;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _view = Substitute.For<TView>();
+            _model = Substitute.For<ITestModel>();
+            _settings = new FakeUserSettings();
+            _model.Services.UserSettings.Returns(_settings);
+        }
+
+        protected void FireTestStartingEvent(string testName)
+        {
+            var start = new TestNode($"<test-start fullname='{testName}'/>");
+            _model.Events.TestStarting += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(start));
+        }
+
+        protected void FireSuiteStartingEvent(string testName)
+        {
+            var start = new TestNode($"<suite-start fullname='{testName}'/>");
+            _model.Events.SuiteStarting += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(start));
+        }
+
+        protected void FireTestFinishedEvent(string testName, string result, string output = null)
+        {
+            ResultNode resultNode = CreateResultNode("test-case", testName, result, output);
+
+            _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
+        }
+
+        protected void FireSuiteFinishedEvent(string testName, string result, string output = null)
+        {
+            ResultNode resultNode = CreateResultNode("test-suite", testName, result, output);
+
+            _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
+        }
+
+        private static ResultNode CreateResultNode(string element, string testName, string result, string output = null)
+        {
+            int colon = result.IndexOf(':');
+            ResultNode resultNode;
+
+            if (colon > 0)
+            {
+                string status = result.Substring(0, colon);
+                string label = result.Substring(colon + 1);
+                resultNode = new ResultNode($"<{element} fullname='{testName}' result='{status}' label='{label}'/>");
+            }
+            else
+            {
+                resultNode = new ResultNode($"<{element} fullname='{testName}' result='{result}'/>");
+            }
+
+            if (output != null)
+                resultNode.Xml.AddElementWithCDataSection("output", output);
+
+            return resultNode;
+        }
+
+        protected void FireTestOutputEvent(string testName, string stream, string text)
+        {
+            _model.Events.TestOutput += Raise.Event<TestOutputEventHandler>(new TestOutputEventArgs(testName, stream, text));
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/StatusBarPresenterTests.cs
@@ -29,32 +29,18 @@ namespace TestCentric.Gui.Presenters
     using Views;
     using Model;
 
-    public class StatusBarPresenterTests
+    public class StatusBarPresenterTests : PresenterTestBase<IStatusBarView>
     {
-        private IStatusBarView _view;
-        private ITestModel _model;
-        private StatusBarPresenter _presenter;
-
         [SetUp]
         public void CreatePresenter()
         {
-            _view = Substitute.For<IStatusBarView>();
-            _model = Substitute.For<ITestModel>();
-
-            _presenter = new StatusBarPresenter(_view, _model);
-        }
-
-        [TearDown]
-        public void RemovePresenter()
-        {
-            _presenter = null;
+            new StatusBarPresenter(_view, _model);
         }
 
         [Test]
         public void WhenTestsAreLoaded_StatusBar_IsInitialized()
         {
-            var testNode = new TestNode("<test-run id='2' testcasecount='123' />");
-            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+            FireTestLoadedEvent( new TestNode("<test-run id='2' testcasecount='123' />") );
 
             _view.Received().Initialize(123);
             _view.Received().DisplayText("Ready");
@@ -63,8 +49,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestsArReloaded_StatusBar_IsInitialized()
         {
-            var testNode = new TestNode("<test-run id='2' testcasecount='123' />");
-            _model.Events.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+            FireTestReloadedEvent( new TestNode("<test-run id='2' testcasecount='123' />") );
 
             _view.Received().Initialize(123);
             _view.Received().DisplayText("Reloaded");
@@ -73,7 +58,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestsAreUnloaded_StatusBar_IsInitialized()
         {
-            _model.Events.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs());
+            FireTestUnloadedEvent();
 
             _view.Received().Initialize(0);
             _view.Received().DisplayText("Unloaded");
@@ -82,7 +67,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestRunBegins_StatusBar_IsInitialized()
         {
-            _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
+            FireRunStartingEvent(1234);
 
             _view.Received().Initialize(1234);
             _view.Received().DisplayTestsRun(0);
@@ -96,10 +81,9 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestBegins_NameIsDisplayed()
         {
-            var testNode = new TestNode("<test-case id='1' name='NAME' fullname='FULLNAME' />");
-            _model.Events.TestStarting += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+            FireTestStartingEvent("TestName");
 
-            _view.Received().DisplayText("FULLNAME");
+            _view.Received().DisplayText("TestName");
         }
 
         [Test]
@@ -108,12 +92,17 @@ namespace TestCentric.Gui.Presenters
             var result = new ResultNode("<test-case id='1' result='Passed' />");
 
             for (int i = 1; i <= 3; i++)
-            {
-                _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+                FireTestFinishedEvent(result);
 
-                _view.Received().DisplayTestsRun(i);
-                _view.Received().DisplayPassed(i);
-            }
+            Received.InOrder(() =>
+            {
+                _view.DisplayTestsRun(1);
+                _view.DisplayPassed(1);
+                _view.DisplayTestsRun(2);
+                _view.DisplayPassed(2);
+                _view.DisplayTestsRun(3);
+                _view.DisplayPassed(3);
+            });
         }
 
         [Test]
@@ -122,12 +111,17 @@ namespace TestCentric.Gui.Presenters
             var result = new ResultNode("<test-case id='1' result='Warning' />");
 
             for (int i = 1; i <= 3; i++)
-            {
-                _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+                FireTestFinishedEvent(result);
 
-                _view.Received().DisplayTestsRun(i);
-                _view.Received().DisplayWarnings(i);
-            }
+            Received.InOrder(() =>
+            {
+                _view.DisplayTestsRun(1);
+                _view.DisplayWarnings(1);
+                _view.DisplayTestsRun(2);
+                _view.DisplayWarnings(2);
+                _view.DisplayTestsRun(3);
+                _view.DisplayWarnings(3);
+            });
         }
 
         [Test]
@@ -136,12 +130,17 @@ namespace TestCentric.Gui.Presenters
             var result = new ResultNode("<test-case id='1' result='Inconclusive' />");
 
             for (int i = 1; i <= 3; i++)
-            {
-                _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+                FireTestFinishedEvent(result);
 
-                _view.Received().DisplayTestsRun(i);
-                _view.Received().DisplayInconclusive(i);
-            }
+            Received.InOrder(() =>
+            {
+                _view.DisplayTestsRun(1);
+                _view.DisplayInconclusive(1);
+                _view.DisplayTestsRun(2);
+                _view.DisplayInconclusive(2);
+                _view.DisplayTestsRun(3);
+                _view.DisplayInconclusive(3);
+            });
         }
 
         [Test]
@@ -150,19 +149,24 @@ namespace TestCentric.Gui.Presenters
             var result = new ResultNode("<test-case id='1' result='Failed' />");
 
             for (int i = 1; i <= 3; i++)
-            {
-                _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+                FireTestFinishedEvent(result);
 
-                _view.Received().DisplayTestsRun(i);
-                _view.Received().DisplayFailed(i);
-            }
+            Received.InOrder(() =>
+            {
+                _view.DisplayTestsRun(1);
+                _view.DisplayFailed(1);
+                _view.DisplayTestsRun(2);
+                _view.DisplayFailed(2);
+                _view.DisplayTestsRun(3);
+                _view.DisplayFailed(3);
+            });
         }
 
         [Test]
         public void WhenTestsFinish_DurationIsDisplayed()
         {
             var result = new ResultNode("<test-run duration='1.234' />");
-            _model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
+            FireRunFinishedEvent(result);
 
             _view.Received().DisplayText("Completed");
             _view.Received().DisplayTime(1.234);

--- a/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
@@ -29,7 +29,6 @@ using NSubstitute;
 namespace TestCentric.Gui.Presenters
 {
     using Views;
-    using Model;
 
     public class TextOutputPresenterTests : PresenterTestBase<ITextOutputView>
     {

--- a/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
@@ -1,0 +1,354 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Drawing;
+using NUnit.Framework;
+using NSubstitute;
+
+namespace TestCentric.Gui.Presenters
+{
+    using Views;
+    using Model;
+
+    public class TextOutputPresenterTests : PresenterTestBase<ITextOutputView>
+    {
+        static readonly string NL = Environment.NewLine;
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void TestStarting_DisplaysCorrectly(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("SomeName");
+
+            if (labels == "ALL" || labels == "BEFORE")
+                VerifyLabelWasWritten("SomeName");
+            else
+                VerifyNothingWasWritten();
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void SuiteStarting_DisplaysNothing(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireSuiteStartingEvent("SomeName");
+
+            VerifyNothingWasWritten();
+        }
+
+        [TestCase("OFF", "Passed")]
+        [TestCase("ON", "Passed")]
+        [TestCase("ALL", "Passed")]
+        [TestCase("BEFORE", "Passed")]
+        [TestCase("AFTER", "Passed")]
+        [TestCase("AFTER", "Failed")]
+        [TestCase("AFTER", "Failed:Error")]
+        [TestCase("AFTER", "Failed:Cancelled")]
+        [TestCase("AFTER", "Failed:Invalid")]
+        [TestCase("AFTER", "Warning")]
+        [TestCase("AFTER", "Skipped")]
+        [TestCase("AFTER", "Skipped:Ignored")]
+        [TestCase("AFTER", "Inconclusive")]
+        public void TestFinished_DisplaysCorrectly(string labels, string result)
+        {
+            CreatePresenter(labels);
+
+            FireTestFinishedEvent("SomeName", result);
+
+            if (labels == "AFTER")
+                VerifyLabelWasWritten("SomeName", result);
+            else
+                VerifyNothingWasWritten();
+        }
+
+        [TestCase("OFF", "Passed")]
+        [TestCase("ON", "Passed")]
+        [TestCase("ALL", "Passed")]
+        [TestCase("BEFORE", "Passed")]
+        [TestCase("AFTER", "Passed")]
+        [TestCase("AFTER", "Failed")]
+        [TestCase("AFTER", "Failed:Error")]
+        [TestCase("AFTER", "Failed:Cancelled")]
+        [TestCase("AFTER", "Failed:Invalid")]
+        [TestCase("AFTER", "Warning")]
+        [TestCase("AFTER", "Skipped")]
+        [TestCase("AFTER", "Skipped:Ignored")]
+        [TestCase("AFTER", "Inconclusive")]
+        public void TestFinishedWithOutput_DisplaysCorrectly(string labels, string result)
+        {
+            CreatePresenter(labels);
+
+            FireTestFinishedEvent("SomeName", result, "OUTPUT");
+
+            Received.InOrder(() =>
+            {
+                Label("SomeName", labels != "OFF");
+                Output("OUTPUT");
+                Label("SomeName", result, labels == "AFTER");
+            });
+        }
+
+        [TestCase("OFF", "Passed")]
+        [TestCase("ON", "Passed")]
+        [TestCase("ALL", "Passed")]
+        [TestCase("BEFORE", "Passed")]
+        [TestCase("AFTER", "Passed")]
+        [TestCase("AFTER", "Failed")]
+        [TestCase("AFTER", "Failed:Error")]
+        [TestCase("AFTER", "Failed:Cancelled")]
+        [TestCase("AFTER", "Failed:Invalid")]
+        [TestCase("AFTER", "Warning")]
+        [TestCase("AFTER", "Skipped")]
+        [TestCase("AFTER", "Skipped:Ignored")]
+        [TestCase("AFTER", "Inconclusive")]
+        public void SuiteFinishedWithOutput_DisplaysCorrectly(string labels, string result)
+        {
+            CreatePresenter(labels);
+
+            FireSuiteFinishedEvent("SomeName", result, "OUTPUT");
+
+            Received.InOrder(() =>
+            {
+                Label("SomeName", labels != "OFF");
+                Output("OUTPUT");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void SuiteFinished_DisplaysNothing(string labels)
+        {
+            CreatePresenter(labels);
+            FireSuiteFinishedEvent("SomeName", "Passed");
+
+            VerifyNothingWasWritten();
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void TestOutput_DisplaysCorrectly(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestOutputEvent("SomeName", "Progress", "OUTPUT");
+
+            Received.InOrder(() =>
+            {
+                Label("SomeName", labels != "OFF");
+                Output("OUTPUT");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void SingleTestStartAndFinish(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("TestName");
+            FireTestFinishedEvent("TestName", "Passed", "OUTPUT");
+
+            Received.InOrder(() =>
+            {
+                Label("TestName", labels != "OFF");
+                Output("OUTPUT");
+                Label("TestName", "Passed", labels == "AFTER");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void SingleTestImmediateOutput(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("TEST1");
+            FireTestOutputEvent("TEST1", "Progress", "IMMEDIATE");
+            FireTestFinishedEvent("TEST1", "Passed", "OUTPUT");
+
+            Received.InOrder(() =>
+            {
+                Label("TEST1", labels != "OFF");
+                Output("IMMEDIATE");
+                Output("OUTPUT");
+                Label("TEST1", "Passed", labels == "AFTER");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void TwoTests_Sequential(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("TEST1");
+            FireTestFinishedEvent("TEST1", "Failed", "OUTPUT1");
+            FireTestStartingEvent("TEST2");
+            FireTestFinishedEvent("TEST2", "Passed", "OUTPUT2");
+
+            Received.InOrder(() =>
+            {
+                Label("TEST1", labels != "OFF");
+                Output("OUTPUT1");
+                Label("TEST1", "Failed", labels == "AFTER");
+                Label("TEST2", labels != "OFF");
+                Output("OUTPUT2");
+                Label("TEST2", "Passed", labels == "AFTER");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void TwoTests_Interleaved(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("TEST1");
+            FireTestOutputEvent("TEST1", "Progress", "IMMEDIATE1A");
+            FireTestStartingEvent("TEST2");
+            FireTestOutputEvent("TEST1", "Progress", "IMMEDIATE1B");
+            FireTestOutputEvent("TEST2", "Progress", "IMMEDIATE2");
+            FireTestFinishedEvent("TEST1", "Failed", "OUTPUT1");
+            FireTestFinishedEvent("TEST2", "Passed", "OUTPUT2");
+
+            Received.InOrder(() =>
+            {
+                Label("TEST1", labels != "OFF");
+                Output("IMMEDIATE1A");
+                Label("TEST2", labels == "BEFORE" || labels == "ALL");
+                Label("TEST1", labels == "BEFORE" || labels == "ALL");
+                Output("IMMEDIATE1B");
+                Label("TEST2", labels != "OFF");
+                Output("IMMEDIATE2");
+                Label("TEST1", labels != "OFF");
+                Output("OUTPUT1");
+                Label("TEST1", "Failed", labels == "AFTER");
+                Label("TEST2", labels != "OFF");
+                Output("OUTPUT2");
+                Label("TEST2", "Passed", labels == "AFTER");
+            });
+        }
+
+        [TestCaseSource(nameof(EveryLabel))]
+        public void TwoTests_Nested(string labels)
+        {
+            CreatePresenter(labels);
+
+            FireTestStartingEvent("TEST1");
+            FireTestOutputEvent("TEST1", "Progress", "IMMEDIATE1");
+            FireTestStartingEvent("TEST2");
+            FireTestOutputEvent("TEST2", "Progress", "IMMEDIATE2");
+            FireTestFinishedEvent("TEST2", "Passed", "OUTPUT2");
+            FireTestFinishedEvent("TEST1", "Failed", "OUTPUT1");
+
+            Received.InOrder(() =>
+            {
+                Label("TEST1", labels != "OFF");
+                Output("IMMEDIATE1");
+                Label("TEST2", labels != "OFF");
+                Output("IMMEDIATE2");
+                Output("OUTPUT2");
+                Label("TEST2", "Passed", labels == "AFTER");
+                Label("TEST1", labels != "OFF");
+                Output("OUTPUT1");
+                Label("TEST1", "Failed", labels == "AFTER");
+            });
+        }
+
+        private static string[] EveryLabel = { "OFF", "ON", "ALL", "BEFORE", "AFTER" };
+
+        #region Helper Methods
+
+        private void CreatePresenter(string labels)
+        {
+            _settings.Gui.TextOutput.Labels = labels;
+            new TextOutputPresenter(_view, _model);
+        }
+
+        /// <summary>
+        /// Verify a label was written as part of a Received.InOrder block.
+        /// </summary>
+        private void Label(string testName, bool condition = true)
+        {
+            if (condition)
+                _view.Write($"=> {testName}{NL}", Color.Green);
+        }
+
+        /// <summary>
+        /// Verify a label was written as part of a Received.InOrder block.
+        /// </summary>
+        private void Label(string testName, string result, bool condition = true)
+        {
+            if (condition)
+                _view.Write($"{Displayed(result)} => {testName}{NL}", Color.Green);
+        }
+
+        /// <summary>
+        /// Verify output was written as part of a Received.InOrder block.
+        /// </summary>
+        private void Output(string output, bool condition = true)
+        {
+            if (condition)
+                _view.Write(output, Color.Black);
+        }
+
+        /// <summary>
+        /// Verify label was written outside of a Received.InOrder block.
+        /// </summary>
+        private void VerifyLabelWasWritten(string testName)
+        {
+            _view.Received().Write($"=> {testName}{NL}", Color.Green);
+        }
+
+        /// <summary>
+        /// Verify label was written outside of a Received.InOrder block.
+        /// </summary>
+        private void VerifyLabelWasWritten(string testName, string result)
+        {
+            _view.Received().Write($"{Displayed(result)} => {testName}{NL}", Color.Green);
+        }
+
+        private static string Displayed(string result)
+        {
+            int colon = result.IndexOf(':');
+            return colon >= 0
+                ? result.Substring(colon + 1)
+                : result;
+        }
+
+        /// <summary>
+        /// Verify output was written outside of of a Received.InOrder block.
+        /// </summary>
+        private void VerifyOutputWasWritten(string output, bool condition = true)
+        {
+            if (condition)
+                _view.Received().Write(output, Color.Black);
+        }
+
+        /// <summary>
+        /// Verify that nothing was written to the view
+        /// </summary>
+        private void VerifyNothingWasWritten()
+        {
+            _view.DidNotReceiveWithAnyArgs().Write(Arg.Any<string>(), Arg.Any<Color>());
+        }
+
+        #endregion
+    }
+}

--- a/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
+++ b/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
@@ -142,9 +142,11 @@
     <Compile Include="ErrorDisplayTests.cs" />
     <Compile Include="Presenters\FakeUserSettings.cs" />
     <Compile Include="LongRunningOperationDisplayTests.cs" />
+    <Compile Include="Presenters\PresenterTestBase.cs" />
     <Compile Include="Presenters\ProgressBarPresenterTests.cs" />
     <Compile Include="Presenters\StatusBarPresenterTests.cs" />
     <Compile Include="Presenters\TestsNotRunPresenterTests.cs" />
+    <Compile Include="Presenters\TextOutputPresenterTests.cs" />
     <Compile Include="RecentFileMenuHandlerTests.cs" />
     <Compile Include="TestSuiteTreeNodeTests.cs" />
     <Compile Include="TestTreeTests.cs" />


### PR DESCRIPTION
This is part of issue #95.

The current PR adds TextOutputView and TextOutputPresenter and refactors all presenter tests to use a base class.