### PR TITLE
Add command-line options for settings, which we don't save

### DIFF
--- a/src/Common/components/Elements/CheckedMenuGroup.cs
+++ b/src/Common/components/Elements/CheckedMenuGroup.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining

--- a/src/Experimental/experimental-gui/AppEntry.cs
+++ b/src/Experimental/experimental-gui/AppEntry.cs
@@ -85,10 +85,20 @@ namespace TestCentric.Gui
             }
 
             var testEngine = TestEngineActivator.CreateInstance(true);
-            if (options.InternalTraceLevel != null)
-                testEngine.InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel);
+            var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel ?? "Off");
+            testEngine.InternalTraceLevel = traceLevel;
 
             var model = new TestModel(testEngine);
+            model.PackageSettings.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
+
+            if (options.ProcessModel != null)
+                model.PackageSettings.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
+            if (options.DomainUsage != null)
+                model.PackageSettings.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
+            if (options.MaxAgents >= 0)
+                model.PackageSettings.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
+            if (options.RunAsX86)
+                model.PackageSettings.Add(EnginePackageSettings.RunAsX86, true);
 
             var form = new MainForm();
 

--- a/src/Experimental/experimental-gui/CommandLineOptions.cs
+++ b/src/Experimental/experimental-gui/CommandLineOptions.cs
@@ -29,10 +29,9 @@ using Mono.Options;
 namespace TestCentric.Gui
 {
     /// <summary>
-    /// GuiOptions encapsulates the option settingsServiceServiceService for
-    /// the nunit-console program. It inherits from the Mono
-    /// Options OptionSet class and provides a central location
-    /// for defining and parsing options.
+    /// CommandLineOptions encapsulates the option settings for TestCentric.
+    /// It inherits from the Mono.Options OptionSet class and provides a 
+    /// central location for defining and parsing options.
     /// </summary>
     public class CommandLineOptions : OptionSet
     {
@@ -43,7 +42,7 @@ namespace TestCentric.Gui
         public CommandLineOptions(params string[] args)
         {
             this.Add("config=", "Project {CONFIG} to load (e.g.: Debug).",
-                v => ActiveConfig = RequiredValue(v, "--config"));
+                v => ActiveConfig = v);
 
             this.Add("noload", "Suppress loading of most recent project.",
                 v => NoLoad = v != null);
@@ -81,11 +80,14 @@ namespace TestCentric.Gui
             //this.Add("runselected", "Automatically run last selected tests.",
             //    v => RunSelectedTests = v != null);
 
-            // Output GuiElement
             this.Add("trace=", "Set internal trace {LEVEL}.",
-                v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
+                v =>
+                {
+                    if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
+                        InternalTraceLevel = v;
+                });
 
-            this.Add("help|h", "Display this message and exit.",
+            this.Add("help|h", "Display thehelp message and exit.",
                 v => ShowHelp = v != null);
 
             // Default
@@ -124,7 +126,6 @@ namespace TestCentric.Gui
         public string DomainUsage { get; private set; }
         public bool RunAsX86 { get; private set; }
         public int MaxAgents { get; private set; }
-        //public InternalTraceLevel InternalTraceLevel { get; private set; }
         public string InternalTraceLevel { get; private set; }
 
         // Error Processing
@@ -201,57 +202,6 @@ namespace TestCentric.Gui
 
             return val;
         }
-
-        private int RequiredInt(string val, string option)
-        {
-            // We have to return something even though the val will 
-            // be ignored if an error is reported. The -1 val seems
-            // like a safe bet in case it isn't ignored due to a bug.
-            int result = -1;
-
-            if (val == null || val == string.Empty)
-                ErrorMessages.Add("Missing required value for option '" + option + "'.");
-            else
-            {
-                int r;
-                if (int.TryParse(val, out r))
-                    result = r;
-                else
-                    ErrorMessages.Add("An int value was expected for option '{0}' but a value of '{1}' was used");
-            }
-
-            return result;
-        }
-
-        //private void RequiredIntError(string option)
-        //{
-        //    ErrorMessages.Insert("An int val is required for option '" + option + "'.");
-        //}
-
-        //private void ProcessIntOption(string v, ref int field)
-        //{
-        //    if (!int.TryParse(v, out field))
-        //        ErrorMessages.Insert("Invalid argument val: " + v);
-        //}
-
-        //private void ProcessEnumOption<T>(string v, ref T field)
-        //{
-        //    if (Enum.IsDefined(typeof(T), v))
-        //        field = (T)Enum.Parse(typeof(T), v);
-        //    else
-        //        ErrorMessages.Insert("Invalid argument val: " + v);
-        //}
-
-        //private object ParseEnumOption(Type enumType, string val)
-        //{
-        //    foreach (string name in Enum.GetNames(enumType))
-        //        if (val.ToLower() == name.ToLower())
-        //            return Enum.Parse(enumType, val);
-
-        //    this.ErrorMessages.Insert(val);
-
-        //    return null;
-        //}
 
         #endregion
     }

--- a/src/Experimental/experimental-gui/CommandLineOptions.cs
+++ b/src/Experimental/experimental-gui/CommandLineOptions.cs
@@ -42,28 +42,6 @@ namespace TestCentric.Gui
 
         public CommandLineOptions(params string[] args)
         {
-            // NOTE: The order in which patterns are added 
-            // determines the display order for the help.
-
-            // Old Options no longer supported:
-            //   test
-            //   console
-            //   include
-            //   exclude
-
-            // Old Options to continue supporting:
-            //   lang
-            //   cleanup
-            //   help
-
-            // Options to be added:
-            //   test
-            //   trace
-
-            // Select Tests
-            //this.Insert("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
-            //    v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));
-
             this.Add("config=", "Project {CONFIG} to load (e.g.: Debug).",
                 v => ActiveConfig = RequiredValue(v, "--config"));
 
@@ -72,6 +50,33 @@ namespace TestCentric.Gui
 
             this.Add("run", "Automatically run the loaded project.",
                 v => RunAllTests = v != null);
+
+            this.Add("process=", "Select the process model for running the tests.",
+                v =>
+                {
+                    if (CheckRequiredValue(v, "--process", "Single", "Separate", "Multiple"))
+                        ProcessModel = v;
+                });
+
+            this.Add("x86", "Run the tests as X86",
+                v => RunAsX86 = v != null);
+
+            this.Add("agents=", "Specify max number of agents",
+                v =>
+                {
+                    if (CheckRequiredInt(v, "--agents", out int val))
+                        MaxAgents = val;
+                });
+
+            this.Add("inprocess", "Run the tests in process.",
+                v => ProcessModel = "Single");
+
+            this.Add("domain=", "Define how AppDomains are used in running the tests.",
+                v =>
+                {
+                    if (CheckRequiredValue(v, "--domain", "Single", "Separate", "Multiple"))
+                        DomainUsage = v;
+                });
 
             //this.Add("runselected", "Automatically run last selected tests.",
             //    v => RunSelectedTests = v != null);
@@ -105,26 +110,21 @@ namespace TestCentric.Gui
         public bool ShowHelp { get; private set; }
         public bool NoLoad { get; private set; }
         public bool RunAllTests { get; private set; }
-        //public bool RunSelectedTests { get; private set; }
 
         // Select tests
 
         private List<string> inputFiles = new List<string>();
         public IList<string> InputFiles { get { return inputFiles; } }
 
-        //private List<string> testList = new List<string>();
-        //public IList<string> TestList { get { return testList; } }
-
         public string ActiveConfig { get; private set; }
 
-        // Where to Run Tests
+        // How to Run Tests
 
-        //public string ProcessModel { get; private set; }
-
-        //public string DomainUsage { get; private set; }
-
-        // Output GuiElement
-
+        public string ProcessModel { get; private set; }
+        public string DomainUsage { get; private set; }
+        public bool RunAsX86 { get; private set; }
+        public int MaxAgents { get; private set; }
+        //public InternalTraceLevel InternalTraceLevel { get; private set; }
         public string InternalTraceLevel { get; private set; }
 
         // Error Processing
@@ -151,6 +151,33 @@ namespace TestCentric.Gui
         #endregion
 
         #region Helper Methods
+
+        private bool CheckRequiredValue(string val, string option, params string[] validValues)
+        {
+            if (validValues == null || validValues.Length == 0)
+                return true;
+
+            foreach (string valid in validValues)
+                if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
+                    return true;
+
+            ErrorMessages.Add(string.Format("The value '{0}' is not valid for option '{1}'.", val, option));
+            return false;
+        }
+
+        private bool CheckRequiredInt(string val, string option, out int result)
+        {
+            // We have to return something even though the val will 
+            // be ignored if an error is reported. The -1 val seems
+            // like a safe bet in case it isn't ignored due to a bug.
+            result = -1;
+
+            if (int.TryParse(val, out result))
+                return true;
+
+            ErrorMessages.Add("An int value was expected for option '{0}' but a value of '{1}' was used");
+            return false;
+        }
 
         private string RequiredValue(string val, string option, params string[] validValues)
         {

--- a/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
@@ -192,10 +192,18 @@ namespace TestCentric.Gui.Presenters
             // Set the font to use
             _view.Font = _settings.Gui.MainForm.Font;
 
+            var settings = _model.PackageSettings;
             if (_options.InternalTraceLevel != null)
-                _model.PackageSettings.Add(EnginePackageSettings.InternalTraceLevel, _options.InternalTraceLevel);
+                settings.Add(EnginePackageSettings.InternalTraceLevel, _options.InternalTraceLevel);
 
-            //_model.OnStartup();
+            if (_options.ProcessModel != null)
+                _view.ProcessModel.SelectedItem = _options.ProcessModel;
+            if (_options.DomainUsage != null)
+                _view.DomainUsage.SelectedItem = _options.DomainUsage;
+            if (_options.MaxAgents >= 0)
+                _model.Services.UserSettings.Engine.Agents = _options.MaxAgents;
+            _view.RunAsX86.Checked = _options.RunAsX86;
+
             if (_options.InputFiles.Count > 0)
             {
                 _model.LoadTests(_options.InputFiles);

--- a/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
@@ -34,7 +34,6 @@ namespace TestCentric.Gui.Presenters
     using Settings;
     using Views;
     using Views.AddinPages;
-    using Elements;
 
     public class MainPresenter : System.IDisposable
     {

--- a/src/Experimental/experimental-gui/Views/MainForm.Designer.cs
+++ b/src/Experimental/experimental-gui/Views/MainForm.Designer.cs
@@ -52,7 +52,7 @@ namespace TestCentric.Gui.Views
             this.processModelToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.defaultProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.inProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.singleProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.separateProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.multipleProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.loadAsX86ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -309,7 +309,7 @@ namespace TestCentric.Gui.Views
             this.processModelToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.defaultProcessToolStripMenuItem,
             this.inProcessToolStripMenuItem,
-            this.singleProcessToolStripMenuItem,
+            this.separateProcessToolStripMenuItem,
             this.multipleProcessToolStripMenuItem,
             this.toolStripSeparator2,
             this.loadAsX86ToolStripMenuItem});
@@ -333,13 +333,13 @@ namespace TestCentric.Gui.Views
             this.inProcessToolStripMenuItem.Text = "InProcess";
             this.inProcessToolStripMenuItem.ToolTipText = "Test assemblies are loaded directly in the NUnit process.";
             // 
-            // singleProcessToolStripMenuItem
+            // separateProcessToolStripMenuItem
             // 
-            this.singleProcessToolStripMenuItem.Name = "singleProcessToolStripMenuItem";
-            this.singleProcessToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
-            this.singleProcessToolStripMenuItem.Tag = "Single";
-            this.singleProcessToolStripMenuItem.Text = "Single";
-            this.singleProcessToolStripMenuItem.ToolTipText = "All test assemblies are loaded in the same process, separate from the NUnit proce" +
+            this.separateProcessToolStripMenuItem.Name = "separateProcessToolStripMenuItem";
+            this.separateProcessToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
+            this.separateProcessToolStripMenuItem.Tag = "Separate";
+            this.separateProcessToolStripMenuItem.Text = "Separate";
+            this.separateProcessToolStripMenuItem.ToolTipText = "All test assemblies are loaded in the same process, separate from the NUnit proce" +
     "ss.";
             // 
             // multipleProcessToolStripMenuItem
@@ -933,7 +933,7 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.ToolStripMenuItem processModelToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem defaultProcessToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem inProcessToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem singleProcessToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem separateProcessToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem multipleProcessToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem loadAsX86ToolStripMenuItem;

--- a/src/Experimental/experimental-gui/Views/MainForm.cs
+++ b/src/Experimental/experimental-gui/Views/MainForm.cs
@@ -55,7 +55,7 @@ namespace TestCentric.Gui.Views
             SelectRuntimeMenu = new ToolStripMenuElement(selectRuntimeToolStripMenuItem);
             SelectedRuntime = new CheckedToolStripMenuGroup(selectRuntimeToolStripMenuItem);
             ProcessModel = new CheckedToolStripMenuGroup("processModel",
-                defaultProcessToolStripMenuItem, inProcessToolStripMenuItem, singleProcessToolStripMenuItem, multipleProcessToolStripMenuItem);
+                defaultProcessToolStripMenuItem, inProcessToolStripMenuItem, separateProcessToolStripMenuItem, multipleProcessToolStripMenuItem);
             DomainUsage = new CheckedToolStripMenuGroup("domainUsage",
                 defaultDomainToolStripMenuItem, singleDomainToolStripMenuItem, multipleDomainToolStripMenuItem);
             RunAsX86 = new ToolStripMenuElement(loadAsX86ToolStripMenuItem);

--- a/src/Experimental/tests/CommandLineTests.cs
+++ b/src/Experimental/tests/CommandLineTests.cs
@@ -93,6 +93,7 @@ namespace TestCentric.Gui.Tests
             Assert.That(property.GetValue(options, null), Is.EqualTo(expected));
         }
 
+        [TestCase("--config")]
         [TestCase("--process")]
         [TestCase("--agents")]
         [TestCase("--domain")]

--- a/src/Experimental/tests/CommandLineTests.cs
+++ b/src/Experimental/tests/CommandLineTests.cs
@@ -1,0 +1,130 @@
+// ***********************************************************************
+// Copyright (c) 2018-2019 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Tests
+{
+    [TestFixture]
+    public class CommandLineTests
+    {
+        [TestCase]
+        [TestCase("tests.dll")]
+        [TestCase("one.dll", "two.dll", "three.dll")]
+        public void InputFiles(params string[] files)
+        {
+            var options = new CommandLineOptions(files);
+
+            Assert.That(options.InputFiles.Count, Is.EqualTo(files.Length));
+            for (int i = 0; i < files.Length; i++)
+                Assert.That(options.InputFiles[i], Is.EqualTo(files[i]));
+
+            Assert.True(options.Validate());
+        }
+
+        [TestCase("NoLoad", false)]
+        [TestCase("RunAllTests", false)]
+        [TestCase("RunAsX86", false)]
+        [TestCase("ShowHelp", false)]
+        [TestCase("ProcessModel", null)]
+        [TestCase("DomainUsage", null)]
+        [TestCase("InternalTraceLevel", null)]
+        public void DefaultOptionValues(string propertyName, object val)
+        {
+            var property = GetPropertyInfo(propertyName);
+            var options = new CommandLineOptions();
+
+            Assert.That(property.GetValue(options, null), Is.EqualTo(val));
+        }
+
+        [TestCase("NoLoad", "--noload", true)]
+        [TestCase("RunAllTests", "--run", true)]
+        [TestCase("ProcessModel", "--process:Single")]
+        [TestCase("ProcessModel", "--process:Separate")]
+        [TestCase("ProcessModel", "--process:Multiple")]
+        [TestCase("ProcessModel", "--inprocess", "Single")]
+        [TestCase("DomainUsage", "--domain:Single")]
+        [TestCase("DomainUsage", "--domain:Separate")]
+        [TestCase("DomainUsage", "--domain:Multiple")]
+        [TestCase("RunAsX86", "--x86", true)]
+        [TestCase("MaxAgents", "--agents:8", 8)]
+        [TestCase("InternalTraceLevel", "--trace:Off")]
+        [TestCase("InternalTraceLevel", "--trace:Error")]
+        [TestCase("InternalTraceLevel", "--trace:Warning")]
+        [TestCase("InternalTraceLevel", "--trace:Info")]
+        [TestCase("InternalTraceLevel", "--trace:Verbose")]
+        [TestCase("InternalTraceLevel", "--trace:Debug")]
+        [TestCase("ShowHelp", "--help", true)]
+        [TestCase("ShowHelp", "-h", true)]
+        public void ValidOptionsAreRecognized(string propertyName, string option, object expected = null)
+        {
+            var property = GetPropertyInfo(propertyName);
+            var options = new CommandLineOptions(option);
+
+            if (expected == null)
+            {
+                var index = option.IndexOf(':');
+                expected = option.Substring(index + 1);
+            }
+
+            Assert.That(options.Validate(), Is.True, $"Should be valid: {option}");
+            Assert.That(property.GetValue(options, null), Is.EqualTo(expected));
+        }
+
+        [TestCase("--process")]
+        [TestCase("--agents")]
+        [TestCase("--domain")]
+        [TestCase("--trace")]
+        public void InvalidOptionsAreDetectedByMonoOptions(string option)
+        {
+            // We would prefer to handle all errors ourselves so
+            // this will eventually change. The test documents
+            // the current behavior.
+            Assert.Throws<Mono.Options.OptionException>(
+                () => new CommandLineOptions(option));
+        }
+
+        [TestCase("--assembly:nunit.tests.dll")]
+        [TestCase("--garbage")]
+        [TestCase("--process:Unknown")]
+        [TestCase("--agents:XYZ")]
+        [TestCase("--domain:Junk")]
+        [TestCase("--trace:Something")]
+        public void InvalidOptionsAreDetected(string option)
+        {
+            var options = new CommandLineOptions(option);
+            Assert.IsFalse(options.Validate());
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        private static PropertyInfo GetPropertyInfo(string propertyName)
+        {
+            PropertyInfo property = typeof(CommandLineOptions).GetProperty(propertyName);
+            Assert.IsNotNull(property, "The property '{0}' is not defined", propertyName);
+            return property;
+        }
+    }
+}
+

--- a/src/Experimental/tests/Experimental.Gui.Tests.csproj
+++ b/src/Experimental/tests/Experimental.Gui.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="CommandLineTests.cs" />
     <Compile Include="Presenters\AddinsPresenterTests.cs" />
     <Compile Include="Presenters\Main\PackageSettingsTests.cs" />
     <Compile Include="Presenters\Main\WhenTestsAreLoading.cs" />

--- a/src/Experimental/tests/Views/MainFormTests.cs
+++ b/src/Experimental/tests/Views/MainFormTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2017 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -57,9 +57,9 @@ namespace TestCentric.Gui.Views
 
             Assert.NotNull(processModel, "ProcessModel not set properly");
             Assert.That(processModel.MenuItems.Select((p) => p.Text),
-                Is.EqualTo(new string[] { "Default", "InProcess", "Single", "Multiple" }));
+                Is.EqualTo(new string[] { "Default", "InProcess", "Separate", "Multiple" }));
             Assert.That(processModel.MenuItems.Select((p) => p.Tag),
-                Is.EqualTo(new string[] { "DEFAULT", "InProcess", "Single", "Multiple" }));
+                Is.EqualTo(new string[] { "DEFAULT", "InProcess", "Separate", "Multiple" }));
         }
 
         [Test]

