### PR TITLE
Fix unhandled NullReferenceException thrown when test fails with Assert.Fail()

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/TestResultItem.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestResultItem.cs
@@ -44,7 +44,7 @@ namespace TestCentric.Gui.Views
 
         public override string ToString()
         {
-            if (message.Length > 64000)
+            if (message?.Length > 64000)
                 return string.Format("{0}:{1}{2}", testName, Environment.NewLine, message.Substring(0, 64000));
 
             return GetMessage();

--- a/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
+++ b/src/TestCentric/tests/TestCentric.Gui.Tests.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Presenters\TextOutputPresenterTests.cs" />
     <Compile Include="TestSuiteTreeNodeTests.cs" />
     <Compile Include="TextOutputDisplayTests.cs" />
+    <Compile Include="Views\TestResultItemTests.cs" />
     <Compile Include="VisualStateTests.cs" />
     <Compile Include="Views\CommonViewTests.cs" />
     <Compile Include="Presenters\Main\CommandTests.cs" />

--- a/src/TestCentric/tests/Views/TestResultItemTests.cs
+++ b/src/TestCentric/tests/Views/TestResultItemTests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Views
+{
+    [TestFixture()]
+    public class TestResultItemTests
+    {
+        [TestCase("message", "stack trace string")]
+        [TestCase("message", null)]
+        [TestCase(null, "stack trace string")]
+        public void ToStringTest(string message, string stackTrace)
+        {
+            var item = new TestResultItem("dummy test name", message, stackTrace);
+            Assert.IsNotNull(item.ToString());
+        }
+    }
+}

--- a/src/TestCentric/tests/Views/TestResultItemTests.cs
+++ b/src/TestCentric/tests/Views/TestResultItemTests.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Views
 {
-    [TestFixture()]
+    [TestFixture]
     public class TestResultItemTests
     {
         [TestCase("message", "stack trace string")]


### PR DESCRIPTION
When running the following test case, testcentric.exe v1.0.1 throws an unhandled `System.NullReferenceException`. If it is running without attaching a debugger on a Windows 10 system (with the default CLR configuration), a dialog box of "Unhandled exception has occurred..." gets displayed with the option of continuing or quitting.

```
using NUnit.Framework;

namespace demo
{
    [TestFixture]
    public class TestClass
    {
        [Test]
        public void TestMethod()
        {
            Assert.Fail();
            // Assert.Fail("") also causes the same unhandled exception.
            // Assert.Fail("Some message") does not cause the unhandled exception.
            // There may be other ways of causing the same issue but I'm not sure.
        }
    }
}
```

The test above was written for NUnit v3.12.0 and .Net Framework v4.7.1, targeting "Any CPU" platform and run on a 64-bit Windows 10 system.

The exception message is shown below.

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at TestCentric.Gui.Views.TestResultItem.ToString() in C:\Users\charlie\dev\TestCentric\testcentric-gui\src\TestCentric\testcentric.gui\Views\TestResultItem.cs:line 47
   at System.Windows.Forms.ListBox.NativeInsert(Int32 index, Object item)
   at System.Windows.Forms.ListBox.ObjectCollection.Insert(Int32 index, Object item)
   at TestCentric.Gui.Views.ErrorsAndFailuresView.InsertTestResultItem(TestResultItem item) in C:\Users\charlie\dev\TestCentric\testcentric-gui\src\TestCentric\testcentric.gui\Views\ErrorsAndFailuresView.cs:line 428
   at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme)
   at System.Windows.Forms.Control.InvokeMarshaledCallbacks()
```

The `NullReferenceException` turned out to be thrown because a `TestCentric.Gui.Views.TestResultItem` was instantiated with a null message and its `ToString()` method later checked for `message.Length` without a null check.

This PR adds a null check in `TestResultItem.ToString()` method along with a few tests.

Another approach might be to modify the model or presenter to ensure a `TestResultItem` always gets instantiated with a non-null message. I think it could possibly be a little cleaner (I don't like null checks, expecially in the view) but I did not take that route because `TestCentric.Gui.Model.ResultNode.GetTrimmedInnerText(XmlNode node)` explicitly returns null string under some conditions and implies that it is acceptable to have a null message.

Would love to hear if this PR aligns with the concepts and style of the project.