### PR TITLE
Make IProjectService part of API

### DIFF
--- a/src/TestEngine/src/NUnitEngine/nunit.engine.api/IProjectService.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine.api/IProjectService.cs
@@ -41,6 +41,13 @@ namespace NUnit.Engine.Services
         bool CanLoadFrom(string path);
 
         /// <summary>
+        /// Loads a project of a known format.
+        /// </summary>
+        /// <param name="path">The path of the project file</param>
+        /// <returns>An IProject interface to the loaded project or null if the project cannot be loaded</returns>
+        IProject LoadFrom(string path);
+
+        /// <summary>
         /// Expands a TestPackage based on a known project format, populating it
         /// with the project contents and any settings the project provides. 
         /// Note that the package file path must be checked to ensure that it is

--- a/src/TestEngine/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -131,7 +131,7 @@ namespace NUnit.Engine.Services
             }
         }
 
-        private IProject LoadFrom(string path)
+        public IProject LoadFrom(string path)
         {
             if (File.Exists(path))
             {


### PR DESCRIPTION
This PR moves the definition of `IProjectService` out of the `nunit.engine` assembly and into the `nunit.engine.api` assembly so ti is usable by clients. It also adds a pre-existing method in the ProjectService to the interface, so that clients may get information about projects.

This is part of issue #402 