### PR TITLE
Fix error list scrolling; simplify event handlers; drop wordwrap option

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
@@ -43,7 +43,6 @@ namespace TestCentric.Gui.Presenters
             _model = model;
             _settings = model.Services.UserSettings;
 
-            _view.WordWrap = _settings.Gui.ErrorDisplay.WordWrapEnabled;
             _view.Font = _settings.Gui.FixedFont;
             _view.SplitterPosition = _settings.Gui.ErrorDisplay.SplitterPosition;
             _view.EnableToolTips = _settings.Gui.ErrorDisplay.ToolTipsEnabled;
@@ -63,26 +62,17 @@ namespace TestCentric.Gui.Presenters
         {
             // Events that arise in the model
 
-            _model.Events.TestLoaded += ((TestNodeEventArgs e) =>
-            {
-                _view.Clear();
-            });
+            _model.Events.TestLoaded += (e) => _view.Clear();
 
-            _model.Events.TestUnloaded += ((TestEventArgs e) =>
-            {
-                _view.Clear();
-            });
+            _model.Events.TestUnloaded += (e) => _view.Clear();
 
-            _model.Events.TestReloaded += (TestNodeEventArgs e) =>
+            _model.Events.TestReloaded += (e) =>
             {
                 if (_settings.Gui.ClearResultsOnReload)
                     _view.Clear();
             };
 
-            _model.Events.RunStarting += (RunStartingEventArgs e) =>
-            {
-                _view.Clear();
-            };
+            _model.Events.RunStarting += (e) => _view.Clear();
 
             _model.Events.TestFinished += (TestResultEventArgs e) =>
             {
@@ -100,7 +90,6 @@ namespace TestCentric.Gui.Presenters
 
             _model.Services.UserSettings.Changed += (object sender, SettingsEventArgs e) =>
             {
-                _view.WordWrap = _settings.Gui.ErrorDisplay.WordWrapEnabled;
                 _view.Font = _settings.Gui.FixedFont;
             };
 

--- a/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
@@ -27,6 +27,8 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
 {
+    using Elements;
+
     public interface IErrorsAndFailuresView
     {
         event EventHandler SplitterPositionChanged;
@@ -34,7 +36,6 @@ namespace TestCentric.Gui.Views
         event EventHandler SourceCodeSplitOrientationChanged;
         event EventHandler SourceCodeDisplayChanged;
 
-        bool WordWrap { get; set; } 
         bool EnableToolTips { get; set; }
         Font Font { get; set; }
         int SplitterPosition { get; set; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -808,7 +808,6 @@ namespace TestCentric.Gui.Views
             this.errorsAndFailuresView1.SourceCodeSplitterDistance = 0.3F;
             this.errorsAndFailuresView1.SplitterPosition = 128;
             this.errorsAndFailuresView1.TabIndex = 0;
-            this.errorsAndFailuresView1.WordWrap = false;
             // 
             // notrunTab
             // 

--- a/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -132,13 +132,6 @@ namespace TestCentric.Gui.Presenters
         }
 
         [Test]
-        public void WhenPresenterIsCreated_WordWrapIsSetToDefault()
-        {
-            bool wordwrap = _settings.Gui.ErrorDisplay.WordWrapEnabled;
-            _view.Received().WordWrap = wordwrap;
-        }
-
-        [Test]
         public void WhenPresenterIsCreated_FontIsSetToDefault()
         {
             var font = _settings.Gui.FixedFont;
@@ -181,14 +174,6 @@ namespace TestCentric.Gui.Presenters
         {
             bool enabled = _settings.Gui.ErrorDisplay.ToolTipsEnabled;
             _view.Received().EnableToolTips = enabled;
-        }
-
-        [Test]
-        public void WhenWordWrapSettingChanges_ViewIsUpdated()
-        {
-            _view.ClearReceivedCalls();
-            _settings.Gui.ErrorDisplay.WordWrapEnabled = true;
-            _view.Received().WordWrap = true;
         }
 
         [Test]


### PR DESCRIPTION
Fixes #99 

The specific scrolling problem is fixed but the display continues to have several problems on Linux only. These turn out to have been around for a long time in NUnit V2 so I'm not fixing them but will create new issues and refer to this one.