### PR TITLE
Move check buttons to TestTreeView

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -787,12 +787,12 @@ namespace TestCentric.Gui.Presenters
 
         public void RunSelectedTests()
         {
-            RunTests(_view.SelectedTests);
+            RunTests(_view.TreeView.SelectedTests);
         }
 
         public void RunFailedTests()
         {
-            RunTests(_view.FailedTests);
+            RunTests(_view.TreeView.FailedTests);
         }
 
         public void RunTests(TestNode test)
@@ -850,15 +850,6 @@ namespace TestCentric.Gui.Presenters
 			_view.SaveResultsCommand.Enabled = !testRunning && !testLoading && _model.HasResults;
 		}
         
-		// TODO:Remove use by TestTree
-        internal void EnableRunCommands(bool enabled)
-        {
-            _view.RunButton.Enabled = enabled;
-            _view.RunAllCommand.Enabled = enabled;
-            _view.RunSelectedCommand.Enabled = enabled;
-            _view.RunFailedCommand.Enabled = enabled && _model.HasResults && _view.FailedTests != null;
-        }
-
        private void InitializeControls(Control owner)
         {
             foreach (Control control in owner.Controls)

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -45,6 +45,8 @@ namespace TestCentric.Gui.Presenters
 			_view.DisplayStyle = (DisplayStyle)_settings.Gui.TestTree.InitialTreeDisplay;
 			_view.AlternateImageSet = (string)_settings.Gui.TestTree.AlternateImageSet;
 
+            //_view.ShowCheckBoxes.Checked = _view.CheckBoxes = _settings.Gui.TestTree.ShowCheckBoxes;
+
 			_view.RunCommand.Enabled = false;
 
 			WireUpEvents();

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -94,10 +94,6 @@ namespace TestCentric.Gui.Views
         ICommand NUnitHelpCommand { get; }
         ICommand AboutCommand { get; }
 	
-		// Test Selection
-		TestNode[] SelectedTests { get; }
-		TestNode[] FailedTests { get; }
-
         // SubViews
 		TestTreeView TreeView { get; }
 		StatusBarView StatusBarView { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -950,15 +950,9 @@ namespace TestCentric.Gui.Views
         public ICommand NUnitHelpCommand { get; }
         public ICommand AboutCommand { get; }
 
-        // Test Selection
-        public TestNode[] SelectedTests
-        {
-            get { return testTree.SelectedTests; }
-        }
-
         public TestNode[] FailedTests
         {
-            get { return testTree.FailedTests; }
+            get { return TreeView.FailedTests; }
         }
 
         public LongRunningOperationDisplay LongOperationDisplay(string text)

--- a/src/TestCentric/testcentric.gui/Views/TestTree.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTree.cs
@@ -44,8 +44,6 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.TabPage categoryPage;
         private System.Windows.Forms.Panel testPanel;
         private System.Windows.Forms.Panel categoryPanel;
-        private System.Windows.Forms.Panel treePanel;
-        private System.Windows.Forms.Panel buttonPanel;
         private TestTreeView tests;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListBox availableList;
@@ -54,8 +52,6 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.Panel categoryButtonPanel;
         private System.Windows.Forms.Button addCategory;
         private System.Windows.Forms.Button removeCategory;
-        private System.Windows.Forms.Button clearAllButton;
-        private System.Windows.Forms.Button checkFailedButton;
         private System.Windows.Forms.CheckBox excludeCheckbox;
 
         /// <summary> 
@@ -158,11 +154,7 @@ namespace TestCentric.Gui.Views
             this.tabs = new System.Windows.Forms.TabControl();
             this.testPage = new System.Windows.Forms.TabPage();
             this.testPanel = new System.Windows.Forms.Panel();
-            this.treePanel = new System.Windows.Forms.Panel();
             this.tests = new TestTreeView();
-            this.buttonPanel = new System.Windows.Forms.Panel();
-            this.checkFailedButton = new System.Windows.Forms.Button();
-            this.clearAllButton = new System.Windows.Forms.Button();
             this.categoryPage = new System.Windows.Forms.TabPage();
             this.categoryPanel = new System.Windows.Forms.Panel();
             this.categoryButtonPanel = new System.Windows.Forms.Panel();
@@ -176,8 +168,6 @@ namespace TestCentric.Gui.Views
             this.tabs.SuspendLayout();
             this.testPage.SuspendLayout();
             this.testPanel.SuspendLayout();
-            this.treePanel.SuspendLayout();
-            this.buttonPanel.SuspendLayout();
             this.categoryPage.SuspendLayout();
             this.categoryPanel.SuspendLayout();
             this.categoryButtonPanel.SuspendLayout();
@@ -209,22 +199,12 @@ namespace TestCentric.Gui.Views
             // 
             // testPanel
             // 
-            this.testPanel.Controls.Add(this.treePanel);
-            this.testPanel.Controls.Add(this.buttonPanel);
+            this.testPanel.Controls.Add(this.tests);
             this.testPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.testPanel.Location = new System.Drawing.Point(0, 0);
             this.testPanel.Name = "testPanel";
             this.testPanel.Size = new System.Drawing.Size(219, 488);
             this.testPanel.TabIndex = 0;
-            // 
-            // treePanel
-            // 
-            this.treePanel.Controls.Add(this.tests);
-            this.treePanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.treePanel.Location = new System.Drawing.Point(0, 0);
-            this.treePanel.Name = "treePanel";
-            this.treePanel.Size = new System.Drawing.Size(219, 448);
-            this.treePanel.TabIndex = 0;
             // 
             // tests
             // 
@@ -235,36 +215,6 @@ namespace TestCentric.Gui.Views
             this.tests.Name = "tests";
             this.tests.Size = new System.Drawing.Size(219, 448);
             this.tests.TabIndex = 0;
-            // 
-            // buttonPanel
-            // 
-            this.buttonPanel.Controls.Add(this.checkFailedButton);
-            this.buttonPanel.Controls.Add(this.clearAllButton);
-            this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.buttonPanel.Location = new System.Drawing.Point(0, 448);
-            this.buttonPanel.Name = "buttonPanel";
-            this.buttonPanel.Size = new System.Drawing.Size(219, 40);
-            this.buttonPanel.TabIndex = 1;
-            // 
-            // checkFailedButton
-            // 
-            this.checkFailedButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.checkFailedButton.Location = new System.Drawing.Point(117, 8);
-            this.checkFailedButton.Name = "checkFailedButton";
-            this.checkFailedButton.Size = new System.Drawing.Size(96, 23);
-            this.checkFailedButton.TabIndex = 1;
-            this.checkFailedButton.Text = "Check Failed";
-            this.checkFailedButton.Click += new System.EventHandler(this.checkFailedButton_Click);
-            // 
-            // clearAllButton
-            // 
-            this.clearAllButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.clearAllButton.Location = new System.Drawing.Point(13, 8);
-            this.clearAllButton.Name = "clearAllButton";
-            this.clearAllButton.Size = new System.Drawing.Size(96, 23);
-            this.clearAllButton.TabIndex = 0;
-            this.clearAllButton.Text = "Clear All";
-            this.clearAllButton.Click += new System.EventHandler(this.clearAllButton_Click);
             // 
             // categoryPage
             // 
@@ -386,8 +336,6 @@ namespace TestCentric.Gui.Views
             this.tabs.ResumeLayout(false);
             this.testPage.ResumeLayout(false);
             this.testPanel.ResumeLayout(false);
-            this.treePanel.ResumeLayout(false);
-            this.buttonPanel.ResumeLayout(false);
             this.categoryPage.ResumeLayout(false);
             this.categoryPanel.ResumeLayout(false);
             this.categoryButtonPanel.ResumeLayout(false);
@@ -445,16 +393,6 @@ namespace TestCentric.Gui.Views
             }
         }
 
