### PR TITLE
Move Tree menu creation from TestTree to Main form

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestTree.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestTree.cs
@@ -58,17 +58,6 @@ namespace TestCentric.Gui.Controls
         private System.Windows.Forms.Button removeCategory;
         private System.Windows.Forms.Button clearAllButton;
         private System.Windows.Forms.Button checkFailedButton;
-        private System.Windows.Forms.MenuItem treeMenu;
-        private System.Windows.Forms.MenuItem checkBoxesMenuItem;
-        private System.Windows.Forms.MenuItem treeMenuSeparatorItem1;
-        private System.Windows.Forms.MenuItem expandMenuItem;
-        private System.Windows.Forms.MenuItem collapseMenuItem;
-        private System.Windows.Forms.MenuItem treeMenuSeparatorItem2;
-        private System.Windows.Forms.MenuItem expandAllMenuItem;
-        private System.Windows.Forms.MenuItem collapseAllMenuItem;
-        private System.Windows.Forms.MenuItem hideTestsMenuItem;
-        private System.Windows.Forms.MenuItem treeMenuSeparatorItem3;
-        private System.Windows.Forms.MenuItem propertiesMenuItem;
         private System.Windows.Forms.CheckBox excludeCheckbox;
 
         /// <summary> 
@@ -83,11 +72,6 @@ namespace TestCentric.Gui.Controls
         public TestSuiteTreeView TreeView
         {
             get { return tests; }
-        }
-
-        public MenuItem TreeMenu 
-        {
-            get { return treeMenu; }
         }
 
         public string[] SelectedCategories
