### PR TITLE
Refactor VisualState so it doesn't know about the tree view

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -87,7 +87,7 @@ namespace TestCentric.Gui.Presenters
 				if (_settings.Gui.TestTree.SaveVisualState)
                     try
                     {
-					    var visualState = new VisualState(_view);
+						var visualState = _view.GetVisualState();
 						visualState.SelectedCategories = _model.SelectedCategories;
 						visualState.ExcludeCategories = _model.ExcludeSelectedCategories;
 						visualState.Save(VisualState.GetVisualStateFileName(_model.TestFiles[0]));

--- a/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
+++ b/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -7,8 +6,7 @@
     <ProjectGuid>{3FF340D5-D3B4-4DF0-BAF1-98B3C00B6148}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyKeyContainerName>
-    </AssemblyKeyContainerName>
+    <AssemblyKeyContainerName></AssemblyKeyContainerName>
     <AssemblyName>TestCentric.Gui.Runner</AssemblyName>
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
@@ -16,10 +14,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestCentric.Gui</RootNamespace>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <FileUpgradeFlags></FileUpgradeFlags>
+    <UpgradeBackupLocation></UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
@@ -42,11 +38,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\..\bin\Debug\</OutputPath>
     <BaseAddress>285212672</BaseAddress>
-    <ConfigurationOverrideFile>
-    </ConfigurationOverrideFile>
+    <ConfigurationOverrideFile></ConfigurationOverrideFile>
     <DefineConstants>TRACE;DEBUG;CLR_2_0,NET_2_0,CS_3_0</DefineConstants>
-    <DocumentationFile>
-    </DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <NoWarn>1699</NoWarn>
@@ -62,11 +56,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\..\bin\Release\</OutputPath>
     <BaseAddress>285212672</BaseAddress>
-    <ConfigurationOverrideFile>
-    </ConfigurationOverrideFile>
+    <ConfigurationOverrideFile></ConfigurationOverrideFile>
     <DefineConstants>TRACE;CLR_2_0,NET_2_0,CS_3_0</DefineConstants>
-    <DocumentationFile>
-    </DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <NoWarn>1699</NoWarn>
     <Optimize>true</Optimize>
@@ -450,9 +442,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <PreBuildEvent></PreBuildEvent>
+    <PostBuildEvent></PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -66,6 +66,9 @@ namespace TestCentric.Gui.Views
 		void Clear();
 		void Reload(TestNode test);
 
+		VisualState GetVisualState();
+		void RestoreVisualState(VisualState visualState);
+
 		void ShowPropertiesDialog(TestSuiteTreeNode node);
 		void ClosePropertiesDialog();
 		void CheckPropertiesDialog();

--- a/src/TestCentric/testcentric.gui/Views/TestTree.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTree.cs
@@ -542,7 +542,7 @@ namespace TestCentric.Gui.Views
 					if (File.Exists(fileName))
 					{
 						var visualState = VisualState.LoadFrom(fileName);
-						visualState.Restore(tests);
+						tests.RestoreVisualState(visualState);
 						model.SelectCategories(visualState.SelectedCategories, visualState.ExcludeCategories);
 					}
 				}

--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -45,11 +45,11 @@ namespace TestCentric.Gui
         public string SelectedNode;
 
         public string[] SelectedCategories;
-
+        
         public bool ExcludeCategories;
 
-        [XmlArrayItem("Node")]
-        public List<VisualTreeNode> Nodes;
+		[XmlArrayItem("Node")]
+		public List<VisualTreeNode> Nodes = new List<VisualTreeNode>();
         #endregion
 
         #region Static Methods
@@ -79,19 +79,7 @@ namespace TestCentric.Gui
 
         #region Constructors
 
-        public VisualState() { }
-
-        public VisualState( ITestTreeView treeView )
-        {
-            ShowCheckBoxes = treeView.CheckBoxes;
-            TopNode = ((TestSuiteTreeNode)treeView.TopNode).Test.Id;
-            SelectedNode = ((TestSuiteTreeNode)treeView.SelectedNode).Test.Id;
-            Nodes = new List<VisualTreeNode>();
-
-            ProcessTreeNodes((TestSuiteTreeNode)treeView.Nodes[0]);
-        }
-
-        private void ProcessTreeNodes(TestSuiteTreeNode node)
+        public void ProcessTreeNodes(TestSuiteTreeNode node)
         {
             if (IsInteresting(node))
                 this.Nodes.Add(new VisualTreeNode(node));
@@ -121,39 +109,6 @@ namespace TestCentric.Gui
         {
             XmlSerializer serializer = new XmlSerializer( GetType() );
             serializer.Serialize( writer, this );
-        }
-
-        public void Restore(TestTreeView treeView)
-        {
-            treeView.CheckBoxes = ShowCheckBoxes;
-
-            foreach (VisualTreeNode visualNode in Nodes)
-            {
-                TestSuiteTreeNode treeNode = treeView[visualNode.Id];
-                if (treeNode != null)
-                {
-                    if (treeNode.IsExpanded != visualNode.Expanded)
-                        treeNode.Toggle();
-
-                    treeNode.Checked = visualNode.Checked;
-                }
-            }
-
-            if (this.SelectedNode != null)
-            {
-                TestSuiteTreeNode treeNode = treeView[SelectedNode];
-                if (treeNode != null)
-                    treeView.SelectedNode = treeNode;
-            }
-
-            if (TopNode != null)
-            {
-                TestSuiteTreeNode treeNode = treeView[TopNode];
-                if (treeNode != null)
-                    treeView.TopNode = treeNode;
-            }
-
-            treeView.Select();
         }
 
         #endregion


### PR DESCRIPTION
VisualState serves as a communications channel between the view and the presenter. In the older implementation, it knows all the internals of the tree view and can be constructed from one. In this commit, I changed it so that it's reversed. The tree view knows about and constructs a visual state on request by the presenter. The presenter can add other stuff from the model and then save it in a file as well as reload it when needed.

This is pure refactoring - no new features.