### PR TITLE
Disable Reload on Run Checkbox for now

### DIFF
--- a/src/Experimental/experimental-gui/Views/SettingsPages/AssemblyReloadSettingsPage.cs
+++ b/src/Experimental/experimental-gui/Views/SettingsPages/AssemblyReloadSettingsPage.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -52,7 +52,8 @@ namespace TestCentric.Gui.Views.SettingsPages
 
         private void reloadOnChangeCheckBox_CheckedChanged(object sender, System.EventArgs e)
         {
-            rerunOnChangeCheckBox.Enabled = reloadOnChangeCheckBox.Checked;
+            // TODO: Waiting for issue #233
+            //rerunOnChangeCheckBox.Enabled = reloadOnChangeCheckBox.Checked;
         }
 
         protected override void OnHelpRequested(HelpEventArgs hevent)

--- a/src/TestCentric/testcentric.gui/SettingsPages/AssemblyReloadSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AssemblyReloadSettingsPage.cs
@@ -177,7 +177,8 @@ namespace TestCentric.Gui.SettingsPages
 
         private void reloadOnChangeCheckBox_CheckedChanged(object sender, System.EventArgs e)
         {
-            rerunOnChangeCheckBox.Enabled = reloadOnChangeCheckBox.Checked;
+            // TODO: Waiting for issue #233
+            //rerunOnChangeCheckBox.Enabled = reloadOnChangeCheckBox.Checked;
         }
 
         protected override void OnHelpRequested(HelpEventArgs hevent)

--- a/testcentric-gui.sln
+++ b/testcentric-gui.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.ps1 = build.ps1
 		build.sh = build.sh
 		CHANGES.txt = CHANGES.txt
+		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.txt = LICENSE.txt
 		NOTICES.txt = NOTICES.txt
 		NuGet.config = NuGet.config


### PR DESCRIPTION
The checkbox on both GUIs will remain disabled until we resolve #233 and provide the capability they are meant to control.