### PR TITLE
Display elapsed time more clearly in status bars

### DIFF
--- a/src/Experimental/experimental-gui/Views/StatusBarView.cs
+++ b/src/Experimental/experimental-gui/Views/StatusBarView.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -83,7 +83,7 @@ namespace TestCentric.Gui.Views
                 DisplayFailed();
                 DisplayWarnings();
                 DisplayInconclusive();
-                DisplayTime(0.0);
+                DisplayDuration(0.0);
             });
         }
 
@@ -92,7 +92,7 @@ namespace TestCentric.Gui.Views
             InvokeIfRequired(() =>
             {
                 StatusLabel.Text = "Completed";
-                DisplayTime(elapsedTime);
+                DisplayDuration(elapsedTime);
             });
         }
 
@@ -220,9 +220,9 @@ namespace TestCentric.Gui.Views
             inconclusivePanel.Visible = true;
         }
 
-        private void DisplayTime(double time)
+        private void DisplayDuration(double duration)
         {
-            timePanel.Text = "Time : " + time.ToString("F3");
+            timePanel.Text = $"Duration : {duration.ToString("F3")}s";
             timePanel.Visible = true;
         }
 

--- a/src/TestCentric/testcentric.gui/Presenters/StatusBarPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/StatusBarPresenter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -91,13 +91,13 @@ namespace TestCentric.Gui.Presenters
                 _view.DisplayFailed(0);
                 _view.DisplayWarnings(0);
                 _view.DisplayInconclusive(0);
-                _view.DisplayTime(0.0);
+                _view.DisplayDuration(0.0);
             };
 
             _model.Events.RunFinished += (ea) =>
             {
                 _view.DisplayText("Completed");
-                _view.DisplayTime(ea.Result.Duration);
+                _view.DisplayDuration(ea.Result.Duration);
             };
 
             _model.Events.TestStarting += (ea) =>

--- a/src/TestCentric/testcentric.gui/Views/IStatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IStatusBarView.cs
@@ -34,6 +34,6 @@ namespace TestCentric.Gui.Views
         void DisplayFailed(int count);
         void DisplayWarnings(int count);
         void DisplayInconclusive(int count);
-        void DisplayTime(double time);
+        void DisplayDuration(double time);
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
@@ -100,11 +100,11 @@ namespace TestCentric.Gui.Views
             });
         }
 
-        public void DisplayTime(double time)
+        public void DisplayDuration(double duration)
         {
             InvokeIfRequired(() =>
             {
-                timePanel.Text = "Time : " + time.ToString("F3");
+                timePanel.Text = $"Duration : {duration.ToString("F3")}s";
                 timePanel.Visible = true;
             });
         }

--- a/src/TestCentric/tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/StatusBarPresenterTests.cs
@@ -75,7 +75,7 @@ namespace TestCentric.Gui.Presenters
             _view.Received().DisplayFailed(0);
             _view.Received().DisplayWarnings(0);
             _view.Received().DisplayInconclusive(0);
-            _view.Received().DisplayTime(0.0);
+            _view.Received().DisplayDuration(0.0);
         }
 
         [Test]
@@ -169,7 +169,7 @@ namespace TestCentric.Gui.Presenters
             FireRunFinishedEvent(result);
 
             _view.Received().DisplayText("Completed");
-            _view.Received().DisplayTime(1.234);
+            _view.Received().DisplayDuration(1.234);
         }
     }
 }


### PR DESCRIPTION
Fixes #226 

I fixed this to diesplay "Duration" rather than "Time" and use suffix "s" 

We can consider hour//minutes/seconds display if there is a further demand for it.