### PR TITLE
Detect and report unhandled exception

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -185,14 +185,20 @@ namespace TestCentric.Gui.Presenters
                 //    //log.Warning("Unable to save result to {0}\n{1}", resultPath, ex.ToString());
                 //}
 
-                if (e.Result.Outcome.Status == TestStatus.Failed)
-                    _view.Activate();
+                //if (e.Result.Outcome.Status == TestStatus.Failed)
+                //    _view.Activate();
             };
 
             _settings.Changed += (s, e) =>
             {
                 if (e.SettingName == "Gui.Options.DisplayFormat")
                     InitializeDisplay();
+            };
+
+            _model.Events.UnhandledException += (UnhandledExceptionEventArgs e) =>
+            {
+                var display = new MessageDisplay("TestCentric - Internal Error");
+                display.Error($"{e.Message}\n\n{e.StackTrace}");
             };
 
             #endregion

--- a/src/TestCentric/tests/packages.config
+++ b/src/TestCentric/tests/packages.config
@@ -4,6 +4,7 @@
   <package id="NSubstitute" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net45" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net45" />

--- a/src/TestEngine/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -102,7 +102,6 @@ namespace NUnit.Engine
                 // For example, ResultService uses ExtensionService, so ExtensionService is added
                 // later.
                 Services.Add(new SettingsService(true));
-                Services.Add(new DriverService());
                 Services.Add(new RecentFilesService());
                 Services.Add(new TestFilterService());
 #if !NETSTANDARD1_6
@@ -114,6 +113,7 @@ namespace NUnit.Engine
                 Services.Add(new TestAgency());
 #endif
 #endif
+                Services.Add(new DriverService());
                 Services.Add(new ResultService());
                 Services.Add(new DefaultTestRunnerFactory());
             }

--- a/src/TestModel/model/ITestEvents.cs
+++ b/src/TestModel/model/ITestEvents.cs
@@ -32,6 +32,7 @@ namespace TestCentric.Gui.Model
     public delegate void TestResultEventHandler(TestResultEventArgs args);
     public delegate void TestItemEventHandler(TestItemEventArgs args);
     public delegate void TestOutputEventHandler(TestOutputEventArgs args);
+    public delegate void UnhandledExceptionEventHandler(UnhandledExceptionEventArgs args);
     public delegate void TestFilesLoadingEventHandler(TestFilesLoadingEventArgs args);
 
     /// <summary>
@@ -61,6 +62,7 @@ namespace TestCentric.Gui.Model
         event TestResultEventHandler TestFinished;
 
         event TestOutputEventHandler TestOutput;
+        event UnhandledExceptionEventHandler UnhandledException;
 
         // Event used to broadcast a change in the selected
         // item, so that all presenters may be notified.

--- a/src/TestModel/model/TestEventArgs.cs
+++ b/src/TestModel/model/TestEventArgs.cs
@@ -93,6 +93,18 @@ namespace TestCentric.Gui.Model
         public string Text { get; }
     }
 
+    public class UnhandledExceptionEventArgs : EventArgs
+    {
+        public UnhandledExceptionEventArgs(string message, string stackTrace)
+        {
+            Message = message;
+            StackTrace = stackTrace;
+        }
+
+        public string Message;
+        public string StackTrace;
+    }
+
     public class TestFilesLoadingEventArgs : EventArgs
     {
         public TestFilesLoadingEventArgs(IList<string> testFilesLoading)

--- a/src/TestModel/model/TestEventDispatcher.cs
+++ b/src/TestModel/model/TestEventDispatcher.cs
@@ -126,6 +126,8 @@ namespace TestCentric.Gui.Model
 
         public event TestOutputEventHandler TestOutput;
 
+        public event UnhandledExceptionEventHandler UnhandledException;
+
         // Test Selection Event
         public event TestItemEventHandler SelectedItemChanged;
 
@@ -185,6 +187,13 @@ namespace TestCentric.Gui.Model
                     string text = xmlNode.InnerText;
                     InvokeHandler(TestOutput, new TestOutputEventArgs(testName, stream, text));
                     break;
+
+                case "unhandled-exception":
+                    string message = xmlNode.GetAttribute("message");
+                    string stackTrace = xmlNode.GetAttribute("stacktrace");
+
+                    InvokeHandler(UnhandledException, new UnhandledExceptionEventArgs(message, stackTrace));
+                    break;
             }
         }
 
