### PR TITLE
Use LoadTests to add a file to those open

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -46,9 +46,7 @@ namespace TestCentric.Gui.Presenters
     /// 1. Many functions, which should properly be in
     /// the presenter, remain in the form.
     /// 
-    /// 2. The form has references to the model and presenter.
-    /// 
-    /// 3. The presenter creates dialogs itself, which
+    /// 2. The presenter creates dialogs itself, which
     /// limits testability.
     /// </summary>
     public class TestCentricPresenter
@@ -653,8 +651,11 @@ namespace TestCentric.Gui.Presenters
 
             if (dlg.ShowDialog() == DialogResult.OK)
             {
-                _model.TestFiles.Add(dlg.FileName);
-                _model.ReloadTests();
+                // We need a copy because LoadTests causes the model to clear TestFiles
+                var files = new List<string>(_model.TestFiles);
+                files.Add(dlg.FileName);
+
+                _model.LoadTests(files);
             }
         }
 

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -31,6 +31,10 @@ namespace TestCentric.Gui.Presenters.Main
 
     public class CommandTests : MainPresenterTestBase
     {
+        // TODO: Because the presenter opens dialogs for these commands,
+        // they can't be tested directly. This could be fixed if the
+        // presenter asked the view to open dialogs.
+
         //[Test]
         //public void NewProjectCommand_CallsNewProject()
         //{
@@ -58,6 +62,13 @@ namespace TestCentric.Gui.Presenters.Main
 
         //    View.OpenProjectCommand.Execute += Raise.Event<CommandHandler>();
         //    Model.DidNotReceive().LoadTests(Arg.Any<IList<string>>());
+        //}
+
+        //[Test]
+        //public void AddTestFileCommand_CallsReloadTests()
+        //{
+        //    _view.AddTestFileCommand.Execute += Raise.Event<CommandHandler>();
+        //    _model.Received().LoadTests();
         //}
 
         [Test]


### PR DESCRIPTION
This is just a basic fix... we needed to use LoadTests in order to get a new set of runners. A better fix would be if the engine itself had a way to add a test to an existing open package and reconfigure itself without reloading al the other tests!