-        private void clearAllButton_Click(object sender, System.EventArgs e)
-        {
-            tests.ClearCheckedNodes();
-        }
-
-        private void checkFailedButton_Click(object sender, System.EventArgs e)
-        {
-            tests.CheckFailedNodes();
-        }
-
         private void excludeCheckbox_CheckedChanged(object sender, System.EventArgs e)
         {
             UpdateCategorySelection();
@@ -476,20 +414,11 @@ namespace TestCentric.Gui.Views
             tests.TreeFilter = treeFilter;
         }
 
-        private void EnableCheckBoxes(bool enable)
-        {
-            buttonPanel.Visible = enable;
-            clearAllButton.Visible = enable;
-            checkFailedButton.Visible = enable;
-        }
-
         #region IViewControl Implementation
 
         public void InitializeView(ITestModel model)
         {
             Model = model;
-
-            EnableCheckBoxes(model.Services.UserSettings.Gui.TestTree.ShowCheckBoxes);
 
             model.Events.TestLoaded += (TestNodeEventArgs e) =>
             {
@@ -569,12 +498,6 @@ namespace TestCentric.Gui.Views
                 selectedList.Items.Clear();
                 excludeCheckbox.Checked = false;
                 excludeCheckbox.Enabled = false;
-            };
-
-            model.Services.UserSettings.Changed += (object sender, SettingsEventArgs e) =>
-            {
-                if (e.SettingName == "Gui.TestTree.ShowCheckBoxes")
-                    this.EnableCheckBoxes(model.Services.UserSettings.Gui.TestTree.ShowCheckBoxes);
             };
         }
 

