### PR TITLE
Expose TestPackage publicly and provide mapping from tests to packages

### DIFF
--- a/src/Experimental/experimental-gui/AppEntry.cs
+++ b/src/Experimental/experimental-gui/AppEntry.cs
@@ -89,16 +89,16 @@ namespace TestCentric.Gui
             testEngine.InternalTraceLevel = traceLevel;
 
             var model = new TestModel(testEngine, "Experimental.");
-            model.PackageSettings.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
+            model.PackageOverrides.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
 
             if (options.ProcessModel != null)
-                model.PackageSettings.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
+                model.PackageOverrides.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
             if (options.DomainUsage != null)
-                model.PackageSettings.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
+                model.PackageOverrides.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
             if (options.MaxAgents >= 0)
-                model.PackageSettings.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
+                model.PackageOverrides.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
             if (options.RunAsX86)
-                model.PackageSettings.Add(EnginePackageSettings.RunAsX86, true);
+                model.PackageOverrides.Add(EnginePackageSettings.RunAsX86, true);
 
             var form = new MainForm();
 

--- a/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
@@ -191,7 +191,7 @@ namespace TestCentric.Gui.Presenters
             // Set the font to use
             _view.Font = _settings.Gui.Font;
 
-            var settings = _model.PackageSettings;
+            var settings = _model.PackageOverrides;
             if (_options.InternalTraceLevel != null)
                 settings.Add(EnginePackageSettings.InternalTraceLevel, _options.InternalTraceLevel);
 
@@ -231,34 +231,34 @@ namespace TestCentric.Gui.Presenters
 
         private void SelectedRuntime_SelectionChanged()
         {
-            ChangePackageSetting(EnginePackageSettings.RuntimeFramework, _view.SelectedRuntime.SelectedItem);
+            OverridePackageSetting(EnginePackageSettings.RuntimeFramework, _view.SelectedRuntime.SelectedItem);
         }
 
         private void ProcessModel_SelectionChanged()
         {
-            ChangePackageSetting(EnginePackageSettings.ProcessModel, _view.ProcessModel.SelectedItem);
+            OverridePackageSetting(EnginePackageSettings.ProcessModel, _view.ProcessModel.SelectedItem);
         }
 
         private void DomainUsage_SelectionChanged()
         {
-            ChangePackageSetting(EnginePackageSettings.DomainUsage, _view.DomainUsage.SelectedItem);
+            OverridePackageSetting(EnginePackageSettings.DomainUsage, _view.DomainUsage.SelectedItem);
         }
 
         private void LoadAsX86_CheckedChanged()
         {
             var key = EnginePackageSettings.RunAsX86;
             if (_view.RunAsX86.Checked)
-                ChangePackageSetting(key, true);
+                OverridePackageSetting(key, true);
             else
-                ChangePackageSetting(key, null);
+                OverridePackageSetting(key, null);
         }
 
-        private void ChangePackageSetting(string key, object setting)
+        private void OverridePackageSetting(string key, object setting)
         {
             if (setting == null || setting as string == "DEFAULT")
-                _model.PackageSettings.Remove(key);
+                _model.PackageOverrides.Remove(key);
             else
-                _model.PackageSettings[key] = setting;
+                _model.PackageOverrides[key] = setting;
 
             string message = string.Format("New {0} setting will not take effect until you reload.\r\n\r\n\t\tReload Now?", key);
 

--- a/src/Experimental/tests/Presenters/Main/PackageSettingsTests.cs
+++ b/src/Experimental/tests/Presenters/Main/PackageSettingsTests.cs
@@ -40,7 +40,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             View.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
 
-            Model.PackageSettings.Received(1)["ProcessModel"] = value;
+            Model.PackageOverrides.Received(1)["ProcessModel"] = value;
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             View.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
 
-            Model.PackageSettings.Received(1).Remove("ProcessModel");
+            Model.PackageOverrides.Received(1).Remove("ProcessModel");
         }
 
         [TestCase("Single")]
@@ -62,7 +62,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             View.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
 
-            Model.PackageSettings.Received(1)["DomainUsage"] = value;
+            Model.PackageOverrides.Received(1)["DomainUsage"] = value;
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             View.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
 
-            Model.PackageSettings.Received(1).Remove("DomainUsage");
+            Model.PackageOverrides.Received(1).Remove("DomainUsage");
         }
 
         [TestCase("net-2.0")]
@@ -87,7 +87,7 @@ namespace TestCentric.Gui.Presenters.Main
 
                 View.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
 
-                Model.PackageSettings.Received(1)["RuntimeFramework"] = setting;
+                Model.PackageOverrides.Received(1)["RuntimeFramework"] = setting;
             }
         }
 
@@ -103,7 +103,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             View.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
 
-            Model.PackageSettings.Received(1).Remove("RuntimeFramework");
+            Model.PackageOverrides.Received(1).Remove("RuntimeFramework");
         }
     }
 }

