### PR TITLE
Issue 402d

### DIFF
--- a/src/Common/components/Elements/ICommand.cs
+++ b/src/Common/components/Elements/ICommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -39,5 +39,10 @@ namespace TestCentric.Gui.Elements
         /// to execute the associated command.
         /// </summary>
         event CommandHandler Execute;
+    }
+
+    public interface IMenuCommand : ICommand
+    {
+        bool DefaultItem { get; set; }
     }
 }

--- a/src/Common/components/Elements/MenuCommand.cs
+++ b/src/Common/components/Elements/MenuCommand.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015-2018 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -25,7 +25,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Elements
 {
-    public class MenuCommand : MenuElement, ICommand
+    public class MenuCommand : MenuElement, IMenuCommand
     {
         public event CommandHandler Execute;
 

--- a/src/Common/components/Elements/ToolStripMenuElement.cs
+++ b/src/Common/components/Elements/ToolStripMenuElement.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -37,13 +37,14 @@ namespace TestCentric.Gui.Views
 
         ContextMenu ContextMenu { get; }
 
-        ICommand RunCommand { get; }
+        IMenuCommand RunCommand { get; }
         IChecked ShowFailedAssumptions { get; }
+        IMenu ActiveConfiguration { get; }
+        ICommand PropertiesCommand { get; }
         IChecked ShowCheckBoxes { get; }
         ICommand ExpandAllCommand { get; }
         ICommand CollapseAllCommand { get; }
         ICommand HideTestsCommand { get; }
-        ICommand PropertiesCommand { get; }
 
         // TODO: Can we eliminate need for having this in addition to ShowCheckBoxes?
         bool CheckBoxes { get; set; }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace TestCentric.Gui.Views
+namespace TestCentric.Gui.Views
 {
     partial class TestTreeView
     {
@@ -36,11 +36,12 @@
             this.treeImages = new System.Windows.Forms.ImageList(this.components);
             this.runMenuItem = new System.Windows.Forms.MenuItem();
             this.failedAssumptionsMenuItem = new System.Windows.Forms.MenuItem();
+            this.activeConfigurationMenuItem = new System.Windows.Forms.MenuItem();
+            this.propertiesMenuItem = new System.Windows.Forms.MenuItem();
             this.showCheckBoxesMenuItem = new System.Windows.Forms.MenuItem();
             this.expandAllMenuItem = new System.Windows.Forms.MenuItem();
             this.collapseAllMenuItem = new System.Windows.Forms.MenuItem();
             this.hideTestsMenuItem = new System.Windows.Forms.MenuItem();
-            this.propertiesMenuItem = new System.Windows.Forms.MenuItem();
             this.treeMenu = new System.Windows.Forms.ContextMenu();
             this.treeMenu.Name = "treeMenu";
             this.checkFailedButton = new System.Windows.Forms.Button();
@@ -86,15 +87,14 @@
             //
             this.treeMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[]{
                 this.runMenuItem,
-                new System.Windows.Forms.MenuItem("-"),
                 this.failedAssumptionsMenuItem,
-                this.showCheckBoxesMenuItem,
+                this.activeConfigurationMenuItem,
+                this.propertiesMenuItem,
                 new System.Windows.Forms.MenuItem("-"),
+                this.showCheckBoxesMenuItem,
                 this.expandAllMenuItem,
                 this.collapseAllMenuItem,
-                this.hideTestsMenuItem,
-                new System.Windows.Forms.MenuItem("-"),
-                this.propertiesMenuItem});
+                this.hideTestsMenuItem });
             // 
             // buttonPanel
             // 
@@ -133,6 +133,11 @@
             //
             this.failedAssumptionsMenuItem.Name = "failedAssumptionsMenuItem";
             this.failedAssumptionsMenuItem.Text = "Show Failed Assumptions";
+            //
+            // activeConfigurationMenuItem
+            //
+            this.activeConfigurationMenuItem.Name = "activeConfigurationMenuItem";
+            this.activeConfigurationMenuItem.Text = "Active Configuration";
             //
             // showCheckBoxesMenuItem
             //
@@ -183,11 +188,12 @@
         private System.Windows.Forms.Button checkFailedButton;
         private System.Windows.Forms.ContextMenu treeMenu;
         private System.Windows.Forms.MenuItem runMenuItem;
-        private System.Windows.Forms.MenuItem showCheckBoxesMenuItem;
         private System.Windows.Forms.MenuItem failedAssumptionsMenuItem;
+        private System.Windows.Forms.MenuItem activeConfigurationMenuItem;
+        private System.Windows.Forms.MenuItem propertiesMenuItem;
+        private System.Windows.Forms.MenuItem showCheckBoxesMenuItem;
         private System.Windows.Forms.MenuItem expandAllMenuItem;
         private System.Windows.Forms.MenuItem collapseAllMenuItem;
         private System.Windows.Forms.MenuItem hideTestsMenuItem;
-        private System.Windows.Forms.MenuItem propertiesMenuItem;
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -58,12 +58,13 @@ namespace TestCentric.Gui.Views
             InitializeComponent();
 
             RunCommand = new MenuCommand(runMenuItem);
-            ShowCheckBoxes = new CheckedMenuItem(showCheckBoxesMenuItem);
             ShowFailedAssumptions = new CheckedMenuItem(failedAssumptionsMenuItem);
+            ActiveConfiguration = new PopupMenu(activeConfigurationMenuItem);
+            PropertiesCommand = new MenuCommand(propertiesMenuItem);
+            ShowCheckBoxes = new CheckedMenuItem(showCheckBoxesMenuItem);
             ExpandAllCommand = new MenuCommand(expandAllMenuItem);
             CollapseAllCommand = new MenuCommand(collapseAllMenuItem);
             HideTestsCommand = new MenuCommand(hideTestsMenuItem);
-            PropertiesCommand = new MenuCommand(propertiesMenuItem);
             ClearAllCheckBoxes = new ButtonElement(clearAllButton);
             CheckFailedTests = new ButtonElement(checkFailedButton);
             Tree = new TreeViewElement(tree);
@@ -117,24 +118,6 @@ namespace TestCentric.Gui.Views
                     : DragDropEffects.None;
             };
 
