### PR TITLE
Upgrade to Cake 0.31.0 use tool on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 ﻿language: csharp
 sudo: false
+dotnet: 2.1.502
 mono:
   - latest
   - 5.10.1
   - 4.6.2
-script: 
+script:
   - git fetch --unshallow
-  - ./build.sh --target=Travis --configuration=Release
+  - dotnet tool install --version "0.31.0" -g Cake.Tool
+  - ~/.dotnet/tools/dotnet-cake --target=Travis --configuration=Release

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.30.0" />
+    <package id="Cake" version="0.31.0" />
 </packages>


### PR DESCRIPTION
* Upgrade to Cake 0.31.0
* Adjust Travis to use Cake.Tool 0.31.0

Refers to cake-build/cake#2401

Example Travis build:
https://travis-ci.org/devlead/testcentric-gui/builds/469518326