### PR TITLE
Adjust status bar height based on font

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.Designer.cs
@@ -51,16 +51,16 @@
             this.warningsPanel,
             this.inconclusivePanel,
             this.timePanel});
-            this.statusStrip1.Location = new System.Drawing.Point(0, -1);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 2);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(579, 24);
+            this.statusStrip1.Size = new System.Drawing.Size(579, 22);
             this.statusStrip1.TabIndex = 0;
             this.statusStrip1.Text = "statusStrip1";
             // 
             // StatusLabel
             // 
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(88, 19);
+            this.StatusLabel.Size = new System.Drawing.Size(564, 17);
             this.StatusLabel.Spring = true;
             this.StatusLabel.Text = "Ready";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -70,7 +70,7 @@
             this.testCountPanel.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
             this.testCountPanel.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
             this.testCountPanel.Name = "testCountPanel";
-            this.testCountPanel.Size = new System.Drawing.Size(52, 19);
+            this.testCountPanel.Size = new System.Drawing.Size(53, 19);
             this.testCountPanel.Text = "Tests : 0";
             this.testCountPanel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.testCountPanel.Visible = false;
@@ -138,8 +138,9 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.statusStrip1);
+            this.MinimumSize = new System.Drawing.Size(0, 24);
             this.Name = "StatusBarView";
-            this.Size = new System.Drawing.Size(579, 23);
+            this.Size = new System.Drawing.Size(579, 24);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
@@ -111,9 +111,10 @@ namespace TestCentric.Gui.Views
 
         protected override void OnFontChanged(EventArgs e)
         {
-            StatusLabel.Font = testCountPanel.Font = testsRunPanel.Font = passedPanel.Font =
-                failedPanel.Font = warningsPanel.Font = inconclusivePanel.Font = timePanel.Font = Font;
             base.OnFontChanged(e);
+
+            Height = Math.Max((int)Font.GetHeight() + 10, MinimumSize.Height);
+            statusStrip1.Font = Font;
         }
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.resx
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Fixes #178 

@drSte This was easier than I thought. By doing the height change at the right time, everything else adjusted itself! I also simplified what you had already done. Take a look and see if you detect any problems.

There's still the possibility that the status bar info won't fit in the space provided, if the display is too narrow. But that has always been the case.