### PR TITLE
Present AboutBox without throwing NRE

### DIFF
--- a/src/TestCentric/testcentric.gui/TestCentricMainForm.cs
+++ b/src/TestCentric/testcentric.gui/TestCentricMainForm.cs
@@ -1314,11 +1314,10 @@ namespace TestCentric.Gui
         /// <summary>
         /// Display the about box when menu item is selected
         /// </summary>
-        private void aboutMenuItem_Click(object sender, System.EventArgs e)
+        private void aboutMenuItem_Click(object sender, EventArgs e)
         {
-            using( AboutBox aboutBox = new AboutBox() )
+            using(var aboutBox = new AboutBox())
             {
-                Site.Container.Add( aboutBox );
                 aboutBox.ShowDialog();
             }
         }


### PR DESCRIPTION
`Site` was null, so the code failed with a NRE.