### PR TITLE
Update NSubstitute to version 4.0

### DIFF
--- a/src/Experimental/tests/Experimental.Gui.Tests.csproj
+++ b/src/Experimental/tests/Experimental.Gui.Tests.csproj
@@ -37,16 +37,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent.exe</HintPath>

--- a/src/Experimental/tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/Experimental/tests/Presenters/StatusBarPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -103,7 +103,7 @@ namespace TestCentric.Gui.Presenters
             _model.Events.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(result));
 
             _view.Received().OnRunFinished(0);
-            _view.Received().OnTestRunSummaryCompiled(Arg.Any<string>());
+            _view.Received().OnTestRunSummaryCompiled(Arg.Compat.Any<string>());
         }
 
         //[Test]

--- a/src/Experimental/tests/Presenters/TestTree/CommandTests.cs
+++ b/src/Experimental/tests/Presenters/TestTree/CommandTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -113,7 +113,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.Tree.SelectedNodeChanged += Raise.Event<TreeNodeActionHandler>(treeNode);
             _view.RunContextCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().RunTests(Arg.Is<TestNode>((t) => t.Id == "5"));
+            _model.Received().RunTests(Arg.Compat.Is<TestNode>((t) => t.Id == "5"));
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.Tree.SelectedNodeChanged += Raise.Event<TreeNodeActionHandler>(treeNode);
             _view.DebugContextCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().DebugTests(Arg.Is<TestNode>((t) => t.Id == "5"));
+            _model.Received().DebugTests(Arg.Compat.Is<TestNode>((t) => t.Id == "5"));
         }
 
         [Test]

--- a/src/Experimental/tests/Presenters/TestTree/NUnitTreeDisplayStrategyTests.cs
+++ b/src/Experimental/tests/Presenters/TestTree/NUnitTreeDisplayStrategyTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -59,8 +59,8 @@ namespace TestCentric.Gui.Presenters.TestTree
                 new TestNode("<test-run id='1'><test-suite id='42'/><test-suite id='99'/></test-run>"));
 
             _view.Tree.Received().Clear();
-            _view.Tree.Received().Add(Arg.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
-            _view.Tree.Received().Add(Arg.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "99"));
+            _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
+            _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "99"));
         }
 
         [Test]

--- a/src/Experimental/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/Experimental/tests/Presenters/TreeViewPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -99,7 +99,7 @@ namespace TestCentric.Gui.Presenters
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Tree.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex);
+            _view.Tree.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace TestCentric.Gui.Presenters
             _view.DisplayFormat.SelectedItem.Returns("NUNIT_TREE");
             _view.DisplayFormat.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _view.Tree.Received().Add(Arg.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
+            _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
         }
     }
 }

--- a/src/Experimental/tests/packages.config
+++ b/src/Experimental/tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="NUnit.Engine" version="3.10.0-tc-00002" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />

--- a/src/GuiException/tests/nunit.uiexception.tests.csproj
+++ b/src/GuiException/tests/nunit.uiexception.tests.csproj
@@ -58,9 +58,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/GuiException/tests/packages.config
+++ b/src/GuiException/tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net45" />

--- a/src/ProjectEditor/tests/nunit-editor.tests.csproj
+++ b/src/ProjectEditor/tests/nunit-editor.tests.csproj
@@ -56,12 +56,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/ProjectEditor/tests/packages.config
+++ b/src/ProjectEditor/tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.9.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -243,7 +243,7 @@ namespace TestCentric.Gui.Presenters
         {
             // NOTE: We only verify that something was sent, not the content
             if (shouldDisplay)
-                _view.Received().AddResult(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+                _view.Received().AddResult(Arg.Compat.Any<string>(), Arg.Compat.Any<string>(), Arg.Compat.Any<string>());
             else
                 _view.DidNotReceiveWithAnyArgs().AddResult(null, null, null);
         }

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -119,7 +119,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.AddTestFilesCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().LoadTests(Arg.Is<List<string>>(l => l.SequenceEqual(allFiles)));
+            _model.Received().LoadTests(Arg.Compat.Is<List<string>>(l => l.SequenceEqual(allFiles)));
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.AddTestFilesCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.DidNotReceive().LoadTests(Arg.Any<IList<string>>());
+            _model.DidNotReceive().LoadTests(Arg.Compat.Any<IList<string>>());
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TextOutputPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -422,7 +422,7 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         private void VerifyNothingWasWritten()
         {
-            _view.DidNotReceiveWithAnyArgs().Write(Arg.Any<string>(), Arg.Any<Color>());
+            _view.DidNotReceiveWithAnyArgs().Write(Arg.Compat.Any<string>(), Arg.Compat.Any<Color>());
         }
 
         /// <summary>

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -110,7 +110,7 @@ namespace TestCentric.Gui.Presenters
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll", "another.dll" }));
             FireTestLoadedEvent(testNode);
 
-            _view.Tree.Received().Load(Arg.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
+            _view.Tree.Received().Load(Arg.Compat.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace TestCentric.Gui.Presenters
             _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
             FireTestLoadedEvent(testNode);
 
-            _view.Tree.Received().Load(Arg.Is<TreeNode>(tn => tn.Text == "another.dll"));
+            _view.Tree.Received().Load(Arg.Compat.Is<TreeNode>(tn => tn.Text == "another.dll"));
         }
 
 
@@ -200,7 +200,7 @@ namespace TestCentric.Gui.Presenters
 
             _view.RunCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().RunTests(Arg.Is<TestSelection>((sel) => sel.Count == 2 && sel[0].Id == "DUMMY-1" && sel[1].Id == "DUMMY-2"));
+            _model.Received().RunTests(Arg.Compat.Is<TestSelection>((sel) => sel.Count == 2 && sel[0].Id == "DUMMY-1" && sel[1].Id == "DUMMY-2"));
         }
 
         [Test]
@@ -286,7 +286,7 @@ namespace TestCentric.Gui.Presenters
         //    _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
         //    _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, resultNode));
 
-        //    _view.Tree.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex);
+        //    _view.Tree.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex);
         //}
 
         //[Test]
@@ -297,7 +297,7 @@ namespace TestCentric.Gui.Presenters
         //    _view.DisplayFormat.SelectedItem.Returns("NUNIT_TREE");
         //    _view.DisplayFormat.SelectionChanged += Raise.Event<CommandHandler>();
 
-        //    _view.Tree.Received().Add(Arg.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
+        //    _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
         //}
     }
 }

--- a/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
+++ b/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
@@ -97,9 +97,12 @@
       <Project>{3ff340d5-d3b4-4df0-baf1-98b3c00b6148}</Project>
       <Name>TestCentric.Gui</Name>
     </ProjectReference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
@@ -131,9 +134,6 @@
       <Project>{3e63ad0f-24d4-46be-bee4-5a3299847d86}</Project>
       <Name>test-utilities</Name>
     </ProjectReference>
-    <Reference Include="Castle.Core">
-      <HintPath>..\..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/src/TestCentric/tests/packages.config
+++ b/src/TestCentric/tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net20" />

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -40,9 +40,8 @@
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent.exe</HintPath>

--- a/src/TestModel/tests/packages.config
+++ b/src/TestModel/tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="NUnit.Engine" version="3.10.0-tc-00002" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />


### PR DESCRIPTION
NSubstitute version 4.0 has a dependency on Castle.Core (>= 4.3.1), so
this package has also been updated.

Fixes #164