### PR TITLE
Altered ChangePackageSetting to do an unload/load rather than a reload.

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using NUnit.Engine;
@@ -748,7 +749,13 @@ namespace TestCentric.Gui.Presenters
             string message = string.Format("New {0} setting will not take effect until you reload.\r\n\r\n\t\tReload Now?", key);
 
             if (_view.MessageDisplay.Ask(message) == DialogResult.Yes)
-                _model.ReloadTests();
+            {
+                // Even though the _model has a Reload method, we cannot use it because Reload
+                // does not re-create the Engine.  Since we just changed a setting, we must
+                // re-create the Engine by unloading/reloading the tests.
+                List<string> listCopy = _model.TestFiles.ToList();
+                LoadTests(listCopy);    // This also does an Unload first.
+            }
         }
 
         private void applyFont(Font font)

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -378,26 +378,26 @@ namespace TestCentric.Gui.Presenters
 
             _view.SelectedRuntime.SelectionChanged += () =>
             {
-                ChangePackageSetting(EnginePackageSettings.RuntimeFramework, _view.SelectedRuntime.SelectedItem);
+                ChangePackageSettingAndReload(EnginePackageSettings.RuntimeFramework, _view.SelectedRuntime.SelectedItem);
             };
 
             _view.ProcessModel.SelectionChanged += () =>
             {
-                ChangePackageSetting(EnginePackageSettings.ProcessModel, _view.ProcessModel.SelectedItem);
+                ChangePackageSettingAndReload(EnginePackageSettings.ProcessModel, _view.ProcessModel.SelectedItem);
             };
 
             _view.DomainUsage.SelectionChanged += () =>
             {
-                ChangePackageSetting(EnginePackageSettings.DomainUsage, _view.DomainUsage.SelectedItem);
+                ChangePackageSettingAndReload(EnginePackageSettings.DomainUsage, _view.DomainUsage.SelectedItem);
             };
 
             _view.RunAsX86.CheckedChanged += () =>
             {
                 var key = EnginePackageSettings.RunAsX86;
                 if (_view.RunAsX86.Checked)
-                    ChangePackageSetting(key, true);
+                    ChangePackageSettingAndReload(key, true);
                 else
-                    ChangePackageSetting(key, null);
+                    ChangePackageSettingAndReload(key, null);
             };
 
             _view.RecentFilesMenu.Popup += () =>
@@ -739,7 +739,7 @@ namespace TestCentric.Gui.Presenters
             return "\"" + s + "\"";
         }
 
-        private void ChangePackageSetting(string key, object setting)
+        private void ChangePackageSettingAndReload(string key, object setting)
         {
             if (setting == null || setting as string == "DEFAULT")
                 _model.PackageSettings.Remove(key);

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -746,16 +746,11 @@ namespace TestCentric.Gui.Presenters
             else
                 _model.PackageSettings[key] = setting;
 
-            string message = string.Format("New {0} setting will not take effect until you reload.\r\n\r\n\t\tReload Now?", key);
-
-            if (_view.MessageDisplay.Ask(message) == DialogResult.Yes)
-            {
-                // Even though the _model has a Reload method, we cannot use it because Reload
-                // does not re-create the Engine.  Since we just changed a setting, we must
-                // re-create the Engine by unloading/reloading the tests.
-                List<string> listCopy = _model.TestFiles.ToList();
-                LoadTests(listCopy);    // This also does an Unload first.
-            }
+            // Even though the _model has a Reload method, we cannot use it because Reload
+            // does not re-create the Engine.  Since we just changed a setting, we must
+            // re-create the Engine by unloading/reloading the tests.
+            List<string> listCopy = _model.TestFiles.ToList();
+            LoadTests(listCopy);    // This also does an Unload first.
         }
 
         private void applyFont(Font font)

--- a/src/TestCentric/tests/Presenters/PresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/PresenterTestBase.cs
@@ -50,6 +50,7 @@ namespace TestCentric.Gui.Presenters
             _model = Substitute.For<ITestModel>();
             _settings = new FakeUserSettings();
             _model.Services.UserSettings.Returns(_settings);
+            _model.TestFiles.Returns(new List<string>());
         }
 
         #region Helper Methods


### PR DESCRIPTION
A reload does not use the setting that you just changed, so the unload/load is necessary.  It re-creates the Engine with your new settings.  This fixes issue #299.