--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -72,7 +72,7 @@ namespace TestCentric.Gui
             // We can't use user settings to provide a default because the settings
             // are an engine service and the engine have the internal trace level
             // set as part of its initialization.
-            var traceLevel = options.InternalTraceLevel;
+            var traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel);
 
             // This initializes the trace setting for the GUI itself.
             InternalTrace.Initialize($"InternalTrace.{Process.GetCurrentProcess().Id}.gui.log", traceLevel);

--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -86,6 +86,15 @@ namespace TestCentric.Gui
             ITestModel model = new TestModel(testEngine);
             model.PackageSettings.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
 
+            if (options.ProcessModel != null)
+                model.PackageSettings.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
+            if (options.DomainUsage != null)
+                model.PackageSettings.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
+            if (options.MaxAgents >= 0)
+                model.PackageSettings.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
+            if (options.RunAsX86)
+                model.PackageSettings.Add(EnginePackageSettings.RunAsX86, true);
+
             log.Info("Constructing Form");
             TestCentricMainView view = new TestCentricMainView();
 

--- a/src/TestCentric/testcentric.gui/CommandLineOptions.cs
+++ b/src/TestCentric/testcentric.gui/CommandLineOptions.cs
@@ -42,45 +42,44 @@ namespace TestCentric.Gui
 
         public CommandLineOptions(params string[] args)
         {
-            // NOTE: The order in which patterns are added 
-            // determines the display order for the help.
-
-            // Old Options no longer supported:
-            //   test
-            //   console
-            //   include
-            //   exclude
-
-            // Old Options to continue supporting:
-            //   lang
-            //   cleanup
-            //   help
-
-            // Options to be added:
-            //   test
-            //   trace
-
-            // Select Tests
-            //this.Insert("test=", "Comma-separated list of {NAMES} of tests to run or explore. This option may be repeated.",
-            //    v => ((List<string>)TestList).AddRange(TestNameParser.Parse(RequiredValue(v, "--test"))));
-
-            //this.Add("config=", "Project {CONFIG} to load.",
-            //    v => ActiveConfig = RequiredValue(v, "--config"));
-
             this.Add("noload", "Suppress loading of the most recent test file.",
                 v => NoLoad = v != null);
 
             this.Add("run", "Automatically run the loaded tests.",
                 v => RunAllTests = v != null);
 
-            //this.Add("runselected", "Automatically run last selected tests.",
-            //    v => RunSelectedTests = v != null);
+            this.Add("process=", "Select the process model for running the tests.",
+                v =>
+                {
+                    if (CheckRequiredValue(v, "--process", "Single", "Separate", "Multiple"))
+                        ProcessModel = v;
+                });
+
+            this.Add("x86", "Run the tests as X86",
+                v => RunAsX86 = v != null);
+
+            this.Add("agents=", "Specify max number of agents",
+                v =>
+                {
+                    if (CheckRequiredInt(v, "--agents", out int val))
+                        MaxAgents = val;
+                });
+
+            this.Add("inprocess", "Run the tests in process.",
+                v => ProcessModel = "Single");
+
+            this.Add("domain=", "Define how AppDomains are used in running the tests.",
+                v =>
+                {
+                    if (CheckRequiredValue(v, "--domain", "Single", "Separate", "Multiple"))
+                        DomainUsage = v;
+                });
 
             this.Add("trace=", "Set internal trace {LEVEL}. Valid values are Off, Error, Warning, Info or Debug.Verbose is a synonym for Debug.",
                 v =>
                 {
-                    var traceSetting = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug");
-                    InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), v);
+                    if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
+                        InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), v);
                 });
 
             this.Add("help|h", "Display the help message and exit.",
@@ -108,26 +107,18 @@ namespace TestCentric.Gui
         public bool ShowHelp { get; private set; }
         public bool NoLoad { get; private set; }
         public bool RunAllTests { get; private set; }
-        //public bool RunSelectedTests { get; private set; }
 
         // Select tests
 
         private List<string> inputFiles = new List<string>();
         public IList<string> InputFiles { get { return inputFiles; } }
 
-        //private List<string> testList = new List<string>();
-        //public IList<string> TestList { get { return testList; } }
+        // How to Run Tests
 
-        //public string ActiveConfig { get; private set; }
-
-        // Where to Run Tests
-
-        //public string ProcessModel { get; private set; }
-
-        //public string DomainUsage { get; private set; }
-
-        // Output GuiElement
-
+        public string ProcessModel { get; private set; }
+        public string DomainUsage { get; private set; }
+        public bool RunAsX86 { get; private set; }
+        public int MaxAgents { get; private set; }
         public InternalTraceLevel InternalTraceLevel { get; private set; }
 
         // Error Processing
@@ -169,79 +160,32 @@ namespace TestCentric.Gui
 
         #region Helper Methods
 
-        private string RequiredValue(string val, string option, params string[] validValues)
+        private bool CheckRequiredValue(string val, string option, params string[] validValues)
         {
-            if (string.IsNullOrEmpty(val))
-                ErrorMessages.Add("Missing required value for option '" + option + "'.");
+            if (validValues == null || validValues.Length == 0)
+                return true;
 
-            bool isValid = true;
+            foreach (string valid in validValues)
+                if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
+                    return true;
 
-            if (validValues != null && validValues.Length > 0)
-            {
-                isValid = false;
-
-                foreach (string valid in validValues)
-                    if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
-                        return valid;
-
-            }
-
-            if (!isValid)
-                ErrorMessages.Add(string.Format("The value '{0}' is not valid for option '{1}'.", val, option));
-
-            return val;
+            ErrorMessages.Add(string.Format("The value '{0}' is not valid for option '{1}'.", val, option));
+            return false;
         }
 
-        private int RequiredInt(string val, string option)
+        private bool CheckRequiredInt(string val, string option, out int result)
         {
             // We have to return something even though the val will 
             // be ignored if an error is reported. The -1 val seems
             // like a safe bet in case it isn't ignored due to a bug.
-            int result = -1;
+            result = -1;
 
-            if (val == null || val == string.Empty)
-                ErrorMessages.Add("Missing required value for option '" + option + "'.");
-            else
-            {
-                int r;
-                if (int.TryParse(val, out r))
-                    result = r;
-                else
-                    ErrorMessages.Add("An int value was expected for option '{0}' but a value of '{1}' was used");
-            }
+            if (int.TryParse(val, out result))
+                return true;
 
-            return result;
+            ErrorMessages.Add("An int value was expected for option '{0}' but a value of '{1}' was used");
+            return false;
         }
-
-        //private void RequiredIntError(string option)
-        //{
-        //    ErrorMessages.Insert("An int val is required for option '" + option + "'.");
-        //}
-
-        //private void ProcessIntOption(string v, ref int field)
-        //{
-        //    if (!int.TryParse(v, out field))
-        //        ErrorMessages.Insert("Invalid argument val: " + v);
-        //}
-
-        //private void ProcessEnumOption<T>(string v, ref T field)
-        //{
-        //    if (Enum.IsDefined(typeof(T), v))
-        //        field = (T)Enum.Parse(typeof(T), v);
-        //    else
-        //        ErrorMessages.Insert("Invalid argument val: " + v);
-        //}
-
-        //private object ParseEnumOption(Type enumType, string val)
-        //{
-        //    foreach (string name in Enum.GetNames(enumType))
-        //        if (val.ToLower() == name.ToLower())
-        //            return Enum.Parse(enumType, val);
-
-        //    this.ErrorMessages.Insert(val);
-
-        //    return null;
-        //}
 
         #endregion
     }

