### PR TITLE
Use NUnit 3.10

### DIFF
--- a/src/Common/testcentric.common/TestCentric.Common.csproj
+++ b/src/Common/testcentric.common/TestCentric.Common.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />

--- a/src/Common/testcentric.common/packages.config
+++ b/src/Common/testcentric.common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/src/Experimental/experimental-gui/Experimental.Gui.csproj
+++ b/src/Experimental/experimental-gui/Experimental.Gui.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/Experimental/experimental-gui/packages.config
+++ b/src/Experimental/experimental-gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/src/Experimental/tests/Experimental.Gui.Tests.csproj
+++ b/src/Experimental/tests/Experimental.Gui.Tests.csproj
@@ -41,22 +41,22 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit-agent.exe</HintPath>
     </Reference>
     <Reference Include="nunit-agent-x86, Version=3.10.0.0, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent-x86.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit-agent-x86.exe</HintPath>
     </Reference>
     <Reference Include="nunit.engine, Version=3.10.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit.engine.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit.engine.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/src/Experimental/tests/packages.config
+++ b/src/Experimental/tests/packages.config
@@ -3,6 +3,6 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.10.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
+++ b/src/TestCentric/testcentric.gui/TestCentric.Gui.csproj
@@ -95,7 +95,7 @@
       <Name>TestCentric.Gui.Model</Name>
     </ProjectReference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/TestCentric/testcentric.gui/packages.config
+++ b/src/TestCentric/testcentric.gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
+++ b/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
@@ -105,7 +105,7 @@
       <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/TestCentric/tests/packages.config
+++ b/src/TestCentric/tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net20" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/TestModel/model/packages.config
+++ b/src/TestModel/model/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -38,22 +38,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.4.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit-agent, Version=3.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit-agent.exe</HintPath>
     </Reference>
     <Reference Include="nunit-agent-x86, Version=3.10.0.0, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit-agent-x86.exe</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit-agent-x86.exe</HintPath>
     </Reference>
     <Reference Include="nunit.engine, Version=3.10.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit.engine.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit.engine.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/TestModel/tests/packages.config
+++ b/src/TestModel/tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.10.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net45" />
 </packages>

--- a/src/tests/test-utilities/packages.config
+++ b/src/tests/test-utilities/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
-  <package id="NUnit.Engine.Api" version="3.10.0-tc-00002" targetFramework="net45" />
+  <package id="NUnit.Engine.Api" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/src/tests/test-utilities/test-utilities.csproj
+++ b/src/tests/test-utilities/test-utilities.csproj
@@ -84,7 +84,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0-tc-00002\lib\net20\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.Engine.Api.3.10.0\lib\net20\nunit.engine.api.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>


### PR DESCRIPTION
The NUnit 3.10 release now has all the changes that was in our private build (3.10.0-tc-00002)

There are other fixes we need, but I'm doing this first in order to get caught up with NUnit.