### PR TITLE
Remove unused using statements from GUI assembly

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;

--- a/src/TestCentric/testcentric.gui/Dialogs/AboutBox.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/AboutBox.cs
@@ -21,9 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Reflection;

--- a/src/TestCentric/testcentric.gui/Dialogs/ExtensionDialog.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/ExtensionDialog.cs
@@ -22,9 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Drawing;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using System.Windows.Forms;
 using NUnit.Engine;

--- a/src/TestCentric/testcentric.gui/Dialogs/LongRunningOperationDisplay.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/LongRunningOperationDisplay.cs
@@ -23,8 +23,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
-using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui

--- a/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.cs
@@ -25,9 +25,7 @@ using System;
 using System.Drawing;
 using System.ComponentModel;
 using System.Windows.Forms;
-using System.Text;
 using System.IO;
-using System.Collections;
 
 namespace TestCentric.Gui
 {

--- a/src/TestCentric/testcentric.gui/Elements/CheckBoxElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/CheckBoxElement.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements

--- a/src/TestCentric/testcentric.gui/Elements/CheckedMenuGroup.cs
+++ b/src/TestCentric/testcentric.gui/Elements/CheckedMenuGroup.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 

--- a/src/TestCentric/testcentric.gui/Elements/FontSelector.cs
+++ b/src/TestCentric/testcentric.gui/Elements/FontSelector.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/TestCentric/testcentric.gui/Elements/IListBox.cs
+++ b/src/TestCentric/testcentric.gui/Elements/IListBox.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements

--- a/src/TestCentric/testcentric.gui/Elements/ListBoxElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/ListBoxElement.cs
@@ -21,9 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements

--- a/src/TestCentric/testcentric.gui/Elements/SplitterPosition.cs
+++ b/src/TestCentric/testcentric.gui/Elements/SplitterPosition.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements

--- a/src/TestCentric/testcentric.gui/Elements/TabSelector.cs
+++ b/src/TestCentric/testcentric.gui/Elements/TabSelector.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -31,7 +31,6 @@ using NUnit.Engine;
 
 namespace TestCentric.Gui.Presenters
 {
-    using Controls;
     using Model;
     using Model.Settings;
     using Views;

--- a/src/TestCentric/testcentric.gui/Presenters/TestsNotRunPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestsNotRunPresenter.cs
@@ -21,12 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TestCentric.Gui.Presenters
 {
     using Model;

--- a/src/TestCentric/testcentric.gui/Presenters/TextOutputPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TextOutputPresenter.cs
@@ -22,11 +22,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/TestCentric/testcentric.gui/SettingsPages/GuiSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/GuiSettingsPage.cs
@@ -21,10 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.SettingsPages

--- a/src/TestCentric/testcentric.gui/SettingsPages/ProjectEditorSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/ProjectEditorSettingsPage.cs
@@ -22,11 +22,8 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.IO;
-using System.Text;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.SettingsPages

--- a/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Windows.Forms;
-using NUnit.Engine;
 
 namespace TestCentric.Gui
 {

--- a/src/TestCentric/testcentric.gui/SettingsPages/TestLoaderSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/TestLoaderSettingsPage.cs
@@ -22,9 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.SettingsPages

--- a/src/TestCentric/testcentric.gui/SettingsPages/TextOutputSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/TextOutputSettingsPage.cs
@@ -21,12 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Drawing;
 using System.Windows.Forms;
-using System.Diagnostics;
 
 namespace TestCentric.Gui.SettingsPages
 {

--- a/src/TestCentric/testcentric.gui/SettingsPages/TreeSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/TreeSettingsPage.cs
@@ -22,9 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Drawing;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;

--- a/src/TestCentric/testcentric.gui/Views/CategoryView.cs
+++ b/src/TestCentric/testcentric.gui/Views/CategoryView.cs
@@ -21,15 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Windows.Forms;
-using NUnit.Engine;
 
 namespace TestCentric.Gui.Views
 {
-    using Model;
     using Elements;
 
     /// <summary>

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -29,7 +29,6 @@ namespace TestCentric.Gui.Views
 {
 	using Controls;
 	using Elements;
-	using Model; // TODO: We shouldn't need this, but we do for now
 
 	public interface IMainView
     {

--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
@@ -21,8 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Windows.Forms;
-
 namespace TestCentric.Gui.Views
 {
     public partial class StatusBarView : UserControlView, IStatusBarView

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -29,7 +29,6 @@ using System.IO;
 namespace TestCentric.Gui.Views
 {
     using Controls;
-    using Model;
     using Elements;
 
     public class TestCentricMainView : TestCentricFormBase, IMainView
@@ -1022,11 +1021,6 @@ namespace TestCentric.Gui.Views
         public ICommand TestCentricHelpCommand { get; }
         public ICommand NUnitHelpCommand { get; }
         public ICommand AboutCommand { get; }
-
-        public TestNode[] FailedTests
-        {
-            get { return TreeView.FailedTests; }
-        }
 
         public LongRunningOperationDisplay LongOperationDisplay(string text)
 		{

--- a/src/TestCentric/testcentric.gui/Views/TestResultItem.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestResultItem.cs
@@ -25,8 +25,6 @@ using System;
 
 namespace TestCentric.Gui.Views
 {
-    using Model;
-
     /// <summary>
     /// TestResultItem is used by the ErrorsAndFailuresView to hold
     /// all the information about a test result for display.


### PR DESCRIPTION
I started this to remove `using Model` from the views, in order to see where it was still needed. Seemed simple to just remove all unused using statements, except for a few `System`, which I figure never hurts.