### PR TITLE
Handle TreeView buttons in presenter

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -57,6 +57,9 @@ namespace TestCentric.Gui.Views
 		IChecked ShowCheckBoxes { get; }
         bool CheckBoxes { get; set; }
 
+        ICommand ClearAllCheckBoxes { get; }
+        ICommand CheckFailedTests { get; }
+
 		DisplayStyle DisplayStyle { get; set; }
 		string AlternateImageSet { get; set; }
 

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -108,7 +108,6 @@
             this.checkFailedButton.Size = new System.Drawing.Size(96, 23);
             this.checkFailedButton.TabIndex = 1;
             this.checkFailedButton.Text = "Check Failed";
-            this.checkFailedButton.Click += new System.EventHandler(this.checkFailedButton_Click);
             // 
             // clearAllButton
             // 
@@ -118,7 +117,6 @@
             this.clearAllButton.Size = new System.Drawing.Size(96, 23);
             this.clearAllButton.TabIndex = 0;
             this.clearAllButton.Text = "Clear All";
-            this.clearAllButton.Click += new System.EventHandler(this.clearAllButton_Click);
            //
             // runMenuItem
             //

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -63,6 +63,8 @@ namespace TestCentric.Gui.Views
             ShowCheckBoxes = new CheckedMenuItem(showCheckBoxesMenuItem);
             ShowFailedAssumptions = new CheckedMenuItem(failedAssumptionsMenuItem);
             PropertiesCommand = new MenuCommand(propertiesMenuItem);
+            ClearAllCheckBoxes = new ButtonElement(clearAllButton);
+            CheckFailedTests = new ButtonElement(checkFailedButton);
 
 			WireUpEvents();
 		}
@@ -148,6 +150,9 @@ namespace TestCentric.Gui.Views
                 checkFailedButton.Visible = value;
             }
         }
+
+        public ICommand ClearAllCheckBoxes { get; private set; }
+        public ICommand CheckFailedTests { get; private set; }
 
         [Browsable(false)]
         public DisplayStyle DisplayStyle { get; set; }
@@ -287,14 +292,6 @@ namespace TestCentric.Gui.Views
             get => _treeFilter;
             set => Accept(new TestFilterVisitor(_treeFilter = value));
         }
-
-        #endregion
-
-        #region Other Public Methods
-
-        public void ClearCheckedNodes() => Accept(new ClearCheckedNodesVisitor());
-
-        public void CheckFailedNodes() => Accept(new CheckFailedNodesVisitor());
 
         #endregion
 
@@ -450,48 +447,6 @@ namespace TestCentric.Gui.Views
             }
 
             return true;
-        }
-
-        private void clearAllButton_Click(object sender, System.EventArgs e)
-        {
-            ClearCheckedNodes();
-        }
-
-        private void checkFailedButton_Click(object sender, System.EventArgs e)
-        {
-            CheckFailedNodes();
-        }
-
-        #endregion
-
-        #region ClearCheckedNodesVisitor
-
-        internal class ClearCheckedNodesVisitor : TestSuiteTreeNodeVisitor
-        {
-            public override void Visit(TestSuiteTreeNode node)
-            {
-                node.Checked = false;
-            }
-        }
-
-        #endregion
-
-        #region CheckFailedNodesVisitor
-
-        internal class CheckFailedNodesVisitor : TestSuiteTreeNodeVisitor
-        {
-            public override void Visit(TestSuiteTreeNode node)
-            {
-                if (!node.Test.IsSuite &&
-                    node.HasResult &&
-                    node.Result.Outcome.Status == TestStatus.Failed)
-                {
-                    node.Checked = true;
-                    node.EnsureVisible();
-                }
-                else
-                    node.Checked = false;
-            }
         }
 
         #endregion

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -115,7 +115,7 @@ namespace TestCentric.Gui.Model
         void SaveResults(string fileName, string format="nunit3");
 
         // Get the result for a test if available
-        ResultNode GetResultForTest(TestNode testNode);
+        ResultNode GetResultForTest(string id);
 
         // Clear the results for all tests
         void ClearResults();

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -255,16 +255,16 @@ namespace TestCentric.Gui.Model
         public void SaveResults(string filePath, string format = "nunit3")
         {
             var resultWriter = Services.ResultService.GetResultWriter(format, new object[0]);
-            var results = GetResultForTest(Tests);
+            var results = GetResultForTest(Tests.Id);
             resultWriter.WriteResultFile(results.Xml, filePath);
         }
 
-        public ResultNode GetResultForTest(TestNode testNode)
+        public ResultNode GetResultForTest(string id)
         {
-            if (testNode != null)
+            if (!string.IsNullOrEmpty(id))
             {
                 ResultNode result;
-                if (Results.TryGetValue(testNode.Id, out result))
+                if (Results.TryGetValue(id, out result))
                     return result;
             }
 


### PR DESCRIPTION
This moves the button event handling for Clear All Checks and Check Failed Tests from the view to the presenter and eliminates two of the nested visitor classes.

An error introduced in an earlier PR is also fixed. Replacement of the old Hashtable with a Dictionary requires testing for lookup success since null is no longer returned on failure.