@@ -122,98 +106,6 @@ namespace TestCentric.Gui.Controls
         {
             // This call is required by the Windows.Forms Form Designer.
             InitializeComponent();
-            treeMenu = new MenuItem();
-            this.checkBoxesMenuItem = new System.Windows.Forms.MenuItem();
-            this.treeMenuSeparatorItem1 = new System.Windows.Forms.MenuItem();
-            this.expandMenuItem = new System.Windows.Forms.MenuItem();
-            this.collapseMenuItem = new System.Windows.Forms.MenuItem();
-            this.treeMenuSeparatorItem2 = new System.Windows.Forms.MenuItem();
-            this.expandAllMenuItem = new System.Windows.Forms.MenuItem();
-            this.collapseAllMenuItem = new System.Windows.Forms.MenuItem();
-            this.hideTestsMenuItem = new System.Windows.Forms.MenuItem();
-            this.treeMenuSeparatorItem3 = new System.Windows.Forms.MenuItem();
-            this.propertiesMenuItem = new System.Windows.Forms.MenuItem();
-
-            // 
-            // treeMenu
-            // 
-            this.treeMenu.MergeType = MenuMerge.Add;
-            this.treeMenu.MergeOrder = 1;
-            this.treeMenu.MenuItems.AddRange(
-                new System.Windows.Forms.MenuItem[] 
-                {
-                    this.checkBoxesMenuItem,
-                    this.treeMenuSeparatorItem1,
-                    this.expandMenuItem,
-                    this.collapseMenuItem,
-                    this.treeMenuSeparatorItem2,
-                    this.expandAllMenuItem,
-                    this.collapseAllMenuItem,
-                    this.hideTestsMenuItem,
-                    this.treeMenuSeparatorItem3,
-                    this.propertiesMenuItem 
-                } );
-            this.treeMenu.Text = "&Tree";
-            this.treeMenu.Visible = false;
-            this.treeMenu.Popup += new System.EventHandler(this.treeMenu_Popup);
-            // 
-            // checkBoxesMenuItem
-            // 
-            this.checkBoxesMenuItem.Index = 0;
-            this.checkBoxesMenuItem.Text = "Show Check&Boxes";
-            this.checkBoxesMenuItem.Click += new System.EventHandler(this.checkBoxesMenuItem_Click);
-            // 
-            // treeMenuSeparatorItem1
-            // 
-            this.treeMenuSeparatorItem1.Index = 1;
-            this.treeMenuSeparatorItem1.Text = "-";
-            // 
-            // expandMenuItem
-            // 
-            this.expandMenuItem.Index = 2;
-            this.expandMenuItem.Text = "&Expand";
-            this.expandMenuItem.Click += new System.EventHandler(this.expandMenuItem_Click);
-            // 
-            // collapseMenuItem
-            // 
-            this.collapseMenuItem.Index = 3;
-            this.collapseMenuItem.Text = "&Collapse";
-            this.collapseMenuItem.Click += new System.EventHandler(this.collapseMenuItem_Click);
-            // 
-            // treeMenuSeparatorItem2
-            // 
-            this.treeMenuSeparatorItem2.Index = 4;
-            this.treeMenuSeparatorItem2.Text = "-";
-            // 
-            // expandAllMenuItem
-            // 
-            this.expandAllMenuItem.Index = 5;
-            this.expandAllMenuItem.Text = "Expand All";
-            this.expandAllMenuItem.Click += new System.EventHandler(this.expandAllMenuItem_Click);
-            // 
-            // collapseAllMenuItem
-            // 
-            this.collapseAllMenuItem.Index = 6;
-            this.collapseAllMenuItem.Text = "Collapse All";
-            this.collapseAllMenuItem.Click += new System.EventHandler(this.collapseAllMenuItem_Click);
-            // 
-            // hideTestsMenuItem
-            // 
-            this.hideTestsMenuItem.Index = 7;
-            this.hideTestsMenuItem.Text = "Hide Tests";
-            this.hideTestsMenuItem.Click += new System.EventHandler(this.hideTestsMenuItem_Click);
-            // 
-            // treeMenuSeparatorItem3
-            // 
-            this.treeMenuSeparatorItem3.Index = 8;
-            this.treeMenuSeparatorItem3.Text = "-";
-            // 
-            // propertiesMenuItem
-            // 
-            this.propertiesMenuItem.Index = 9;
-            this.propertiesMenuItem.Text = "&Properties";
-            this.propertiesMenuItem.Click += new System.EventHandler(this.propertiesMenuItem_Click);
-
 
             //tests.SelectedTestChanged += new SelectedTestChangedHandler(tests_SelectedTestChanged);
             //tests.CheckedTestChanged += new CheckedTestChangedHandler(tests_CheckedTestChanged);
@@ -278,60 +170,6 @@ namespace TestCentric.Gui.Controls
         #endregion
 
         #region View Menu Handlers
-
-        private void treeMenu_Popup(object sender, System.EventArgs e)
-        {
-            TreeNode selectedNode = tests.SelectedNode;
-            if ( selectedNode != null && selectedNode.Nodes.Count > 0 )
-            {
-                bool isExpanded = selectedNode.IsExpanded;
-                collapseMenuItem.Enabled = isExpanded;
-                expandMenuItem.Enabled = !isExpanded;		
-            }
-            else
-            {
-                collapseMenuItem.Enabled = expandMenuItem.Enabled = false;
-            }
-        }
-
-        private void collapseMenuItem_Click(object sender, System.EventArgs e)
-        {
-            tests.SelectedNode.Collapse();
-        }
-
-        private void expandMenuItem_Click(object sender, System.EventArgs e)
-        {
-            tests.SelectedNode.Expand();
-        }
-
-        private void collapseAllMenuItem_Click(object sender, System.EventArgs e)
-        {
-            tests.BeginUpdate();
-            tests.CollapseAll();
-            tests.EndUpdate();
-
-            // Compensate for a bug in the underlying control
-            if ( tests.Nodes.Count > 0 )
-                tests.SelectedNode = tests.Nodes[0];	
-        }
-
-        private void hideTestsMenuItem_Click(object sender, System.EventArgs e)
-        {
-            tests.HideTests();
-        }
-
-        private void expandAllMenuItem_Click(object sender, System.EventArgs e)
-        {
-            tests.BeginUpdate();
-            tests.ExpandAll();
-            tests.EndUpdate();
-        }
-
-        private void propertiesMenuItem_Click(object sender, System.EventArgs e)
-        {
-            if (tests.SelectedTest != null)
-                tests.ShowPropertiesDialog(tests.SelectedTest);
-        }
 
         #endregion
 
@@ -675,11 +513,6 @@ namespace TestCentric.Gui.Controls
         //	}
         //}
 
-        private void checkBoxesMenuItem_Click(object sender, System.EventArgs e)
-        {
-            Model.Services.UserSettings.Gui.TestTree.ShowCheckBoxes = !checkBoxesMenuItem.Checked;
-        }
-
         private void UpdateCategorySelection()
         {
             Model.SelectCategories(SelectedCategories, excludeCheckbox.Checked);
@@ -701,7 +534,6 @@ namespace TestCentric.Gui.Controls
             buttonPanel.Visible = enable;
             clearAllButton.Visible = enable;
             checkFailedButton.Visible = enable;
-            checkBoxesMenuItem.Checked = enable;
         }
 
         #region IViewControl Implementation
@@ -714,8 +546,6 @@ namespace TestCentric.Gui.Controls
 
             model.Events.TestLoaded += (TestNodeEventArgs e) =>
             {
-                treeMenu.Visible = true;
-
                 availableList.Items.Clear();
                 selectedList.Items.Clear();
 
@@ -782,7 +612,6 @@ namespace TestCentric.Gui.Controls
                 selectedList.Items.Clear();
                 excludeCheckbox.Checked = false;
                 excludeCheckbox.Enabled = false;
-                treeMenu.Visible = false;
             };
 
             model.Services.UserSettings.Changed += (object sender, SettingsEventArgs e) =>

--- a/src/TestCentric/testcentric.gui/TestCentricMainForm.cs
+++ b/src/TestCentric/testcentric.gui/TestCentricMainForm.cs
@@ -129,6 +129,18 @@ namespace TestCentric.Gui
         private TabPage outputTab;
         private ErrorsAndFailuresView errorsAndFailuresView1;
         private TestsNotRunView testsNotRunView1;
+        private MenuItem treeMenuItem;
+        private MenuItem showCheckboxesMenuItem;
+        private MenuItem menuItem5;
+        private MenuItem expandMenuItem;
+        private MenuItem collapseMenuItem;
+        private MenuItem menuItem8;
+        private MenuItem expandAllMenuItem;
+        private MenuItem collapseAllMenuItem;
+        private MenuItem hideTestsMenuItem;
+        private MenuItem menuItem12;
+        private MenuItem propertiesMenuItem;
+        private MenuItem menuItem3;
         private TextOutputView textOutputView1;
         private ExpandingLabel suiteName;
 
@@ -194,6 +206,17 @@ namespace TestCentric.Gui
             this.fullGuiMenuItem = new System.Windows.Forms.MenuItem();
             this.miniGuiMenuItem = new System.Windows.Forms.MenuItem();
             this.viewMenuSeparator1 = new System.Windows.Forms.MenuItem();
+            this.treeMenuItem = new System.Windows.Forms.MenuItem();
+            this.showCheckboxesMenuItem = new System.Windows.Forms.MenuItem();
+            this.menuItem5 = new System.Windows.Forms.MenuItem();
+            this.expandMenuItem = new System.Windows.Forms.MenuItem();
+            this.collapseMenuItem = new System.Windows.Forms.MenuItem();
+            this.menuItem8 = new System.Windows.Forms.MenuItem();
+            this.expandAllMenuItem = new System.Windows.Forms.MenuItem();
+            this.collapseAllMenuItem = new System.Windows.Forms.MenuItem();
+            this.hideTestsMenuItem = new System.Windows.Forms.MenuItem();
+            this.menuItem12 = new System.Windows.Forms.MenuItem();
+            this.propertiesMenuItem = new System.Windows.Forms.MenuItem();
             this.viewMenuSeparator2 = new System.Windows.Forms.MenuItem();
             this.guiFontMenuItem = new System.Windows.Forms.MenuItem();
             this.increaseFontMenuItem = new System.Windows.Forms.MenuItem();
@@ -350,6 +373,7 @@ namespace TestCentric.Gui
             this.fullGuiMenuItem,
             this.miniGuiMenuItem,
             this.viewMenuSeparator1,
+            this.treeMenuItem,
             this.viewMenuSeparator2,
             this.guiFontMenuItem,
             this.fixedFontMenuItem,
@@ -377,14 +401,88 @@ namespace TestCentric.Gui
             this.viewMenuSeparator1.Index = 2;
             this.viewMenuSeparator1.Text = "-";
             // 
+            // treeMenuItem
+            // 
+            this.treeMenuItem.Index = 3;
+            this.treeMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.showCheckboxesMenuItem,
+            this.menuItem5,
+            this.expandMenuItem,
+            this.collapseMenuItem,
+            this.menuItem8,
+            this.expandAllMenuItem,
+            this.collapseAllMenuItem,
+            this.hideTestsMenuItem,
+            this.menuItem12,
+            this.propertiesMenuItem});
+            this.treeMenuItem.Text = "Tree";
+            this.treeMenuItem.Popup += new System.EventHandler(this.treeMenuItem_Popup);
+            // 
+            // showCheckboxesMenuItem
+            // 
+            this.showCheckboxesMenuItem.Index = 0;
+            this.showCheckboxesMenuItem.Text = "Show Checkboxes";
+            this.showCheckboxesMenuItem.Click += new System.EventHandler(this.showCheckboxesMenuItem_Click);
+            // 
+            // menuItem5
+            // 
+            this.menuItem5.Index = 1;
+            this.menuItem5.Text = "-";
+            // 
+            // expandMenuItem
+            // 
+            this.expandMenuItem.Index = 2;
+            this.expandMenuItem.Text = "Expand";
+            this.expandMenuItem.Click += new System.EventHandler(this.expandMenuItem_Click);
+            // 
+            // collapseMenuItem
+            // 
+            this.collapseMenuItem.Index = 3;
+            this.collapseMenuItem.Text = "Collapse";
+            this.collapseMenuItem.Click += new System.EventHandler(this.collapseMenuItem_Click);
+            // 
+            // menuItem8
+            // 
+            this.menuItem8.Index = 4;
+            this.menuItem8.Text = "-";
+            // 
+            // expandAllMenuItem
+            // 
+            this.expandAllMenuItem.Index = 5;
+            this.expandAllMenuItem.Text = "Expand All";
+            this.expandAllMenuItem.Click += new System.EventHandler(this.expandAllMenuItem_Click);
+            // 
+            // collapseAllMenuItem
+            // 
+            this.collapseAllMenuItem.Index = 6;
+            this.collapseAllMenuItem.Text = "Collapse All";
+            this.collapseAllMenuItem.Click += new System.EventHandler(this.collapseAllMenuItem_Click);
+            // 
+            // hideTestsMenuItem
+            // 
+            this.hideTestsMenuItem.Index = 7;
+            this.hideTestsMenuItem.Text = "Hide Tests";
+            this.hideTestsMenuItem.Click += new System.EventHandler(this.hideTestsMenuItem_Click);
+            // 
+            // menuItem12
+            // 
+            this.menuItem12.Index = 8;
+            this.menuItem12.Text = "-";
+            // 
+            // propertiesMenuItem
+            // 
+            this.propertiesMenuItem.Index = 9;
+            this.propertiesMenuItem.Text = "Properties...";
+            this.propertiesMenuItem.Click += new System.EventHandler(this.propertiesMenuItem_Click);
+            // 
             // viewMenuSeparator2
             // 