-            treeMenu.Popup += (s, e) =>
-            {
-                TestSuiteTreeNode targetNode = ContextNode ?? (TestSuiteTreeNode)tree.SelectedNode;
-                TestSuiteTreeNode theoryNode = targetNode?.GetTheoryNode();
-
-
-                runMenuItem.DefaultItem = runMenuItem.Enabled && targetNode != null && targetNode.Included &&
-                        (targetNode.Test.RunState == RunState.Runnable || targetNode.Test.RunState == RunState.Explicit);
-
-                showCheckBoxesMenuItem.Checked = tree.CheckBoxes;
-
-                //failedAssumptionsMenuItem.Visible = 
-                failedAssumptionsMenuItem.Enabled = theoryNode != null;
-                failedAssumptionsMenuItem.Checked = theoryNode?.ShowFailedAssumptions ?? false;
-
-                propertiesMenuItem.Enabled = targetNode != null;
-            };
-
             treeMenu.Collapse += (s, e) => ContextNode = null;
         }
 
@@ -144,13 +127,14 @@ namespace TestCentric.Gui.Views
 
         public event FileDropEventHandler FileDrop;
 
-        public ICommand RunCommand { get; private set; }
+        public IMenuCommand RunCommand { get; private set; }
         public IChecked ShowFailedAssumptions { get; private set; }
+        public IMenu ActiveConfiguration { get; private set; }
+        public ICommand PropertiesCommand { get; private set; }
         public IChecked ShowCheckBoxes { get; private set; }
         public ICommand ExpandAllCommand { get; private set; }
         public ICommand CollapseAllCommand { get; private set; }
         public ICommand HideTestsCommand { get; private set; }
-        public ICommand PropertiesCommand { get; private set; }
 
         [Category("Appearance"), DefaultValue(false)]
         [Description("Indicates whether checkboxes are displayed beside test nodes")]

--- a/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewPresenterTests.cs
@@ -39,6 +39,7 @@ namespace TestCentric.Gui.Presenters
         [SetUp]
         public void CreatePresenter()
         {
+            _view.Tree.ContextMenu.Returns(new ContextMenu());
             _settings.Gui.TestTree.AlternateImageSet = "MyImageSet";
             _settings.Gui.TestTree.ShowCheckBoxes = true;
             _presenter = new TreeViewPresenter(_view, _model);

--- a/src/TestModel/model/TestNode.cs
+++ b/src/TestModel/model/TestNode.cs
@@ -93,6 +93,8 @@ namespace TestCentric.Gui.Model
         public string Id => GetAttribute("id");
         public string FullName => GetAttribute("fullname") ?? Name;
         public string Type => IsSuite ? GetAttribute("type") : "TestCase";
+        public bool IsAssembly => Type == "Assembly";
+        public bool IsProject => Type == "Project";
 
         public int TestCount => IsSuite ? GetAttribute("testcasecount", 0) : 1;
         public RunState RunState => GetRunState();


### PR DESCRIPTION
Part of #402. This implements a context menu item that allows setting the active configuration. The menu item only appears on tree nodes representing a project.

One deficiency in the implementation is that reloading the project using a new config loses all expansion information. This requires work in the engine in order to be fixed.