### PR TITLE
Move SetTestResult from the view to the presenter

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -81,7 +81,5 @@ namespace TestCentric.Gui.Views
 		void ShowPropertiesDialog(TestSuiteTreeNode node);
 		void ClosePropertiesDialog();
 		void CheckPropertiesDialog();
-
-		void SetTestResult(ResultNode result);
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -300,7 +300,7 @@ namespace TestCentric.Gui.Views
 
             foreach (VisualTreeNode visualNode in visualState.Nodes)
             {
-                TestSuiteTreeNode treeNode = this[visualNode.Id];
+                TestSuiteTreeNode treeNode = (TestSuiteTreeNode)_treeMap[visualNode.Id];
                 if (treeNode != null)
                 {
                     if (treeNode.IsExpanded != visualNode.Expanded)
@@ -312,14 +312,14 @@ namespace TestCentric.Gui.Views
 
             if (visualState.SelectedNode != null)
             {
-                TestSuiteTreeNode treeNode = this[visualState.SelectedNode];
+                TestSuiteTreeNode treeNode = (TestSuiteTreeNode)_treeMap[visualState.SelectedNode];
                 if (treeNode != null)
                     this.SelectedNode = treeNode;
             }
 
             if (visualState.TopNode != null)
             {
-                TestSuiteTreeNode treeNode = this[visualState.TopNode];
+                TestSuiteTreeNode treeNode = (TestSuiteTreeNode)_treeMap[visualState.TopNode];
                 if (treeNode != null)
                     this.TopNode = treeNode;
             }
@@ -344,32 +344,6 @@ namespace TestCentric.Gui.Views
                 _propertiesDialog.Close();
         }
 
-        /// <summary>
-        /// Add the result of a test to the tree
-        /// </summary>
-        /// <param name="result">The result of the test</param>
-        public void SetTestResult(ResultNode result)
-        {
-            TestSuiteTreeNode node = this[result.Id];
-            if (node == null)
-            {
-                Debug.WriteLine("Test not found in tree: " + result.FullName);
-            }
-            else
-            {
-                InvokeIfRequired(() =>
-                    {
-                        node.Result = result;
-
-                        if (result.Type == "Theory")
-                            node.RepopulateTheoryNode();
-
-                        Invalidate(node.Bounds);
-                        Update();
-                    });
-            }
-        }
-
         #endregion
 
         #region Other Public Properties
@@ -389,8 +363,6 @@ namespace TestCentric.Gui.Views
             get => _treeFilter;
             set => Accept(new TestFilterVisitor(_treeFilter = value));
         }
-
-        public TestSuiteTreeNode this[string id] => _treeMap[id] as TestSuiteTreeNode;
 
         #endregion
 

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -76,7 +76,7 @@ namespace TestCentric.Gui.Presenters
         {
             ClearAllReceivedCalls();
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
-            FireTestLoadedEvent(new TestNode("<test-run/>"));
+            FireTestLoadedEvent(new TestNode("<test-run id='2'/>"));
             
             _view.RunCommand.Received().Enabled = true;
         }
@@ -84,7 +84,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestLoadCompletes_MultipleAssemblies_TopNodeIsTestRun()
         {
-            TestNode testNode = new TestNode("<test-run><test-suite id='1' name='test.dll'/><test-suite id='2' name='another.dll'/></test-run>");
+            TestNode testNode = new TestNode("<test-run id='2'><test-suite id='101' name='test.dll'/><test-suite id='102' name='another.dll'/></test-run>");
             ClearAllReceivedCalls();
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll", "another.dll" }));
             FireTestLoadedEvent(testNode);
@@ -117,7 +117,7 @@ namespace TestCentric.Gui.Presenters
         public void WhenTestReloadCompletes_RunCommandIsEnabled()
         {
             ClearAllReceivedCalls();
-            FireTestReloadedEvent(new TestNode("<test-run/>"));
+            FireTestReloadedEvent(new TestNode("<test-run id='2'/>"));
 
             _view.RunCommand.Received().Enabled = true;
         }
@@ -183,19 +183,29 @@ namespace TestCentric.Gui.Presenters
 		[Test]
         public void WhenTestCaseCompletes_ResultIsPosted()
         {
-            var result = new ResultNode("<test-case id='DUMMY' result='Passed'/>");
+            var test = new TestNode("<test-case id='100' name='DummyTest'/>");
+            var treeNode = new TestSuiteTreeNode(test);
+            _presenter.TreeMap["100"] = treeNode;
+
+            var result = new ResultNode("<test-case id='100' name='DummyTest' result='Passed'/>");
+
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
 
-            _view.Received().SetTestResult(result);
+            Assert.That(treeNode.Result, Is.EqualTo(result));
         }
         
 		[Test]
         public void WhenTestSuiteCompletes_ResultIsPosted()
         {
-            var result = new ResultNode("<test-suite id='DUMMY' result='Passed'/>");
+            var suite = new TestNode("<test-suite id='100' name='DUMMY'/>");
+            var treeNode = new TestSuiteTreeNode(suite);
+            _presenter.TreeMap["100"] = treeNode;
+
+            var result = new ResultNode("<test-suite id='100' name='DUMMY' result='Passed'/>");
+
             _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
 
-            _view.Received().SetTestResult(result);
+            Assert.That(treeNode.Result, Is.EqualTo(result));
         }
 
         //[Test]


### PR DESCRIPTION
Another incremental change, moving functionality out of the view so it's more testable.

This PR drops the SetTestResult method, which required the view to understand what a test result looks like and gives the job of finding the proper tree node and posting the result to the presenter.

In order to accomplish this, I introduced some more duplication: both the view and the presenter now have a map to allow lookup of test ids to find the corresponding tree node. Eventually, this will be removed from the view, when all the functionality is in the presenter.