### PR TITLE
Add Project nodes to test tree

### DIFF
--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -180,8 +180,7 @@ namespace TestCentric.Gui.Model
             TestPackage = MakeTestPackage(files);
 
             Runner = TestEngine.GetRunner(TestPackage);
-
-            Tests = new TestNode(Runner.Explore(TestFilter.Empty));
+            Tests = ExploreTestPackage(TestPackage);
             AvailableCategories = GetAvailableCategories();
 
             Results.Clear();
@@ -225,7 +224,7 @@ namespace TestCentric.Gui.Model
 
             TestPackage = MakeTestPackage(TestFiles);
 
-            Tests = new TestNode(Runner.Explore(TestFilter.Empty));
+            Tests = ExploreTestPackage(TestPackage);
             AvailableCategories = GetAvailableCategories();
 
             if (Services.UserSettings.Gui.ClearResultsOnReload)
@@ -397,6 +396,48 @@ namespace TestCentric.Gui.Model
                 package.AddSetting(entry.Key, entry.Value);
 
             return package;
+        }
+
+        private TestNode ExploreTestPackage(TestPackage package)
+        {
+            var tests = new TestNode(Runner.Explore(TestFilter.Empty));
+            int nextId = 10;
+            int nextTest = 0;
+            int nextPackage = 0;
+
+            while (nextPackage < package.SubPackages.Count && nextTest < tests.Children.Count)
+            {
+                var subPackage = package.SubPackages[nextPackage++];
+                var childTest = tests.Children[nextTest];
+
+                if (subPackage.Name != childTest.Name)
+                {
+                    // SubPackage did not match the next child test node, so it must be a project.
+                     var project = new TestNode($"<test-suite type='Project' id='{nextId++}' name='{subPackage.Name}' fullname='{subPackage.FullName}' runstate='Runnable'/>");
+                    int testCount = 0;
+
+                    // Now move any children of this project under it
+                    foreach(var subSubPackage in subPackage.SubPackages)
+                    {
+                        childTest = tests.Children[nextTest];
+
+                        if (subSubPackage.Name == childTest.Name)
+                        {
+                            project.Children.Add(childTest);
+                            tests.Children.RemoveAt(nextTest);
+                            testCount += childTest.TestCount;
+                        }
+                    }
+
+                    project.Xml.AddAttribute("testcasecount", testCount.ToString());
+                    tests.Children.Insert(nextTest, project);
+                }
+
+                nextTest++;
+            }
+
+
+            return tests;
         }
 
         // The engine returns more values than we really want.


### PR DESCRIPTION
Fixes #159 

This isn't ready to merge but I wanted it to be looked at so I made the PR.

It's a great example of the lengths we have to go to if the tree returned by the standard engine release is used. Nothing is present in the tree to indicate a project. I used the info found in the TestPackage to modify the tree of TestNodes and modified TestNode so that a project node creates a filter that combines its child nodes. IOW, the GUI is doing what the engine was supposed to do in the first place.

@mikkelbu I think you have the most experience to review the code. It's not supported by tests - I only spiked it. I have only tested using the solution, i.e. a single project on the command-line. We need to verify it for multiple projects and projects combined with individual asssemblies.

@OsirisTerje I thought you should look at this because it relates to some separate discussion we have had about the support of the engine.