### PR TITLE
Add force parameter to TestModel.StopRun

### DIFF
--- a/src/Experimental/experimental-gui/Presenters/TreeViewPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/TreeViewPresenter.cs
@@ -142,7 +142,7 @@ namespace TestCentric.Gui.Presenters
             _view.RunAllCommand.Execute += () => RunAllTests();
             _view.RunSelectedCommand.Execute += () => RunTests(_selectedTestItem);
             _view.RunFailedCommand.Execute += () => RunAllTests(); // RunFailed NYI
-            _view.StopRunCommand.Execute += () => _model.CancelTestRun();
+            _view.StopRunCommand.Execute += () => _model.CancelTestRun(true);
 
             // Debug button and dropdowns
             _view.DebugButton.Execute += () =>

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -27,6 +27,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using NUnit.Engine;
 
@@ -302,7 +303,7 @@ namespace TestCentric.Gui.Presenters
                             return;
                         }
 
-                        _model.CancelTestRun();
+                        _model.CancelTestRun(true);
                     }
 
                     if (CloseProject() == DialogResult.Cancel)
@@ -658,7 +659,7 @@ namespace TestCentric.Gui.Presenters
                     "Do you want to cancel the running test?");
 
                 if (dialogResult == DialogResult.Yes)
-                    _model.CancelTestRun();
+                    _model.CancelTestRun(true);
             }
         }
 

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -116,7 +116,7 @@ namespace TestCentric.Gui.Model
         void DebugTests(ITestItem testItem);
 
         // Cancel the running test
-        void CancelTestRun();
+        void CancelTestRun(bool force);
 
         // Save the results of the last run in the specified format
         void SaveResults(string fileName, string format="nunit3");

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -307,9 +307,9 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        public void CancelTestRun()
+        public void CancelTestRun(bool force)
         {
-            Runner.StopRun(false);
+            Runner.StopRun(force);
         }
 
         public void SaveResults(string filePath, string format = "nunit3")


### PR DESCRIPTION
I have changed this to do a force stop when the Stop button is pressed. The thing is, it requires a fix to the NUnit framework in order to work correctly. I have submitted a PR with the fix.

So the question is whether to merge this or to try to make it work even with the existing build of the framework. @TestCentric/gui-team What do you think?