--- a/src/Experimental/tests/Presenters/PresenterTestBase.cs
+++ b/src/Experimental/tests/Presenters/PresenterTestBase.cs
@@ -50,7 +50,6 @@ namespace TestCentric.Gui.Presenters
             _model = Substitute.For<ITestModel>();
             _settings = new FakeUserSettings();
             _model.Services.UserSettings.Returns(_settings);
-            _model.TestFiles.Returns(new List<string>());
         }
 
         #region Helper Methods

--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -87,16 +87,16 @@ namespace TestCentric.Gui
 
             log.Info("Instantiating TestModel");
             ITestModel model = new TestModel(testEngine, "TestCentric");
-            model.PackageSettings.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
+            model.PackageOverrides.Add(EnginePackageSettings.InternalTraceLevel, traceLevel.ToString());
 
             if (options.ProcessModel != null)
-                model.PackageSettings.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
+                model.PackageOverrides.Add(EnginePackageSettings.ProcessModel, options.ProcessModel);
             if (options.DomainUsage != null)
-                model.PackageSettings.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
+                model.PackageOverrides.Add(EnginePackageSettings.DomainUsage, options.DomainUsage);
             if (options.MaxAgents >= 0)
-                model.PackageSettings.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
+                model.PackageOverrides.Add(EnginePackageSettings.MaxAgents, options.MaxAgents);
             if (options.RunAsX86)
-                model.PackageSettings.Add(EnginePackageSettings.RunAsX86, true);
+                model.PackageOverrides.Add(EnginePackageSettings.RunAsX86, true);
 
             log.Info("Constructing Form");
             TestCentricMainView view = new TestCentricMainView();

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -123,10 +123,9 @@ namespace TestCentric.Gui.Presenters
 
                 UpdateViewCommands();
 
-                if (_model.TestFiles.Count == 1)
-                {
-                    _view.SetTitleBar(_model.TestFiles.First());
-                }
+                var files = _model.TestFiles;
+                if (files.Count == 1)
+                    _view.SetTitleBar(files.First());
             };
 
             _model.Events.TestsUnloading += (TestEventArgse) =>
@@ -221,7 +220,7 @@ namespace TestCentric.Gui.Presenters
             {
                 InitializeDisplay(_settings.Gui.DisplayFormat);
 
-                var settings = _model.PackageSettings;
+                var settings = _model.PackageOverrides;
                 if (_options.ProcessModel != null)
                     _view.ProcessModel.SelectedItem = _options.ProcessModel;
                 if (_options.DomainUsage != null)
@@ -580,9 +579,7 @@ namespace TestCentric.Gui.Presenters
 
             if (filesToAdd.Count > 0)
             {
-                var files = new List<string>();
-                if (_model.TestFiles != null)
-                    files.AddRange(_model.TestFiles);
+                var files = _model.TestFiles;
                 files.AddRange(filesToAdd);
 
                 _model.LoadTests(files);
@@ -752,15 +749,14 @@ namespace TestCentric.Gui.Presenters
         private void ChangePackageSettingAndReload(string key, object setting)
         {
             if (setting == null || setting as string == "DEFAULT")
-                _model.PackageSettings.Remove(key);
+                _model.PackageOverrides.Remove(key);
             else
-                _model.PackageSettings[key] = setting;
+                _model.PackageOverrides[key] = setting;
 
             // Even though the _model has a Reload method, we cannot use it because Reload
             // does not re-create the Engine.  Since we just changed a setting, we must
             // re-create the Engine by unloading/reloading the tests.
-            List<string> listCopy = _model.TestFiles.ToList();
-            LoadTests(listCopy);    // This also does an Unload first.
+            LoadTests(_model.TestFiles);    // This also does an Unload first.
         }
 
         private void applyFont(Font font)

--- a/src/TestCentric/tests/Presenters/Main/PackageSettingsTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/PackageSettingsTests.cs
@@ -40,7 +40,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _model.PackageSettings.Received(1)["ProcessModel"] = value;
+            _model.PackageOverrides.Received(1)["ProcessModel"] = value;
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _model.PackageSettings.Received(1).Remove("ProcessModel");
+            _model.PackageOverrides.Received(1).Remove("ProcessModel");
         }
 
         [TestCase("Single")]
@@ -62,7 +62,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _model.PackageSettings.Received(1)["DomainUsage"] = value;
+            _model.PackageOverrides.Received(1)["DomainUsage"] = value;
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _model.PackageSettings.Received(1).Remove("DomainUsage");
+            _model.PackageOverrides.Received(1).Remove("DomainUsage");
         }
 
         [TestCase("net-2.0")]
@@ -87,7 +87,7 @@ namespace TestCentric.Gui.Presenters.Main
 
                 _view.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
 
-                _model.PackageSettings.Received(1)["RuntimeFramework"] = setting;
+                _model.PackageOverrides.Received(1)["RuntimeFramework"] = setting;
             }
         }
 