@@ -203,22 +212,11 @@ namespace TestCentric.Gui.Model
                 object target = handler.Target;
                 System.Windows.Forms.Control control
                     = target as System.Windows.Forms.Control;
-                try
-                {
-                    if (control != null && control.InvokeRequired)
+
+                if (control != null && control.InvokeRequired)
                         control.Invoke(handler, args);
                     else
                         handler.Method.Invoke(target, args);
-                }
-                catch (Exception ex)
-                {
-                    // TODO: Stop rethrowing this since it goes back to the
-                    // Test domain which may not know how to handle it!!!
-                    Console.WriteLine("Exception:");
-                    Console.WriteLine(ex);
-                    //throw new TestEventInvocationException( ex );
-                    //throw;
-                }
             }
         }
 

--- a/src/tests/mock-assembly-v2/MockAssembly.cs
+++ b/src/tests/mock-assembly-v2/MockAssembly.cs
@@ -1,0 +1,290 @@
+// ****************************************************************
+// Copyright 2002-2018, Charlie Poole
+// This is free software licensed under the NUnit license, a copy
+// of which should be included with this software. If not, you may
+// obtain a copy at https://github.com/nunit-legacy/nunitv2.
+// ****************************************************************
+using System;
+using NUnit.Framework;
+
+namespace NUnit.Tests
+{
+    namespace Assemblies
+    {
+        /// <summary>
+        /// Constant definitions for the mock-assembly dll.
+        /// </summary>
+        public class MockAssembly
+        {
+#if CLR_2_0 || CLR_4_0
+            public static int Classes = 9;
+#else
+            public static int Classes = 8;
+#endif
+            public static int NamespaceSuites = 6; // assembly, NUnit, Tests, Assemblies, Singletons, TestAssembly
+
+            public static int Tests = MockTestFixture.Tests 
+                        + Singletons.OneTestCase.Tests 
+                        + TestAssembly.MockTestFixture.Tests 
+                        + IgnoredFixture.Tests
+                        + ExplicitFixture.Tests
+                        + BadFixture.Tests
+                        + FixtureWithTestCases.Tests
+                        + ParameterizedFixture.Tests
+                        + GenericFixtureConstants.Tests;
+            
+            public static int Suites = MockTestFixture.Suites 
+                        + Singletons.OneTestCase.Suites
+                        + TestAssembly.MockTestFixture.Suites 
+                        + IgnoredFixture.Suites
+                        + ExplicitFixture.Suites
+                        + BadFixture.Suites
+                        + FixtureWithTestCases.Suites
+                        + ParameterizedFixture.Suites
+                        + GenericFixtureConstants.Suites
+                        + NamespaceSuites;
+            
+            public static readonly int Nodes = Tests + Suites;
+            
+            public static int ExplicitFixtures = 1;
+            public static int SuitesRun = Suites - ExplicitFixtures;
+
+            public static int Ignored = MockTestFixture.Ignored + IgnoredFixture.Tests;
+            public static int Explicit = MockTestFixture.Explicit + ExplicitFixture.Tests;
+            public static int NotRunnable = MockTestFixture.NotRunnable + BadFixture.Tests;
+            public static int NotRun = Ignored + Explicit + NotRunnable;
+            public static int TestsRun = Tests - NotRun;
+            public static int ResultCount = Tests - Explicit;
+
+            public static int Errors = MockTestFixture.Errors;
+            public static int Failures = MockTestFixture.Failures;
+
+            public static int Categories = MockTestFixture.Categories;
+        }
+
+        [TestFixture(Description="Fake Test Fixture")]
+        [Category("FixtureCategory")]
+        public class MockTestFixture
+        {
+            public static readonly int Tests = 11;
+            public static readonly int Suites = 1;
+
+            public static readonly int Ignored = 1;
+            public static readonly int Explicit = 1;
+            public static readonly int NotRunnable = 2;
+            public static readonly int NotRun = Ignored + Explicit + NotRunnable;
+            public static readonly int TestsRun = Tests - NotRun;
+            public static readonly int ResultCount = Tests - Explicit;
+
+            public static readonly int Failures = 1;
+            public static readonly int Errors = 1;
+
+            public static readonly int Categories = 5;
+            public static readonly int MockCategoryTests = 2;
+
+            [Test(Description="Mock Test #1")]
+            public void MockTest1()
+            {}
+
+            [Test]
+            [Category("MockCategory")]
+            [Property("Severity","Critical")]
+            [Description("This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description")]
+            public void MockTest2()
+            {}
+
+            [Test]
+            [Category("MockCategory")]
+            [Category("AnotherCategory")]
+            public void MockTest3()
+            { Assert.Pass("Succeeded!"); }
+
+            [Test]
+            protected static void MockTest5()
+            {}
+
+            [Test]
+            public void FailingTest()
+            {
+                Assert.Fail("Intentional failure");
+            }
+
+            [Test, Property("TargetMethod", "SomeClassName"), Property("Size", 5), /*Property("TargetType", typeof( System.Threading.Thread ))*/]
+            public void TestWithManyProperties()
+            {}
+
+            [Test]
+            [Ignore("ignoring this test method for now")]
+            [Category("Foo")]
+            public void MockTest4()
+            {}
+
+            [Test, Explicit]
+            [Category( "Special" )]
+            public void ExplicitlyRunTest()
+            {}
+
+            [Test]
+            public void NotRunnableTest( int a, int b)
+            {
+            }
+
+            [Test]
+            public void InconclusiveTest()
+            {
+                Assert.Inconclusive("No valid data");
+            }
+
+            [Test]
+            public void TestWithException()
+            {
+                MethodThrowsException();
+            }
+
+            private void MethodThrowsException()
+            {
+                throw new ApplicationException("Intentional Exception");
+            }
+        }
+    }
+
+    namespace Singletons
+    {
+        [TestFixture]
+        public class OneTestCase
+        {
+            public static readonly int Tests = 1;
+            public static readonly int Suites = 1;		
+
+            [Test]
+            public virtual void TestCase() 
+            {}
+        }
+    }
+
+    namespace TestAssembly
+    {
+        [TestFixture]
+        public class MockTestFixture
+        {
+            public static readonly int Tests = 1;
+            public static readonly int Suites = 1;
+
+            [Test]
+            public void MyTest()
+            {
+            }
+        }
+    }
+
+    [TestFixture, Ignore]
+    public class IgnoredFixture
+    {
+        public static readonly int Tests = 3;
+        public static readonly int Suites = 1;
+
+        [Test]
+        public void Test1() { }
+
+        [Test]
+        public void Test2() { }
+        
+        [Test]
+        public void Test3() { }
+    }
+
+    [TestFixture,Explicit]
+    public class ExplicitFixture
+    {
+        public static readonly int Tests = 2;
+        public static readonly int Suites = 1;
+        public static readonly int Nodes = Tests + Suites;
+
+        [Test]
+        public void Test1() { }
+
+        [Test]
+        public void Test2() { }
+    }
+
+    [TestFixture]
+    public class BadFixture
+    {
+        public static readonly int Tests = 1;
+        public static readonly int Suites = 1;
+
+        public BadFixture(int val) { }
+
+        [Test]
+        public void SomeTest() { }
+    }
+    
+    [TestFixture]
+    public class FixtureWithTestCases
+    {
+#if CLR_2_0 || CLR_4_0
+        public static readonly int Tests = 4;
+        public static readonly int Suites = 3;
+#else
+        public static readonly int Tests = 2;
+        public static readonly int Suites = 2;
+#endif
+        
+        [TestCase(2, 2, Result=4)]
+        [TestCase(9, 11, Result=20)]
+        public int MethodWithParameters(int x, int y)
+        {
+            return x+y;
+        }
+
+#if CLR_2_0 || CLR_4_0
+        [TestCase(2, 4)]
+        [TestCase(9.2, 11.7)]
+        public void GenericMethod<T>(T x, T y)
+        {
+        }
+#endif
+    }
+    
+    [TestFixture(5)]
+    [TestFixture(42)]
+    public class ParameterizedFixture
+    {
+        public static readonly int Tests = 4;
+        public static readonly int Suites = 3;
+
+        public ParameterizedFixture(int num) { }
+        
+        [Test]
+        public void Test1() { }
+        
+        [Test]
+        public void Test2() { }
+    }
+    
+    public class GenericFixtureConstants
+    {
+#if CLR_2_0 || CLR_4_0
+        public static readonly int Tests = 4;
+        public static readonly int Suites = 3;
+#else
+        public static readonly int Tests = 0;
+        public static readonly int Suites = 0;
+#endif
+    }
+
+#if CLR_2_0 || CLR_4_0
+    [TestFixture(5)]
+    [TestFixture(11.5)]
+    public class GenericFixture<T>
+    {
+        public GenericFixture(T num){ }
+        
+        [Test]
+        public void Test1() { }
+        
+        [Test]
+        public void Test2() { }
+    }
+#endif
+}

