### PR TITLE
Set default for checkboxes only from settings page

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -81,10 +81,7 @@ namespace TestCentric.Gui.Presenters
 
         private void WireUpEvents()
         {
-            _model.Events.TestsLoading += (e) =>
-            {
-                _view.RunCommand.Enabled = false;
-            };
+            _model.Events.TestsLoading += (e) => _view.RunCommand.Enabled = false;
 
             _model.Events.TestLoaded += (e) =>
             {
@@ -113,10 +110,7 @@ namespace TestCentric.Gui.Presenters
                 }
             };
 
-            _model.Events.TestsReloading += (e) =>
-            {
-                _view.RunCommand.Enabled = false;
-            };
+            _model.Events.TestsReloading += (e) => _view.RunCommand.Enabled = false;
 
             _model.Events.TestReloaded += (e) =>
             {
@@ -152,10 +146,7 @@ namespace TestCentric.Gui.Presenters
                 _treeMap.Clear();
             };
 
-            _model.Events.TestUnloaded += (e) =>
-            {
-                _view.RunCommand.Enabled = false;
-            };
+            _model.Events.TestUnloaded += (e) => _view.RunCommand.Enabled = false;
 
             _model.Events.RunStarting += (e) =>
             {
@@ -163,10 +154,7 @@ namespace TestCentric.Gui.Presenters
                 _view.CheckPropertiesDialog();
             };
 
-            _model.Events.RunFinished += (e) =>
-            {
-                _view.RunCommand.Enabled = true;
-            };
+            _model.Events.RunFinished += (e) => _view.RunCommand.Enabled = true;
 
             _model.Events.TestFinished += (e) => SetTestResult(e.Result);
 
@@ -226,11 +214,8 @@ namespace TestCentric.Gui.Presenters
                     _model.RunTests(new TestSelection(_view.SelectedTests));
             };
 
-            _view.ShowCheckBoxes.CheckedChanged += () =>
-            {
-                _settings.Gui.TestTree.ShowCheckBoxes = _view.ShowCheckBoxes.Checked;
-            };
-
+            _view.ShowCheckBoxes.CheckedChanged += () => _view.CheckBoxes = _view.ShowCheckBoxes.Checked;
+ 
             _view.ClearAllCheckBoxes.Execute += () => ClearAllCheckBoxes(_view.Tree.TopNode);
 
             _view.CheckFailedTests.Execute += () => CheckFailedTests(_view.Tree.TopNode);
@@ -243,20 +228,11 @@ namespace TestCentric.Gui.Presenters
                     theoryNode.ShowFailedAssumptions = _view.ShowFailedAssumptions.Checked;
             };
 
-            _view.ExpandAllCommand.Execute += () =>
-            {
-                _view.Tree.ExpandAll();
-            };
+            _view.ExpandAllCommand.Execute += () => _view.Tree.ExpandAll();
 
-            _view.CollapseAllCommand.Execute += () =>
-            {
-                _view.Tree.CollapseAll();
-            };
+            _view.CollapseAllCommand.Execute += () => _view.Tree.CollapseAll();
 
-            _view.HideTestsCommand.Execute += () =>
-            {
-                HideTestsUnderNode(_model.Tests);
-            };
+            _view.HideTestsCommand.Execute += () => HideTestsUnderNode(_model.Tests);
 
             _view.PropertiesCommand.Execute += () =>
             {

--- a/src/TestCentric/testcentric.gui/SettingsPages/TreeSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/TreeSettingsPage.cs
@@ -35,6 +35,7 @@ namespace TestCentric.Gui.SettingsPages
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.ComboBox initialDisplayComboBox;
         private System.Windows.Forms.CheckBox saveVisualStateCheckBox;
+        private System.Windows.Forms.CheckBox showCheckBoxesCheckBox;
         private System.Windows.Forms.HelpProvider helpProvider1;
         private Label label6;
         private PictureBox successImage;
@@ -93,6 +94,7 @@ namespace TestCentric.Gui.SettingsPages
             this.label2 = new System.Windows.Forms.Label();
             this.initialDisplayComboBox = new System.Windows.Forms.ComboBox();
             this.saveVisualStateCheckBox = new System.Windows.Forms.CheckBox();
+            this.showCheckBoxesCheckBox = new System.Windows.Forms.CheckBox();
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.label6 = new System.Windows.Forms.Label();
             this.successImage = new System.Windows.Forms.PictureBox();
@@ -164,6 +166,17 @@ namespace TestCentric.Gui.SettingsPages
             this.saveVisualStateCheckBox.Size = new System.Drawing.Size(184, 17);
             this.saveVisualStateCheckBox.TabIndex = 35;
             this.saveVisualStateCheckBox.Text = "Save Visual State of each project";
+            // 
+            // saveVisualStateCheckBox
+            // 
+            this.showCheckBoxesCheckBox.AutoSize = true;
+            this.helpProvider1.SetHelpString(this.showCheckBoxesCheckBox, "If checked, a checkbox is displayed next to each item in the tree.");
+            this.showCheckBoxesCheckBox.Location = new System.Drawing.Point(32, 185);
+            this.showCheckBoxesCheckBox.Name = "showCheckBoxesCheckBox";
+            this.helpProvider1.SetShowHelp(this.showCheckBoxesCheckBox, true);
+            this.showCheckBoxesCheckBox.Size = new System.Drawing.Size(184, 17);
+            this.showCheckBoxesCheckBox.TabIndex = 36;
+            this.showCheckBoxesCheckBox.Text = "Display a checkbox next to each tree item.";
             // 
             // label6
             // 
@@ -256,6 +269,7 @@ namespace TestCentric.Gui.SettingsPages
             this.Controls.Add(this.label2);
             this.Controls.Add(this.initialDisplayComboBox);
             this.Controls.Add(this.saveVisualStateCheckBox);
+            this.Controls.Add(this.showCheckBoxesCheckBox);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.label1);
             this.Name = "TreeSettingsPage";
@@ -274,6 +288,7 @@ namespace TestCentric.Gui.SettingsPages
         {
             initialDisplayComboBox.SelectedIndex = Settings.Gui.TestTree.InitialTreeDisplay;
             saveVisualStateCheckBox.Checked = Settings.Gui.TestTree.SaveVisualState;
+            showCheckBoxesCheckBox.Checked = Settings.Gui.TestTree.ShowCheckBoxes;
 
             string[] altDirs = Directory.Exists(treeImageDir)
                 ? Directory.GetDirectories(treeImageDir)
@@ -293,6 +308,7 @@ namespace TestCentric.Gui.SettingsPages
         {
             Settings.Gui.TestTree.InitialTreeDisplay = initialDisplayComboBox.SelectedIndex;
             Settings.Gui.TestTree.SaveVisualState = saveVisualStateCheckBox.Checked;
+            Settings.Gui.TestTree.ShowCheckBoxes = showCheckBoxesCheckBox.Checked;
 
             if (imageSetListBox.SelectedIndex >= 0)
                 Settings.Gui.TestTree.AlternateImageSet = (string)imageSetListBox.SelectedItem;


### PR DESCRIPTION
Fixes #156 

Changes:
 * Changing CheckBoxes in the tree via context menu no longer sets default
 * Default setting is once again in the settings dialog
 * Reformated some lambdas to use expression format