### PR TITLE
Persisted "Run as X86" choice across runs of the gui.

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -394,9 +394,15 @@ namespace TestCentric.Gui.Presenters
             {
                 var key = EnginePackageSettings.RunAsX86;
                 if (_view.RunAsX86.Checked)
+                {
                     ChangePackageSetting(key, true);
+                    _settings.Gui.RunAsX86 = true;
+                }
                 else
+                {
                     ChangePackageSetting(key, null);
+                    _settings.Gui.RunAsX86 = false;
+                }
             };
 
             _view.RecentFilesMenu.Popup += () =>
@@ -800,6 +806,8 @@ namespace TestCentric.Gui.Presenters
 
             if (useFullGui)
                 _view.SplitterPosition = _settings.Gui.MainForm.SplitPosition;
+
+            _view.RunAsX86.Checked = (bool)_model.PackageSettings[EnginePackageSettings.RunAsX86];
         }
 
         private static bool IsValidLocation(Point location, Size size)

--- a/src/TestModel/model/Settings/GuiSettings.cs
+++ b/src/TestModel/model/Settings/GuiSettings.cs
@@ -132,5 +132,11 @@ namespace TestCentric.Gui.Model.Settings
             get { return GetSetting(nameof(InternalTraceLevel), InternalTraceLevel.Off); }
             set { SaveSetting(nameof(InternalTraceLevel), value); }
         }
+
+        public bool RunAsX86
+        {
+            get { return GetSetting(nameof(RunAsX86), false); }
+            set { SaveSetting(nameof(RunAsX86), value); }
+        }
     }
 }

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -60,6 +60,8 @@ namespace TestCentric.Gui.Model
                     VisualStudioSupport = true;
             }
 
+            PackageSettings[EnginePackageSettings.RunAsX86] = Services.UserSettings.Gui.RunAsX86;
+
             _events = new TestEventDispatcher(this);
             _assemblyWatcher = new AssemblyWatcher();
         }

--- a/src/TestModel/tests/SettingsTests.cs
+++ b/src/TestModel/tests/SettingsTests.cs
@@ -145,7 +145,8 @@ namespace TestCentric.Gui.Model.Settings
             new TestCaseData("ClearResultsOnReload", false, true),
             new TestCaseData("Font", DEFAULT_FONT, TEST_FONT),
             new TestCaseData("FixedFont", DEFAULT_FIXED_FONT, TEST_FIXED_FONT),
-            new TestCaseData("InternalTraceLevel", InternalTraceLevel.Off, InternalTraceLevel.Verbose)
+            new TestCaseData("InternalTraceLevel", InternalTraceLevel.Off, InternalTraceLevel.Verbose),
+            new TestCaseData("RunAsX86", false, true)
         };
 
         [TestCase("TestTree", typeof(TestTreeSettings))]

--- a/src/TestModel/tests/TestModelPackageTests.cs
+++ b/src/TestModel/tests/TestModelPackageTests.cs
@@ -90,5 +90,25 @@ namespace TestCentric.Gui.Model
                     Assert.That(subpackage.Settings, Does.Not.ContainKey(skipKey));
             }
         }
+
+        [Test]
+        public void RunAsX86_GuiSettingFalse_DefaultsPackageSettingToFalse()
+        {
+            MockTestEngine testEngine = new MockTestEngine().WithSetting("Gui.Options." + EnginePackageSettings.RunAsX86, false);
+
+            TestModel model = new TestModel(testEngine);
+
+            Assert.That(model.PackageSettings[EnginePackageSettings.RunAsX86], Is.EqualTo(false));
+        }
+
+        [Test]
+        public void RunAsX86_GuiSettingTrue_DefaultsPackageSettingToTrue()
+        {
+            MockTestEngine testEngine = new MockTestEngine().WithSetting("Gui.Options." + EnginePackageSettings.RunAsX86, true);
+
+            TestModel model = new TestModel(testEngine);
+
+            Assert.That(model.PackageSettings[EnginePackageSettings.RunAsX86], Is.EqualTo(true));
+        }
     }
 }


### PR DESCRIPTION
Hopefully I got all the pieces/tests needed.  This implements feature #302.