--- a/src/TestCentric/testcentric.gui/Views/TestTree.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTree.cs
@@ -84,16 +84,6 @@ namespace TestCentric.Gui.Views
             }
         }
 
-        public TestNode[] SelectedTests
-        {
-            get { return tests.SelectedTests; }
-        }
-
-        public TestNode[] FailedTests
-        {
-            get { return tests.FailedTests; }
-        }
-
         private ITestModel Model { get; set; }
 
         #endregion
@@ -109,15 +99,6 @@ namespace TestCentric.Gui.Views
             //tests.CheckedTestChanged += new CheckedTestChangedHandler(tests_CheckedTestChanged);
 
             this.excludeCheckbox.Enabled = false;
-        }
-
-        protected override void OnLoad(EventArgs e)
-        {
-            if ( !this.DesignMode )
-            {
-            }
-
-            base.OnLoad (e);
         }
 
         public void ClearSelectedCategories()
@@ -478,19 +459,6 @@ namespace TestCentric.Gui.Views
         {
             UpdateCategorySelection();
         }
-
-        //private void tests_CheckedTestChanged(ITest[] tests)
-        //{
-        //	if (SelectedTestsChanged != null) 
-        //	{
-        //		SelectedTestsChangedEventArgs args = new SelectedTestsChangedEventArgs("", tests.Length);
-        //		SelectedTestsChanged(tests, args);
-        //	}
-
-        //	if (tests.Length > 0) 
-        //	{
-        //	}
-        //}
 
         private void UpdateCategorySelection()
         {

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -30,6 +30,8 @@
         {
 			this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TestTreeView));
+            this.treePanel = new System.Windows.Forms.Panel();
+            this.buttonPanel = new System.Windows.Forms.Panel();
             this.tree = new System.Windows.Forms.TreeView();
             this.treeImages = new System.Windows.Forms.ImageList(this.components);
             this.runMenuItem = new System.Windows.Forms.MenuItem();
@@ -38,6 +40,10 @@
             this.propertiesMenuItem = new System.Windows.Forms.MenuItem();
             this.treeMenu = new System.Windows.Forms.ContextMenu();
             this.treeMenu.Name = "treeMenu";
+            this.checkFailedButton = new System.Windows.Forms.Button();
+            this.clearAllButton = new System.Windows.Forms.Button();
+            this.treePanel.SuspendLayout();
+            this.buttonPanel.SuspendLayout();
             this.SuspendLayout();
 			// 
             // treeImages
@@ -49,6 +55,15 @@
             this.treeImages.Images.SetKeyName(2, "Success.png");
             this.treeImages.Images.SetKeyName(3, "Ignored.png");
             this.treeImages.Images.SetKeyName(4, "Inconclusive.png");
+            // 
+            // treePanel
+            // 
+            this.treePanel.Controls.Add(this.tree);
+            this.treePanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.treePanel.Location = new System.Drawing.Point(0, 0);
+            this.treePanel.Name = "treePanel";
+            this.treePanel.Size = new System.Drawing.Size(219, 448);
+            this.treePanel.TabIndex = 0;
             // 
             // tree
             //
@@ -73,7 +88,38 @@
                 this.showCheckBoxesMenuItem,
                 new System.Windows.Forms.MenuItem("-"),
                 this.propertiesMenuItem});
