### PR TITLE
Revise and simplify tree view interface

### DIFF
--- a/src/Common/testcentric.common/TestCentric.Common.csproj
+++ b/src/Common/testcentric.common/TestCentric.Common.csproj
@@ -32,7 +32,7 @@
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="nunit.engine.api">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.9.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.8.0\lib\nunit.engine.api.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Common/testcentric.common/packages.config
+++ b/src/Common/testcentric.common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.9.0" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/testcentric.gui/Elements/IControlElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/IControlElement.cs
@@ -29,7 +29,7 @@ namespace TestCentric.Gui.Elements
     /// <summary>
     /// IControlElement is implemented by elements that wrap controls.
     /// </summary>
-    public interface IControlElement : ITextElement
+    public interface IControlElement : IViewElement
     {
         Point Location { get; set; }
         Size Size { get; set; }

--- a/src/TestCentric/testcentric.gui/Elements/ITreeView.cs
+++ b/src/TestCentric/testcentric.gui/Elements/ITreeView.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2015-2018 Charlie Poole
+// Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,18 +21,45 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements
 {
+    public delegate void TreeNodeActionHandler(TreeNode treeNode);
+
     /// <summary>
-    /// Implemented by View Elements that display text in some way.
+    /// The ITreeViewElement interface provides additional methods
+    /// used when wrapping a TreeView.
     /// </summary>
-	public interface ITextElement : IViewElement
-	{
-		/// <summary>
-        /// Gets or sets the Text of an element
-        /// </summary>
-        string Text { get; set; }
-	}
+    public interface ITreeView : IControlElement<TreeView>
+    {
+        event TreeNodeActionHandler SelectedNodeChanged;
+
+        bool CheckBoxes { get; set; }
+
+        TreeNode TopNode { get; set; }
+
+        TreeNode SelectedNode { get; set; }
+
+        IList<TreeNode> Nodes { get; }
+        int VisibleCount { get; }
+
+#if EXPERIMENTAL
+        IList<TreeNode> CheckedNodes { get; }
+        IContextMenuElement ContextMenu { get; set; }
+#endif
+
+        void Clear();
+        void ExpandAll();
+        void CollapseAll();
+        void Load(TreeNode treeNode);
+        int GetNodeCount(bool includeSubTrees);
+        void Select();
+
+#if EXPERIMENTAL
+        void Add(TreeNode treeNode);
+        void SetImageIndex(TreeNode treeNode, int imageIndex);
+#endif
+    }
 }

--- a/src/TestCentric/testcentric.gui/Elements/IViewElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/IViewElement.cs
@@ -43,9 +43,14 @@ namespace TestCentric.Gui.Elements
         /// </summary>
         bool Visible { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text of an element.
+        /// </summary>
+        string Text { get; set; }
+
         ///// <summary>
         ///// Invoke a delegate if necessary, otherwise just call it
         ///// </summary>
-        //void InvokeIfRequired(MethodInvoker _delegate);
+        void InvokeIfRequired(MethodInvoker _delegate);
     }
 }

--- a/src/TestCentric/testcentric.gui/Elements/MenuElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/MenuElement.cs
@@ -87,7 +87,7 @@ namespace TestCentric.Gui.Elements
             }
         }
 
