### PR TITLE
Add packages.config to git repo

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.30.0" />
+</packages>


### PR DESCRIPTION
Fixes #185 

This locks the Cake version at 0.30 to avoid an issue with the 0.31 build.
