### PR TITLE
Stop using ProcessModel and DomainUsage saved settings

### DIFF
--- a/src/TestModel/model/Settings/EngineSettings.cs
+++ b/src/TestModel/model/Settings/EngineSettings.cs
@@ -41,18 +41,6 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(ShadowCopyFiles), value); }
         }
 
-        public string ProcessModel
-        {
-            get { return GetSetting(nameof(ProcessModel), "Default"); }
-            set { SaveSetting(nameof(ProcessModel), value); }
-        }
-
-        public string DomainUsage
-        {
-            get { return GetSetting(nameof(DomainUsage), "Default"); }
-            set { SaveSetting(nameof(DomainUsage), value); }
-        }
-
         public int Agents
         {
             get { return GetSetting(nameof(Agents), 0); }

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -419,14 +419,9 @@ namespace TestCentric.Gui.Model
             // We use AddSetting rather than just setting the value because
             // it propagates the setting to all subprojects.
 
-            if (engineSettings.ProcessModel != "Default")
-                package.AddSetting(EnginePackageSettings.ProcessModel, engineSettings.ProcessModel);
+            //WIP: No longer use the process  or domain settings from earlier versions
 
-            // Don't set DomainUsage for Multiple to avoid engine error
-            if (engineSettings.ProcessModel != "Multiple")
-                package.AddSetting(EnginePackageSettings.DomainUsage, engineSettings.DomainUsage);
-            // Don't bother checking Agents unless we are running multiple processes
-            else if (engineSettings.Agents > 0)
+            if (engineSettings.Agents > 0)
                 package.AddSetting(EnginePackageSettings.MaxAgents, engineSettings.Agents);
 
             if (engineSettings.SetPrincipalPolicy)

--- a/src/TestModel/tests/SettingsTests.cs
+++ b/src/TestModel/tests/SettingsTests.cs
@@ -90,8 +90,6 @@ namespace TestCentric.Gui.Model.Settings
         public static TestCaseData[] TestCases = new TestCaseData[]
         {
             new TestCaseData("ShadowCopyFiles", true, false),
-            new TestCaseData("ProcessModel", "Default", "InProcess"),
-            new TestCaseData("DomainUsage", "Default", "Single"),
             new TestCaseData("Agents", 0, 8),
             new TestCaseData("ReloadOnChange", true, false),
             new TestCaseData("RerunOnChange", false, true),

--- a/src/TestModel/tests/TestModelAssemblyTests.cs
+++ b/src/TestModel/tests/TestModelAssemblyTests.cs
@@ -41,7 +41,6 @@ namespace TestCentric.Gui.Model
             Assert.NotNull(engine, "Unable to create engine instance for testing");
 
             _model = new TestModel(engine);
-            _model.Services.UserSettings.Engine.ProcessModel = "Single";
 
             _model.LoadTests(new[] { Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY) });
         }


### PR DESCRIPTION
Fixes #358 

This eliminates the saved settings `EngineSettings.ProcessModel` and `EngineSettings.DomainUsage` entirely. For each of them the only default value is now "Default".

This is necessary because projects (e.g. nunit format projects) can contain values for these settings and we don't want to accidentally override the project settings with a global setting.