-            this.viewMenuSeparator2.Index = 3;
+            this.viewMenuSeparator2.Index = 4;
             this.viewMenuSeparator2.Text = "-";
             // 
             // guiFontMenuItem
             // 
-            this.guiFontMenuItem.Index = 4;
+            this.guiFontMenuItem.Index = 5;
             this.guiFontMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.increaseFontMenuItem,
             this.decreaseFontMenuItem,
@@ -424,7 +522,7 @@ namespace TestCentric.Gui
             // 
             // fixedFontMenuItem
             // 
-            this.fixedFontMenuItem.Index = 5;
+            this.fixedFontMenuItem.Index = 6;
             this.fixedFontMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.increaseFixedFontMenuItem,
             this.decreaseFixedFontMenuItem,
@@ -457,13 +555,13 @@ namespace TestCentric.Gui
             // 
             // viewMenuSeparator3
             // 
-            this.viewMenuSeparator3.Index = 6;
+            this.viewMenuSeparator3.Index = 7;
             this.viewMenuSeparator3.Text = "-";
             // 
             // statusBarMenuItem
             // 
             this.statusBarMenuItem.Checked = true;
-            this.statusBarMenuItem.Index = 7;
+            this.statusBarMenuItem.Index = 8;
             this.statusBarMenuItem.Text = "&Status Bar";
             this.statusBarMenuItem.Click += new System.EventHandler(this.statusBarMenuItem_Click);
             // 
