### PR TITLE
Handle non-terminating Cancel Run in engine

### DIFF
--- a/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Xml;
@@ -14,43 +37,80 @@ namespace NUnit.Engine.Runners
     /// </summary>
     internal class WorkItemTracker : ITestEventListener
     {
-        public List<XmlNode> ItemsInProcess { get; } = new List<XmlNode>();
-
-        public ManualResetEvent AllItemsComplete = new ManualResetEvent(false);
+        private List<XmlNode> _itemsInProcess = new List<XmlNode>();
+        private ManualResetEvent _allItemsComplete = new ManualResetEvent(false);
+        private object _trackerLock = new object();
         
         public void Clear()
         {
-            ItemsInProcess.Clear();
-            AllItemsComplete.Reset();
+            lock (_trackerLock)
+            {
+                _itemsInProcess.Clear();
+                _allItemsComplete.Reset();
+            }
+        }
+
+        public bool WaitForCompletion(int millisecondsTimeout)
+        {
+            return _allItemsComplete.WaitOne(millisecondsTimeout);
+        }
+
+        public void IssuePendingNotifications(ITestEventListener listener)
+        {
+            lock (_trackerLock)
+            {
+                int count = _itemsInProcess.Count;
+
+                // Signal completion of all pending suites, in reverse order
+                while (count > 0)
+                    listener.OnTestEvent(CreateTestSuiteElement(_itemsInProcess[--count]).OuterXml);
+            }
+        }
+
+        private static XmlNode CreateTestSuiteElement(XmlNode startSuiteElement)
+        {
+            XmlNode testSuiteElement = XmlHelper.CreateTopLevelElement("test-suite");
+            testSuiteElement.AddAttribute("type", startSuiteElement.GetAttribute("type"));
+            testSuiteElement.AddAttribute("id", startSuiteElement.GetAttribute("id"));
+            testSuiteElement.AddAttribute("name", startSuiteElement.GetAttribute("name"));
+            testSuiteElement.AddAttribute("fullame", startSuiteElement.GetAttribute("fullname"));
+            testSuiteElement.AddAttribute("result", "Failed");
+            testSuiteElement.AddAttribute("label", "Cancelled");
+            XmlNode failure = testSuiteElement.AddElement("failure");
+            XmlNode message = failure.AddElementWithCDataSection("message", "Test run cancelled by user");
+            return testSuiteElement;
         }
 
         void ITestEventListener.OnTestEvent(string report)
         {
             XmlNode xmlNode = XmlHelper.CreateXmlNode(report);
 
-            switch (xmlNode.Name)
+            lock (_trackerLock)
             {
-                case "start-suite":
-                    ItemsInProcess.Add(xmlNode);
-                    break;
+                switch (xmlNode.Name)
+                {
+                    case "start-suite":
+                        _itemsInProcess.Add(xmlNode);
+                        break;
 
-                case "test-suite":
-                    string id = xmlNode.GetAttribute("id");
-                    RemoveItem(id);
+                    case "test-suite":
+                        string id = xmlNode.GetAttribute("id");
+                        RemoveItem(id);
 
-                    if (ItemsInProcess.Count == 0)
-                        AllItemsComplete.Set();
-                    break;
+                        if (_itemsInProcess.Count == 0)
+                            _allItemsComplete.Set();
+                        break;
+                }
             }
         }
 
         private void RemoveItem(string id)
         {
-            foreach (XmlNode item in ItemsInProcess)
+            foreach (XmlNode item in _itemsInProcess)
             {
                 if (item.GetAttribute("id") == id)
                 {
-                    ItemsInProcess.Remove(item);
+                    _itemsInProcess.Remove(item);
                     return;
                 }
             }

--- a/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Xml;
+
+namespace NUnit.Engine.Runners
+{
+    /// <summary>
+    /// WorkItemTracker examines test events and keeps track of those
+    /// that have started but not yet finished. It implements ITestEventListener
+    /// in order to capture events and provides a property to return a list of 
+    /// all item ids that have started but not yet finished and a Clear() method
+    /// to clear the contents of that list.
+    /// </summary>
+    internal class WorkItemTracker : ITestEventListener
+    {
+        public List<XmlNode> ItemsInProcess { get; } = new List<XmlNode>();
+
+        public ManualResetEvent AllItemsComplete = new ManualResetEvent(false);
+        
+        public void Clear()
+        {
+            ItemsInProcess.Clear();
+            AllItemsComplete.Reset();
+        }
+
+        void ITestEventListener.OnTestEvent(string report)
+        {
+            XmlNode xmlNode = XmlHelper.CreateXmlNode(report);
+
+            switch (xmlNode.Name)
+            {
+                case "start-suite":
+                    ItemsInProcess.Add(xmlNode);
+                    break;
+
+                case "test-suite":
+                    string id = xmlNode.GetAttribute("id");
+                    RemoveItem(id);
+
+                    if (ItemsInProcess.Count == 0)
+                        AllItemsComplete.Set();
+                    break;
+            }
+        }
+
+        private void RemoveItem(string id)
+        {
+            foreach (XmlNode item in ItemsInProcess)
+            {
+                if (item.GetAttribute("id") == id)
+                {
+                    ItemsInProcess.Remove(item);
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #337 by handling the case where the version of the NUnit 3 framework in use has not been patched to handle a forced StopRun correctly. It delays five seconds and then, if all outstanding suites have not signaled termination, if does it for them and ends the run. This eliminates the apparent hang in the GUI.

Note that the change has no impact on actually cancelling the run. The error we are compensating for seems to have to do with __notifying__ the caller about the cancellation, which appears to happen correctly.