-            //
+            // 
+            // buttonPanel
+            // 
+            this.buttonPanel.Controls.Add(this.checkFailedButton);
+            this.buttonPanel.Controls.Add(this.clearAllButton);
+            //this.buttonPanel.Visible = true;
+            this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.buttonPanel.Location = new System.Drawing.Point(0, 448);
+            this.buttonPanel.Name = "buttonPanel";
+            this.buttonPanel.Size = new System.Drawing.Size(219, 40);
+            this.buttonPanel.TabIndex = 1;
+            // 
+            // checkFailedButton
+            // 
+            this.checkFailedButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.checkFailedButton.Location = new System.Drawing.Point(117, 8);
+            this.checkFailedButton.Name = "checkFailedButton";
+            this.checkFailedButton.Size = new System.Drawing.Size(96, 23);
+            this.checkFailedButton.TabIndex = 1;
+            this.checkFailedButton.Text = "Check Failed";
+            this.checkFailedButton.Click += new System.EventHandler(this.checkFailedButton_Click);
+            // 
+            // clearAllButton
+            // 
+            this.clearAllButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.clearAllButton.Location = new System.Drawing.Point(13, 8);
+            this.clearAllButton.Name = "clearAllButton";
+            this.clearAllButton.Size = new System.Drawing.Size(96, 23);
+            this.clearAllButton.TabIndex = 0;
+            this.clearAllButton.Text = "Clear All";
+            this.clearAllButton.Click += new System.EventHandler(this.clearAllButton_Click);
+           //
             // runMenuItem
             //
             this.runMenuItem.Name = "runMenuItem";
@@ -98,8 +144,12 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.tree);
+            this.Controls.AddRange(new System.Windows.Forms.Control[]{
+                this.treePanel,
+                this.buttonPanel});
             this.Name = "TestTreeView";
+            this.buttonPanel.ResumeLayout();
+            this.treePanel.ResumeLayout();
             this.ResumeLayout(false);
 
         }
@@ -107,7 +157,11 @@
         #endregion
 
         private System.Windows.Forms.ImageList treeImages;
+        private System.Windows.Forms.Panel treePanel;
         private System.Windows.Forms.TreeView tree;
+        private System.Windows.Forms.Panel buttonPanel;
+        private System.Windows.Forms.Button clearAllButton;
+        private System.Windows.Forms.Button checkFailedButton;
         private System.Windows.Forms.ContextMenu treeMenu;
         private System.Windows.Forms.MenuItem runMenuItem;
         private System.Windows.Forms.MenuItem showCheckBoxesMenuItem;

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -156,7 +156,7 @@ namespace TestCentric.Gui.Views
                         ? GetVisualState()
                         : null;
 
-                    tree.CheckBoxes = value;
+                    EnableCheckBoxes(value);
 
                     if (visualState != null)
                     {
@@ -165,6 +165,14 @@ namespace TestCentric.Gui.Views
                     }
                 }
             }
+        }
+
+        private void EnableCheckBoxes(bool enable)
+        {
+            tree.CheckBoxes = enable;
+            buttonPanel.Visible = enable;
+            clearAllButton.Visible = enable;
+            checkFailedButton.Visible = enable;
         }
 
         [Browsable(false)]
@@ -293,7 +301,7 @@ namespace TestCentric.Gui.Views
 
         public void RestoreVisualState(VisualState visualState)
         {
-            CheckBoxes = visualState.ShowCheckBoxes;
+            EnableCheckBoxes(visualState.ShowCheckBoxes);
 
             foreach (VisualTreeNode visualNode in visualState.Nodes)
             {
@@ -594,6 +602,16 @@ namespace TestCentric.Gui.Views
             }
 
             return true;
+        }
+
+        private void clearAllButton_Click(object sender, System.EventArgs e)
+        {
+            ClearCheckedNodes();
+        }
+
+        private void checkFailedButton_Click(object sender, System.EventArgs e)
+        {
+            CheckFailedNodes();
         }
 
         #endregion


### PR DESCRIPTION
This PR is the fruition of the preparatorywork done in issue-95j, which changed TestTreeView into a user control. Placing the two buttons on the same view as the tree eliminates one of the sources of cross-connection between the TestTree and TestTreeView views and allows TestTree to be further downsized (in a coming PR).