### PR TITLE
Update engine to TC-00001

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,7 @@ if (!IsRunningOnWindows() && !isMonoButSupportsMsBuild)
 //////////////////////////////////////////////////////////////////////
 
 // HACK: Engine Version - Must update this manually to match package used
-var ENGINE_VERSION = "3.10.0-dev-00004";
+var ENGINE_VERSION = "3.10.0-tc-00001";
 
 // Directories
 var PROJECT_DIR = Context.Environment.WorkingDirectory.FullPath + "/";

--- a/src/Common/testcentric.common/TestCentric.Common.csproj
+++ b/src/Common/testcentric.common/TestCentric.Common.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />

--- a/src/Common/testcentric.common/packages.config
+++ b/src/Common/testcentric.common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
 </packages>

--- a/src/Experimental/experimental-gui/Experimental.Gui.csproj
+++ b/src/Experimental/experimental-gui/Experimental.Gui.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/Experimental/experimental-gui/packages.config
+++ b/src/Experimental/experimental-gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
 </packages>

--- a/src/Experimental/tests/Experimental.Gui.Tests.csproj
+++ b/src/Experimental/tests/Experimental.Gui.Tests.csproj
@@ -42,23 +42,23 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit-agent.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit-agent.exe</HintPath>
     </Reference>
     <Reference Include="nunit-agent-x86, Version=3.10.0.0, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit-agent-x86.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit-agent-x86.exe</HintPath>
     </Reference>
     <Reference Include="nunit.engine, Version=3.10.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit.engine.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit.engine.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/src/Experimental/tests/packages.config
+++ b/src/Experimental/tests/packages.config
@@ -3,6 +3,6 @@
   <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.10.0-tc-00001" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
+++ b/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
@@ -94,7 +94,7 @@
       <Name>TestCentric.Gui.Model</Name>
     </ProjectReference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/TestCentric/testcentric.gui/packages.config
+++ b/src/TestCentric/testcentric.gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
+++ b/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
@@ -101,7 +101,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/TestCentric/tests/packages.config
+++ b/src/TestCentric/tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net20" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/TestModel/model/packages.config
+++ b/src/TestModel/model/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
 </packages>

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -38,23 +38,23 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit-agent.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit-agent.exe</HintPath>
     </Reference>
     <Reference Include="nunit-agent-x86, Version=3.10.0.0, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit-agent-x86.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit-agent-x86.exe</HintPath>
     </Reference>
     <Reference Include="nunit.engine, Version=3.10.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit.engine.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit.engine.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/TestModel/tests/packages.config
+++ b/src/TestModel/tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.10.0-tc-00001" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net45" />
 </packages>

--- a/src/tests/test-utilities/packages.config
+++ b/src/tests/test-utilities/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine.Api" version="3.10.0-dev-00004" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0-tc-00001" targetFramework="net45" />
 </packages>

--- a/src/tests/test-utilities/test-utilities.csproj
+++ b/src/tests/test-utilities/test-utilities.csproj
@@ -83,7 +83,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-dev-00004\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00001\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>


### PR DESCRIPTION
Really, not much is changing in this PR except the numbering of the releases. Having `-dev` releases in the test-centric myget feed creates confusion with NUnit's own `-dev` releases, so I've changed to use `-tc`.