### PR TITLE
Move visualstate to presenter

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -433,7 +433,7 @@ namespace TestCentric.Gui.Presenters
 
             _view.CheckboxesCommand.CheckedChanged += () =>
             {
-                _settings.Gui.TestTree.ShowCheckBoxes = _view.TreeView.CheckBoxes = _view.CheckboxesCommand.Checked;
+                _settings.Gui.TestTree.ShowCheckBoxes = _view.CheckboxesCommand.Checked;
             };
 
             _view.ExpandCommand.Execute += () =>

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -55,15 +55,15 @@ namespace TestCentric.Gui.Views
 		ICommand PropertiesCommand { get; }
 		// TODO: Can we eliminate need for having both of the following?
 		IChecked ShowCheckBoxes { get; }
-		bool CheckBoxes { get; set; }
+        bool CheckBoxes { get; set; }
 
 		DisplayStyle DisplayStyle { get; set; }
 		string AlternateImageSet { get; set; }
 
 		TreeNodeCollection Nodes { get; }
-		TreeNode TopNode { get; }
+        TreeNode TopNode { get; set; }
         TestSuiteTreeNode ContextNode { get; }
-		TreeNode SelectedNode { get; }
+        TreeNode SelectedNode { get; set; }
 		TestNode[] SelectedTests { get; }
 
         TestNodeFilter TreeFilter { get; set; }
@@ -74,9 +74,6 @@ namespace TestCentric.Gui.Views
 		void ExpandAll();
 		void CollapseAll();
 		void HideTests();
-
-		VisualState GetVisualState();
-		void RestoreVisualState(VisualState visualState);
 
 		void ShowPropertiesDialog(TestSuiteTreeNode node);
 		void ClosePropertiesDialog();

--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Windows.Forms;
 using System.Xml.Serialization;
 
 namespace TestCentric.Gui
@@ -79,16 +80,16 @@ namespace TestCentric.Gui
 
         #region Constructors
 
-        public void ProcessTreeNodes(TestSuiteTreeNode node)
+        public void ProcessTreeNodes(TreeNode node)
         {
             if (IsInteresting(node))
                 this.Nodes.Add(new VisualTreeNode(node));
 
-            foreach (TestSuiteTreeNode childNode in node.Nodes)
+            foreach (TreeNode childNode in node.Nodes)
                 ProcessTreeNodes(childNode);
         }
 
-        private bool IsInteresting(TestSuiteTreeNode node)
+        private bool IsInteresting(TreeNode node)
         {
             return node.IsExpanded || node.Checked;
         }
@@ -131,9 +132,9 @@ namespace TestCentric.Gui
 
         public VisualTreeNode() { }
 
-        public VisualTreeNode( TestSuiteTreeNode treeNode )
+        public VisualTreeNode( TreeNode treeNode )
         {
-            Id = treeNode.Test.Id;
+            Id = (string)treeNode.Tag;
             Expanded = treeNode.IsExpanded;
             Checked = treeNode.Checked;
         }

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -110,13 +110,13 @@ namespace TestCentric.Gui.Presenters
             ClearAllReceivedCalls();
             FireTestsReloadingEvent();
 
-            _view.RunCommand.Received().Enabled = false;
-        }
+            _view.RunCommand.Received().Enabled = false;}
 
         [Test]
         public void WhenTestReloadCompletes_RunCommandIsEnabled()
         {
             ClearAllReceivedCalls();
+
             FireTestReloadedEvent(new TestNode("<test-run id='2'/>"));
 
             _view.RunCommand.Received().Enabled = true;


### PR DESCRIPTION
This moves the saving and restoring of visual state out of the tree view and into the presenter. The presenter now maintains the lookup dictionary from test ids to tree nodes.