--- a/src/TestCentric/testcentric.gui/CommandLineOptions.cs
+++ b/src/TestCentric/testcentric.gui/CommandLineOptions.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Options;
-using NUnit.Engine;
 
 namespace TestCentric.Gui
 {
@@ -42,6 +41,9 @@ namespace TestCentric.Gui
 
         public CommandLineOptions(params string[] args)
         {
+            //this.Add("config=", "Project {CONFIG} to load (e.g.: Debug).",
+            //    v => ActiveConfig = v);
+
             this.Add("noload", "Suppress loading of the most recent test file.",
                 v => NoLoad = v != null);
 
@@ -75,11 +77,14 @@ namespace TestCentric.Gui
                         DomainUsage = v;
                 });
 
+            //this.Add("runselected", "Automatically run last selected tests.",
+            //    v => RunSelectedTests = v != null);
+
             this.Add("trace=", "Set internal trace {LEVEL}. Valid values are Off, Error, Warning, Info or Debug.Verbose is a synonym for Debug.",
                 v =>
                 {
-                    if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
-                        InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), v);
+                if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
+                    InternalTraceLevel = v;
                 });
 
             this.Add("help|h", "Display the help message and exit.",
@@ -113,13 +118,15 @@ namespace TestCentric.Gui
         private List<string> inputFiles = new List<string>();
         public IList<string> InputFiles { get { return inputFiles; } }
 
+        public string ActiveConfig { get; private set; }
+
         // How to Run Tests
 
         public string ProcessModel { get; private set; }
         public string DomainUsage { get; private set; }
         public bool RunAsX86 { get; private set; }
         public int MaxAgents { get; private set; }
-        public InternalTraceLevel InternalTraceLevel { get; private set; }
+        public string InternalTraceLevel { get; private set; }
 
         // Error Processing
 

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -218,14 +218,6 @@ namespace TestCentric.Gui.Presenters
                 if (_options.MaxAgents >= 0)
                     _model.Services.UserSettings.Engine.Agents = _options.MaxAgents;
                 _view.RunAsX86.Checked = _options.RunAsX86;
-                //if (settings.ContainsKey(EnginePackageSettings.ProcessModel))
-                //    _view.ProcessModel.SelectedItem = (string)settings[EnginePackageSettings.ProcessModel];
-                //if (settings.ContainsKey(EnginePackageSettings.DomainUsage))
-                //    _view.DomainUsage.SelectedItem = (string)settings[EnginePackageSettings.DomainUsage];
-                //if (settings.ContainsKey(EnginePackageSettings.RunAsX86))
-                //    _view.RunAsX86.Checked = (bool)settings[EnginePackageSettings.RunAsX86];
-                //if (settings.ContainsKey(EnginePackageSettings.MaxAgents))
-                //    _model.Services.UserSettings.Engine.Agents = (int)settings[EnginePackageSettings.MaxAgents];
             };
 
             _view.Shown += (s, e) =>

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -209,6 +209,23 @@ namespace TestCentric.Gui.Presenters
             _view.Load += (s, e) =>
             {
                 InitializeDisplay(_settings.Gui.DisplayFormat);
+
+                var settings = _model.PackageSettings;
+                if (_options.ProcessModel != null)
+                    _view.ProcessModel.SelectedItem = _options.ProcessModel;
+                if (_options.DomainUsage != null)
+                    _view.DomainUsage.SelectedItem = _options.DomainUsage;
+                if (_options.MaxAgents >= 0)
+                    _model.Services.UserSettings.Engine.Agents = _options.MaxAgents;
+                _view.RunAsX86.Checked = _options.RunAsX86;
+                //if (settings.ContainsKey(EnginePackageSettings.ProcessModel))
+                //    _view.ProcessModel.SelectedItem = (string)settings[EnginePackageSettings.ProcessModel];
+                //if (settings.ContainsKey(EnginePackageSettings.DomainUsage))
+                //    _view.DomainUsage.SelectedItem = (string)settings[EnginePackageSettings.DomainUsage];
+                //if (settings.ContainsKey(EnginePackageSettings.RunAsX86))
+                //    _view.RunAsX86.Checked = (bool)settings[EnginePackageSettings.RunAsX86];
+                //if (settings.ContainsKey(EnginePackageSettings.MaxAgents))
+                //    _model.Services.UserSettings.Engine.Agents = (int)settings[EnginePackageSettings.MaxAgents];
             };
 
             _view.Shown += (s, e) =>

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -407,21 +407,25 @@ namespace TestCentric.Gui.Views
             // defaultProcessMenuItem
             // 
             this.defaultProcessMenuItem.Index = 0;