@@ -103,7 +103,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
 
-            _model.PackageSettings.Received(1).Remove("RuntimeFramework");
+            _model.PackageOverrides.Received(1).Remove("RuntimeFramework");
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -40,7 +40,6 @@ namespace TestCentric.Gui.Presenters.Main
 
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.Tests.Returns(testNode);
-            _model.TestAssemblies.Returns(new TestSelection(new[] { testNode }));
             FireTestLoadedEvent(testNode);
         }
 

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -54,13 +54,13 @@ namespace TestCentric.Gui.Model
 
         #region Current State of the Model
 
+        TestPackage TestPackage { get; }
+
         bool IsPackageLoaded { get; }
 
         List<string> TestFiles { get; }
 
-        TestSelection TestAssemblies { get; }
-
-        IDictionary<string, object> PackageSettings { get; }
+        IDictionary<string, object> PackageOverrides { get; }
 
         // TestNode hierarchy representing the discovered tests
         TestNode Tests { get; }
@@ -123,6 +123,9 @@ namespace TestCentric.Gui.Model
 
         // Get the result for a test if available
         ResultNode GetResultForTest(string id);
+
+        // Get the TestPackage represented by a test,if available
+        TestPackage GetPackageForTest(string id);
 
         // Clear the results for all tests
         void ClearResults();

--- a/src/TestModel/model/TestEventDispatcher.cs
+++ b/src/TestModel/model/TestEventDispatcher.cs
@@ -225,7 +225,7 @@ namespace TestCentric.Gui.Model
             // Initialize Dictionary to look up projects to which assemblies belong
             _projectLookup = new Dictionary<string, ProjectInfo>();
 
-            foreach (var projectNode in _model.TestProjects)
+            foreach (var projectNode in _model.Tests.Select(tn => tn.Type == "Project"))
             {
                 var projectInfo = new ProjectInfo(projectNode);
 

--- a/src/TestModel/tests/TestModelAssemblyTests.cs
+++ b/src/TestModel/tests/TestModelAssemblyTests.cs
@@ -69,6 +69,26 @@ namespace TestCentric.Gui.Model
         }
 
         [Test]
+        public void CheckThatTestsMapToPackages()
+        {
+            var package1 = _model.GetPackageForTest(_model.Tests.Id);
+            var package2 = _model.GetPackageForTest(_model.Tests.Children[0].Id);
+            var nopackage = _model.GetPackageForTest(_model.Tests.Children[0].Children[0].Id);
+
+            Assert.NotNull(package1, "Package1");
+            Assert.NotNull(package2, "Package2");
+            Assert.Null(nopackage);
+
+            Assert.Null(package1.Name);
+            Assert.That(package1.SubPackages.Count, Is.EqualTo(1));
+
+            Assert.That(package2.Name, Is.EqualTo(MOCK_ASSEMBLY));
+            Assert.That(package2.SubPackages.Count, Is.Zero);
+
+            Assert.That(package2, Is.SameAs(package1.SubPackages[0]));
+        }
+
+        [Test]
         public void CheckStateAfterRunningTests()
         {
             RunAllTestsAndWaitForCompletion();

--- a/src/TestModel/tests/TestModelPackageTests.cs
+++ b/src/TestModel/tests/TestModelPackageTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -42,11 +42,12 @@ namespace TestCentric.Gui.Model
 
         [TestCase("my.test.assembly.dll")]
         [TestCase("one.dll", "two.dll", "three.dll")]
-        public void PackageContainsOneSubPackagePerAssembly(params string[] assemblies)
+        [TestCase("tests.nunit")]
+        public void PackageContainsOneSubPackagePerTestFile(params string[] testFiles)
         {
-            TestPackage package = _model.MakeTestPackage(assemblies);
+            TestPackage package = _model.MakeTestPackage(testFiles);
 
-            Assert.That(package.SubPackages.Select(p => p.Name), Is.EqualTo(assemblies));
+            Assert.That(package.SubPackages.Select(p => p.Name), Is.EqualTo(testFiles));
         }
 
         [TestCase(EnginePackageSettings.ProcessModel, "Single")]
@@ -56,7 +57,7 @@ namespace TestCentric.Gui.Model
         [TestCase(EnginePackageSettings.ShadowCopyFiles, false)]
         public void PackageReflectsPackageSettings(string key, object value)
         {
-            _model.PackageSettings[key] = value;
+            _model.PackageOverrides[key] = value;
             TestPackage package = _model.MakeTestPackage(new[] { "my.dll" });
 
             Assert.That(package.Settings.ContainsKey(key));


### PR DESCRIPTION
Part of issue #402.

This PR makes `TestPackage` public in the model. It also adds a public method to map an assembly-level or higher `TestNode` to the package for which it was created.

These features are preliminary for use in finishing #402.