### PR TITLE
Small change to show the test assembly name in the main view's title bar.

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -121,6 +121,11 @@ namespace TestCentric.Gui.Presenters
                 }
 
                 UpdateViewCommands();
+
+                if (e.Test.Children.Count == 1)
+                {
+                    _view.SetTitleBar(e.Test.Children[0].Name);
+                }
             };
 
             _model.Events.TestsUnloading += (TestEventArgse) =>

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -122,9 +122,9 @@ namespace TestCentric.Gui.Presenters
 
                 UpdateViewCommands();
 
-                if (e.Test.Children.Count == 1)
+                if (_model.TestFiles.Count == 1)
                 {
-                    _view.SetTitleBar(e.Test.Children[0].Name);
+                    _view.SetTitleBar(_model.TestFiles.First());
                 }
             };
 

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -98,6 +98,7 @@ namespace TestCentric.Gui.Views
 
         // Methods used by Presenter
         void Configure(bool useFullGui);
+        void SetTitleBar(string fileName);
         LongRunningOperationDisplay LongOperationDisplay(string text);
 
         // Form methods that we have to use

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -1100,7 +1100,7 @@ namespace TestCentric.Gui.Views
         /// Set the title bar based on the loaded file or project
         /// </summary>
         /// <param name="fileName"></param>
-        private void SetTitleBar(string fileName)
+        public void SetTitleBar(string fileName)
         {
             Text = fileName == null
                 ? "NUnit"


### PR DESCRIPTION
 I was running some tests on a project here and couldn't remember which assembly I was running.

This is a small change to show the assembly name in the main view when there is only one test assembly loaded.