@@ -820,6 +918,8 @@ namespace TestCentric.Gui
 
         #region Subordinate Views contained in main form
 
+        public TestSuiteTreeView TreeView { get { return testTree.TreeView; } }
+
         public ProgressBarView ProgressBarView { get { return progressBar; } }
 
         public StatusBarView StatusBarView { get { return statusBar; } }
@@ -1069,10 +1169,73 @@ namespace TestCentric.Gui
             applyFixedFont( new Font( FontFamily.GenericMonospace, 8.0f ) );
         }
 
-        private void applyFixedFont( Font font )
+        private void applyFixedFont(Font font)
         {
             UserSettings.Gui.FixedFont = _fixedFont = font;
         }
+
+        private void treeMenuItem_Popup(object sender, EventArgs e)
+        {
+            TreeNode selectedNode = TreeView.SelectedNode;
+
+            showCheckboxesMenuItem.Checked = UserSettings.Gui.TestTree.ShowCheckBoxes;
+
+            if (selectedNode != null && selectedNode.Nodes.Count > 0)
+            {
+                bool isExpanded = selectedNode.IsExpanded;
+                collapseMenuItem.Enabled = isExpanded;
+                expandMenuItem.Enabled = !isExpanded;
+            }
+            else
+            {
+                collapseMenuItem.Enabled = expandMenuItem.Enabled = false;
+            }
+        }
+
+        private void showCheckboxesMenuItem_Click(object sender, EventArgs e)
+        {
+            UserSettings.Gui.TestTree.ShowCheckBoxes = !showCheckboxesMenuItem.Checked;
+        }
+
+        private void expandMenuItem_Click(object sender, EventArgs e)
+        {
+            TreeView.SelectedNode.Expand();
+        }
+
+        private void collapseMenuItem_Click(object sender, EventArgs e)
+        {
+            TreeView.SelectedNode.Collapse();
+        }
+
+        private void expandAllMenuItem_Click(object sender, EventArgs e)
+        {
+            TreeView.BeginUpdate();
+            TreeView.ExpandAll();
+            TreeView.EndUpdate();
+        }
+
+        private void collapseAllMenuItem_Click(object sender, EventArgs e)
+        {
+            TreeView.BeginUpdate();
+            TreeView.CollapseAll();
+            TreeView.EndUpdate();
+
+            // Compensate for a bug in the underlying control
+            if (TreeView.Nodes.Count > 0)
+                TreeView.SelectedNode = TreeView.Nodes[0];
+        }
+
+        private void hideTestsMenuItem_Click(object sender, EventArgs e)
+        {
+            TreeView.HideTests();
+        }
+
+        private void propertiesMenuItem_Click(object sender, EventArgs e)
+        {
+            if (TreeView.SelectedTest != null)
+                TreeView.ShowPropertiesDialog(TreeView.SelectedTest);
+        }
+
         #endregion
 
         #region Test Menu
@@ -1173,9 +1336,6 @@ namespace TestCentric.Gui
         {
             if ( !DesignMode )
             {
-                // TODO: Can the controls add its own menu?
-                viewMenu.MenuItems.Add(3, testTree.TreeMenu);
-
                 EnableRunCommand( false );
                 EnableStopCommand( false );
 


### PR DESCRIPTION
This relates to #95.

The inter-relationships between the main form, TestTree and TestSuiteTreeView are so complicated that I decided to do some small commits next, in order to reduce the complexity.

This one deals with the `View | Test` menu. 

In the past, the tree menu was created by TestTree, in an excess of object-oriented zeal. The idea was that the tree "knew" what was needed in the menu, so let's put it there. The main form got the menu from TestTree and inserted it in it's own main menu.

This may once have served a purpose but the menu is no longer dynamic and can easily be handled by the main form. This commit simply moves it, while keeping everything else working. As a side effect, one piece of interdependence among these three classes is removed.