### PR TITLE
Replace LoadTests and ReloadTests in view with LoadTree

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -69,8 +69,7 @@ namespace TestCentric.Gui.Views
         TestNodeFilter TreeFilter { get; set; }
 
 		void Clear();
-        void LoadTests(TestNode test);
-		void Reload(TestNode test);
+        void LoadTree(TreeNode topLevelNode);
 
 		void ExpandAll();
 		void CollapseAll();

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Windows.Forms;
 using NUnit.Framework;
 using NSubstitute;
 
@@ -83,23 +84,23 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestLoadCompletes_MultipleAssemblies_TopNodeIsTestRun()
         {
-            TestNode tn = new TestNode("<test-run><test-suite id='1' name='test.dll'/><test-suite id='2' name='another.dll'/></test-run>");
+            TestNode testNode = new TestNode("<test-run><test-suite id='1' name='test.dll'/><test-suite id='2' name='another.dll'/></test-run>");
             ClearAllReceivedCalls();
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll", "another.dll" }));
-            FireTestLoadedEvent(tn);
+            FireTestLoadedEvent(testNode);
 
-            _view.Received().LoadTests(tn);
+            _view.Received().LoadTree(Arg.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
         }
 
         [Test]
         public void WhenTestLoadCompletes_SingleAssembly_TopNodeIsAssembly()
         {
-            TestNode tn = new TestNode("<test-run><test-suite id='1' name='another.dll'/></test-run>");
+            TestNode testNode = new TestNode("<test-run><test-suite id='1' name='another.dll'/></test-run>");
             ClearAllReceivedCalls();
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
-            FireTestLoadedEvent(tn);
+            FireTestLoadedEvent(testNode);
 
-            _view.Received().LoadTests(tn.Children[0]);
+            _view.Received().LoadTree(Arg.Is<TreeNode>(tn => tn.Text == "another.dll"));
         }
 
 


### PR DESCRIPTION
This is another step in simplifying the `TestTreeView`, which I'm doing in stages.

This PR eliminates two methods that take a TestNode (defined in the model) as an argument with a single method that takes a `System.Windows.Forms.TreeNode`.

To keep things working, I added some duplication for the time being. The `Tag` of the `TreeNode` holds the test id. This is needed to access the private `_treeMap`in the view, which I plan to move to the presenter in a subsequent refactoring.

When all is done, this view will be purely about UI, as intended.