-        protected void InvokeIfRequired(MethodInvoker del)
+        public void InvokeIfRequired(MethodInvoker del)
         {
             if (_form!= null && _form.InvokeRequired)
                 _form.BeginInvoke(del, new object[0]);

--- a/src/TestCentric/testcentric.gui/Elements/TreeViewElement.cs
+++ b/src/TestCentric/testcentric.gui/Elements/TreeViewElement.cs
@@ -1,0 +1,241 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace TestCentric.Gui.Elements
+{
+    /// <summary>
+    /// TreeViewElement extends ControlElement for wrapping a TreeView.
+    /// In addition to the normal shallow adapter provided by an element,
+    /// TreeViewElement extends some of the functionality of TreeView:
+    ///  * Checkboxes may be turned on and off dynamically, while retaining
+    ///    the current visual state of the tree.
+    ///  * The CheckedNodes property returns a list of checked TreeNodes.
+    /// </summary>
+    public class TreeViewElement : ControlElement<TreeView>, ITreeView
+    {
+        public event TreeNodeActionHandler SelectedNodeChanged;
+
+        public TreeViewElement(TreeView treeView)
+            : base(treeView)
+        {
+            _checkBoxes = treeView.CheckBoxes;
+
+            treeView.AfterSelect += (s, e) =>
+            {
+                if (SelectedNodeChanged != null)
+                    SelectedNodeChanged(e.Node);
+            };
+
+            treeView.MouseUp += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Right)
+                {
+                    var treeNode = treeView.GetNodeAt(e.X, e.Y);
+                    if (treeNode != null)
+                        treeView.SelectedNode = treeNode;
+                }
+            };
+        }
+
+#if EXPERIMENTAL
+       private IContextMenuElement contextMenu;
+        public IContextMenuElement ContextMenu
+        {
+            get 
+            {
+                if (contextMenu == null && Control.ContextMenuStrip != null)
+                    contextMenu = new ContextMenuElement(Control.ContextMenuStrip);
+
+                return contextMenu;
+            }
+            set 
+            {
+                InvokeIfRequired(() =>
+                {
+                    contextMenu = value;
+                    Control.ContextMenuStrip = contextMenu.Control;
+                });
+            }
+        }
+#endif
+
+        private bool _checkBoxes;
+        public bool CheckBoxes
+        {
+            get { return _checkBoxes; }
+            set
+            {
+                if (_checkBoxes != value)
+                {
+                    var expandedNodes = new List<TreeNode>();
+
+                    // Turning off checkboxes collapses everything, so we
+                    // have to save and restore the expanded nodes.
+                    if (!value)
+                        foreach (TreeNode node in Control.Nodes)
+                            RecordExpandedNodes(expandedNodes, node);
+
+                    InvokeIfRequired(() => { Control.CheckBoxes = _checkBoxes = value; });
+
+                    if (!value)
+                        foreach (var node in expandedNodes)
+                            node.Expand();
+                }
+            }
+        }
+
+        public TreeNode TopNode
+        {
+            get => Control.TopNode;
+            set => Control.TopNode = value;
+        }
+
+        public int VisibleCount => Control.VisibleCount;
+
+        public TreeNode SelectedNode
+        {
+            get => Control.SelectedNode;
+            set => Control.SelectedNode = value;
+        }
+
+        public IList<TreeNode> Nodes
+        {
+            get
+            {
+                var nodes = new List<TreeNode>();
+                foreach (TreeNode node in Control.Nodes)
+                    nodes.Add(node);
+                return nodes;
+            }
+        }
+
+        public IList<TreeNode> CheckedNodes => GetCheckedNodes();
+
+        public int GetNodeCount(bool includeSubTrees)
+        {
+            return Control.GetNodeCount(includeSubTrees);
+        }
+
+        public void Clear()
+        {
+            InvokeIfRequired(() => Control.Nodes.Clear());
+        }
+
+        public void ExpandAll()
+        {
+            InvokeIfRequired(() => Control.ExpandAll());
+        }
+
+        public void CollapseAll()
+        {
+            InvokeIfRequired(() => Control.CollapseAll());
+        }
+
+        public void Select()
+        {
+            InvokeIfRequired(() => Control.Select());
+        }
+
+        public void Load(TreeNode treeNode)
+        {
+            Add(treeNode, true);
+        }
+
+        #if EXPERIMENTAL
+        public void Add(TreeNode treeNode)
+        {
+            Add(treeNode, false);
+        }
+
+        public void Insert(int index, TreeNode treeNode)
+        {
+            InvokeIfRequired(() =>
+            {
+                Control.Nodes.Insert(index, treeNode);
+            });
+        }
+
+        public void Load(TreeNode treeNode)
+        {
+            Add(treeNode, true);
+        }
+
+        public void SetImageIndex(TreeNode treeNode, int imageIndex)
+        {
+            InvokeIfRequired(() =>
+            {
+                treeNode.ImageIndex = treeNode.SelectedImageIndex = imageIndex;
+            });
+        }
+#endif
+
+#region Helper Methods
+
+        private void Add(TreeNode treeNode, bool doClear)
+        {
+            InvokeIfRequired(() =>
+            {
+                if (doClear)
+                    Control.Nodes.Clear();
+
+                Control.BeginUpdate();
+                Control.Nodes.Add(treeNode);
+                if (Control.SelectedNode == null)
+                    Control.SelectedNode = treeNode;
+                Control.EndUpdate();
+                Control.Select();
+            });
+        }
+
+        private void RecordExpandedNodes(List<TreeNode> expanded, TreeNode startNode)
+        {
+            if (startNode.IsExpanded)
+                expanded.Add(startNode);
+
+            foreach (TreeNode node in startNode.Nodes)
+                RecordExpandedNodes(expanded, node);
+        }
+
+        private IList<TreeNode> GetCheckedNodes()
+        {
+            var checkedNodes = new List<TreeNode>();
+            foreach (TreeNode node in Control.Nodes)
+                CollectCheckedNodes(checkedNodes, node);
+            return checkedNodes;
+        }
+
+        private void CollectCheckedNodes(List<TreeNode> checkedNodes, TreeNode node)
+        {
+            if (node.Checked)
+                checkedNodes.Add(node);
+            else
+                foreach (TreeNode child in node.Nodes)
+                    CollectCheckedNodes(checkedNodes, child);
+        }
+
+#endregion
+    }
+}

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -415,7 +415,7 @@ namespace TestCentric.Gui.Presenters
 
             _view.TreeMenu.Popup += () =>
             {
-                TreeNode selectedNode = _view.TreeView.SelectedNode;
+                TreeNode selectedNode = _view.TreeView.Tree.SelectedNode;
 
                 _view.CheckboxesCommand.Checked = _settings.Gui.TestTree.ShowCheckBoxes;
 
@@ -438,12 +438,12 @@ namespace TestCentric.Gui.Presenters
 
             _view.ExpandCommand.Execute += () =>
             {
-                _view.TreeView.SelectedNode.Expand();
+                _view.TreeView.Tree.SelectedNode.Expand();
             };
 
             _view.CollapseCommand.Execute += () =>
             {
-                _view.TreeView.SelectedNode.Collapse();
+                _view.TreeView.Tree.SelectedNode.Collapse();
             };
 
             _view.ExpandAllCommand.Execute += () =>
@@ -463,8 +463,8 @@ namespace TestCentric.Gui.Presenters
 
             _view.PropertiesCommand.Execute += () =>
             {
-				if (_view.TreeView.SelectedNode != null)
-					_view.TreeView.ShowPropertiesDialog((TestSuiteTreeNode)_view.TreeView.SelectedNode);
+				if (_view.TreeView.Tree.SelectedNode != null)
+					_view.TreeView.ShowPropertiesDialog((TestSuiteTreeNode)_view.TreeView.Tree.SelectedNode);
 			};
 
             _view.IncreaseFontCommand.Execute += () =>

--- a/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
+++ b/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
@@ -341,7 +341,6 @@
     <Compile Include="Elements\MenuCommand.cs" />
     <Compile Include="Elements\PopupMenu.cs" />
     <Compile Include="Elements\CheckedMenuItem.cs" />
-    <Compile Include="Elements\ITextElement.cs" />
     <Compile Include="Elements\IMenuElement.cs" />
     <Compile Include="Views\TestTreeView.cs" />
     <Compile Include="Views\TestTreeView.Designer.cs">
@@ -356,6 +355,8 @@
     <Compile Include="Elements\ControlElement.cs" />
     <Compile Include="Elements\IListBox.cs" />
     <Compile Include="Elements\ListBoxElement.cs" />
+    <Compile Include="Elements\ITreeView.cs" />
+    <Compile Include="Elements\TreeViewElement.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="nunit.snk" />

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -30,19 +30,7 @@ namespace TestCentric.Gui.Views
 	using Model; // To be removed
 	using Elements;
 
-	/// <summary>
-    /// Indicates how a tree should be displayed
-    /// </summary>
-    public enum DisplayStyle
-    {
-        Auto,       // Select based on space available
-        Expand,     // Expand fully
-        Collapse,   // Collapase fully
-        HideTests   // Expand all but the fixtures, leaving
-                    // leaf nodes hidden
-    }
-
-    public delegate void FileDropEventHandler(IList<string> fileNames);
+   public delegate void FileDropEventHandler(IList<string> fileNames);
 
 	public interface ITestTreeView
     {
@@ -55,28 +43,21 @@ namespace TestCentric.Gui.Views
 		ICommand PropertiesCommand { get; }
 		// TODO: Can we eliminate need for having both of the following?
 		IChecked ShowCheckBoxes { get; }
+
         bool CheckBoxes { get; set; }
 
         ICommand ClearAllCheckBoxes { get; }
         ICommand CheckFailedTests { get; }
 
-		DisplayStyle DisplayStyle { get; set; }
 		string AlternateImageSet { get; set; }
 
-		TreeNodeCollection Nodes { get; }
-        TreeNode TopNode { get; set; }
+        ITreeView Tree { get; }
         TestSuiteTreeNode ContextNode { get; }
-        TreeNode SelectedNode { get; set; }
 		TestNode[] SelectedTests { get; }
 
         TestNodeFilter TreeFilter { get; set; }
 
-		void Clear();
-        void LoadTree(TreeNode topLevelNode);
-
-		void ExpandAll();
-		void CollapseAll();
-		void HideTests();
+        void Clear();
 
 		void ShowPropertiesDialog(TestSuiteTreeNode node);
 		void ClosePropertiesDialog();

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -40,19 +40,15 @@ namespace TestCentric.Gui.Presenters
         [SetUp]
         public void CreatePresenter()
         {
+            _settings.Gui.TestTree.AlternateImageSet = "MyImageSet";
+            _settings.Gui.TestTree.ShowCheckBoxes = true;
             _presenter = new TreeViewPresenter(_view, _model);
 			_model.IsTestRunning.Returns(false);
-
-            // Make it look like the view loaded
-            //_view.Load += Raise.Event<System.EventHandler>(null, new System.EventArgs());
         }
 
         [TearDown]
         public void RemovePresenter()
         {
-            //if (_presenter != null)
-            //    _presenter.Dispose();
-            
             _presenter = null;
         }
 
@@ -61,6 +57,19 @@ namespace TestCentric.Gui.Presenters
 		{
 			_view.RunCommand.Received().Enabled = false;
 		}
+
+        [Test]
+        public void WhenPresenterIsCreated_AlternateImageSetIsSet()
+        {
+            _view.Received().AlternateImageSet = "MyImageSet";
+        }
+
+        [Test]
+        public void WhenPresenterIsCreated_ShowCheckBoxesIsSet()
+        {
+            _view.Received().CheckBoxes = true;
+            _view.ShowCheckBoxes.Received().Checked = true;
+        }
 
 		[Test]
         public void WhenTestLoadBegins_RunCommandIsDisabled()
@@ -77,8 +86,18 @@ namespace TestCentric.Gui.Presenters
             ClearAllReceivedCalls();
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
             FireTestLoadedEvent(new TestNode("<test-run id='2'/>"));
-            
+
             _view.RunCommand.Received().Enabled = true;
+        }
+
+        [Test]
+        public void WhenTestLoadCompletes_PropertyDialogIsClosed()
+        {
+            ClearAllReceivedCalls();
+            _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
+            FireTestLoadedEvent(new TestNode("<test-run id='2'/>"));
+
+            _view.Received().CheckPropertiesDialog();
         }
 
         [Test]
@@ -89,7 +108,7 @@ namespace TestCentric.Gui.Presenters
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll", "another.dll" }));
             FireTestLoadedEvent(testNode);
 
-            _view.Received().LoadTree(Arg.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
+            _view.Tree.Received().Load(Arg.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
         }
 
         [Test]
@@ -100,7 +119,7 @@ namespace TestCentric.Gui.Presenters
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
             FireTestLoadedEvent(testNode);
 
-            _view.Received().LoadTree(Arg.Is<TreeNode>(tn => tn.Text == "another.dll"));
+            _view.Tree.Received().Load(Arg.Is<TreeNode>(tn => tn.Text == "another.dll"));
         }
 
 
@@ -116,7 +135,6 @@ namespace TestCentric.Gui.Presenters
         public void WhenTestReloadCompletes_RunCommandIsEnabled()
         {
             ClearAllReceivedCalls();
-
             FireTestReloadedEvent(new TestNode("<test-run id='2'/>"));
 
             _view.RunCommand.Received().Enabled = true;

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -210,8 +210,6 @@ namespace TestCentric.Gui.Model
 
             TestPackage = MakeTestPackage(TestFiles);
 
-            Runner = TestEngine.GetRunner(TestPackage);
-
             Tests = new TestNode(Runner.Explore(TestFilter.Empty));
             AvailableCategories = GetAvailableCategories();
 


### PR DESCRIPTION
The simplification involves introduction of the TreeViewElement from the experimental GUI, with some modifications. Since the element takes on more of the work the `ITestTreeView` interface can be simplified. At the same time, this solves some problems with reloading of tests and helped uncover and resolve an issue with how the model was performing reloading.

Once again, since this is entirely refactoring plus addition of a few new tests, I'm going ahead and merging once CI passes.