### PR TITLE
Ensure that error message displays when exception is thrown in engine

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -172,6 +172,11 @@ namespace TestCentric.Gui.Presenters
                     "Passed: {0}   Failed: {1}   Errors: {2}   Inconclusive: {3}   Invalid: {4}   Ignored: {5}   Skipped: {6}   Time: {7}",
                     summary.PassCount, summary.FailedCount, summary.ErrorCount, summary.InconclusiveCount, summary.InvalidCount, summary.IgnoreCount, summary.SkipCount, summary.Duration);
 
+                if (summary.RunCount == 0)
+                {
+
+                }
+
                 //string resultPath = Path.Combine(TestProject.BasePath, "TestResult.xml");
                 // TODO: Use Work Directory
                 string resultPath = "TestResult.xml";

--- a/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xml;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 using System.ComponentModel;
@@ -535,7 +536,7 @@ namespace NUnit.Engine.Runners
                 resultXml.AddAttribute("duration", duration.ToString("0.000000", NumberFormatInfo.InvariantInfo));
 
                 _eventDispatcher.OnTestEvent(resultXml.OuterXml);
-                _eventDispatcher.OnTestEvent($"<unhandled-exception message='{ex.Message}' stacktrace='{ex.StackTrace}'/>");
+                _eventDispatcher.OnTestEvent($"<unhandled-exception message='{ex.Message}' />");
 
                 return new TestEngineResult(resultXml);
             }

--- a/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -134,17 +134,9 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases</returns>
         public override int CountTestCases(TestFilter filter)
         {
-            try
-            {
-                CreateAgentAndRunner();
+            CreateAgentAndRunner();
 
-                return _remoteRunner.CountTestCases(filter);
-            }
-            catch (Exception e)
-            {
-                log.Error("Failed to count remote tests {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
-                return 0;
-            }
+            return _remoteRunner.CountTestCases(filter);
         }
 
         /// <summary>


### PR DESCRIPTION
This relates to #340 but doesn't fix it fully. It does however ensure that a message displays to indicate why no tests were found. Turns out that the stack trace from a call to another process is not a valid attribute value in some cases. In retrospect, the message and stack trace should probably use CDATA elements. This PR fixes the problem by not displaying the stack trace at all, which is probably only a short-term solution.