### PR TITLE
Use AppVeyor build number to create unique build identifier

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -136,7 +136,7 @@ Setup(context =>
 		}
 
 		if (BuildSystem.IsRunningOnAppVeyor)
-			AppVeyor.UpdateBuildVersion(packageVersion);
+			AppVeyor.UpdateBuildVersion(packageVersion + "-" + AppVeyor.Environment.Build.Number);
 	}
 
     Information("Building {0} version {1} of TestCentric GUI.", configuration, packageVersion);


### PR DESCRIPTION
Fixes #406 by using unique build number for each Appveyor build.