--- a/src/tests/mock-assembly-v2/mock-assembly-v2.csproj
+++ b/src/tests/mock-assembly-v2/mock-assembly-v2.csproj
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <ProjectType>Local</ProjectType>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{713E77FC-8CB1-46BC-93C8-33D1D302159C}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
+    <AssemblyName>mock-assembly</AssemblyName>
+    <DefaultClientScript>JScript</DefaultClientScript>
+    <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
+    <DefaultTargetSchema>IE50</DefaultTargetSchema>
+    <DelaySign>false</DelaySign>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\..\bin\Debug\v2-tests\</OutputPath>
+    <BaseAddress>285212672</BaseAddress>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>TRACE;DEBUG;CLR_2_0,NET_2_0,CS_3_0</DefineConstants>
+    <DocumentationFile>
+    </DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
+    <FileAlignment>4096</FileAlignment>
+    <Optimize>false</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <WarningLevel>4</WarningLevel>
+    <DebugType>full</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\..\bin\Release\v2-tests\</OutputPath>
+    <BaseAddress>285212672</BaseAddress>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>TRACE;CLR_2_0,NET_2_0,CS_3_0</DefineConstants>
+    <DocumentationFile>
+    </DocumentationFile>
+    <FileAlignment>4096</FileAlignment>
+    <Optimize>true</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <WarningLevel>4</WarningLevel>
+    <DebugType>none</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>3</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System">
+      <Name>System</Name>
+    </Reference>
+    <Reference Include="System.Data">
+      <Name>System.Data</Name>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Name>System.XML</Name>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="MockAssembly.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/src/tests/mock-assembly-v2/packages.config
+++ b/src/tests/mock-assembly-v2/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net20" />
+</packages>