+            this.defaultProcessMenuItem.Tag = "Default";
             this.defaultProcessMenuItem.Text = "Default";
             // 
             // inProcessMenuItem
             // 
             this.inProcessMenuItem.Index = 1;
+            this.inProcessMenuItem.Tag = "InProcess";
             this.inProcessMenuItem.Text = "InProcess";
             // 
             // singleProcessMenuItem
             // 
             this.singleProcessMenuItem.Index = 2;
+            this.singleProcessMenuItem.Tag = "Separate";
             this.singleProcessMenuItem.Text = "Separate";
             // 
             // multipleProcessMenuItem
             // 
             this.multipleProcessMenuItem.Index = 3;
+            this.multipleProcessMenuItem.Tag = "Multiple";
             this.multipleProcessMenuItem.Text = "Multiple";
             // 
             // menuItem11

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -450,16 +450,19 @@ namespace TestCentric.Gui.Views
             // defaultDomainMenuItem
             // 
             this.defaultDomainMenuItem.Index = 0;
+            this.defaultDomainMenuItem.Tag = "Default";
             this.defaultDomainMenuItem.Text = "Default";
             // 
             // singleDomainMenuItem
             // 
             this.singleDomainMenuItem.Index = 1;
+            this.singleDomainMenuItem.Tag = "Single";
             this.singleDomainMenuItem.Text = "Single";
             // 
             // multipleDomainMenuItem
             // 
             this.multipleDomainMenuItem.Index = 2;