--- a/testcentric-gui.sln
+++ b/testcentric-gui.sln
@@ -81,6 +81,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-agent", "src\TestEngi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-agent-x86", "src\TestEngine\src\NUnitEngine\nunit-agent\nunit-agent-x86.csproj", "{A1BA8C1F-27CD-4078-B8F5-28496C51C7A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mock-assembly-v2", "src\tests\mock-assembly-v2\mock-assembly-v2.csproj", "{713E77FC-8CB1-46BC-93C8-33D1D302159C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,10 @@ Global
 		{A1BA8C1F-27CD-4078-B8F5-28496C51C7A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1BA8C1F-27CD-4078-B8F5-28496C51C7A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1BA8C1F-27CD-4078-B8F5-28496C51C7A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{713E77FC-8CB1-46BC-93C8-33D1D302159C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{713E77FC-8CB1-46BC-93C8-33D1D302159C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{713E77FC-8CB1-46BC-93C8-33D1D302159C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{713E77FC-8CB1-46BC-93C8-33D1D302159C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -183,6 +189,7 @@ Global
 		{AC7ED833-5C39-4AB6-8054-CDFDD82DDFBF} = {EA14AF63-0F5D-4938-9C87-6EC67A961DB3}
 		{FC7B82E4-D2B6-464C-8812-D8630949E14C} = {EA14AF63-0F5D-4938-9C87-6EC67A961DB3}
 		{A1BA8C1F-27CD-4078-B8F5-28496C51C7A3} = {EA14AF63-0F5D-4938-9C87-6EC67A961DB3}
+		{713E77FC-8CB1-46BC-93C8-33D1D302159C} = {0F939442-8450-41CF-8BB7-FAA00866F4E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CDFF439B-8888-4133-8734-86F4F899BC40}


### PR DESCRIPTION
This is a partial fix for #340. It reports the error by showing a message for the exception, indicating that an id filter may not be used with NUnit V2.