+            this.multipleDomainMenuItem.Tag = "Multiple";
             this.multipleDomainMenuItem.Text = "Multiple";
             // 
             // menuItem2

--- a/src/TestCentric/tests/CommandLineTests.cs
+++ b/src/TestCentric/tests/CommandLineTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2018 Charlie Poole
+// Copyright (c) 2018-2019 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/TestCentric/tests/CommandLineTests.cs
+++ b/src/TestCentric/tests/CommandLineTests.cs
@@ -50,7 +50,7 @@ namespace TestCentric.Gui.Tests
         [TestCase("ShowHelp", false)]
         [TestCase("ProcessModel", null)]
         [TestCase("DomainUsage", null)]
-        [TestCase("InternalTraceLevel", NUnit.Engine.InternalTraceLevel.Default)]
+        [TestCase("InternalTraceLevel", null)]
         public void DefaultOptionValues(string propertyName, object val)
         {
             var property = GetPropertyInfo(propertyName);
@@ -70,12 +70,12 @@ namespace TestCentric.Gui.Tests
         [TestCase("DomainUsage", "--domain:Multiple")]
         [TestCase("RunAsX86", "--x86", true)]
         [TestCase("MaxAgents", "--agents:8", 8)]
-        [TestCase("InternalTraceLevel", "--trace:Off", NUnit.Engine.InternalTraceLevel.Off)]
-        [TestCase("InternalTraceLevel", "--trace:Error", NUnit.Engine.InternalTraceLevel.Error)]
-        [TestCase("InternalTraceLevel", "--trace:Warning", NUnit.Engine.InternalTraceLevel.Warning)]
-        [TestCase("InternalTraceLevel", "--trace:Info", NUnit.Engine.InternalTraceLevel.Info)]
-        [TestCase("InternalTraceLevel", "--trace:Verbose", NUnit.Engine.InternalTraceLevel.Verbose)]
-        [TestCase("InternalTraceLevel", "--trace:Debug", NUnit.Engine.InternalTraceLevel.Debug)]
+        [TestCase("InternalTraceLevel", "--trace:Off")]
+        [TestCase("InternalTraceLevel", "--trace:Error")]
+        [TestCase("InternalTraceLevel", "--trace:Warning")]
+        [TestCase("InternalTraceLevel", "--trace:Info")]
+        [TestCase("InternalTraceLevel", "--trace:Verbose")]
+        [TestCase("InternalTraceLevel", "--trace:Debug")]
         [TestCase("ShowHelp", "--help", true)]
         [TestCase("ShowHelp", "-h", true)]
         public void ValidOptionsAreRecognized(string propertyName, string option, object expected = null)
@@ -93,6 +93,7 @@ namespace TestCentric.Gui.Tests
             Assert.That(property.GetValue(options, null), Is.EqualTo(expected));
         }
 
+        //[TestCase("--config")]
         [TestCase("--process")]
         [TestCase("--agents")]
         [TestCase("--domain")]


### PR DESCRIPTION
Fixes #357

In addition to adding command-line options for ProcessModal, DomainUsage, RunAsX86 and Agents, this PR brings the two CommandLineOptions classes closer together, with the aim of eventuallly combining them.