### PR TITLE
Fix to allow keeping the same visual state when changing configs

### DIFF
--- a/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
@@ -372,8 +372,6 @@ namespace TestCentric.Gui.Presenters
 
         private string CreateOpenFileFilter()
         {
-            const string VS_FILE_TYPES = "*.csproj,*.fsproj,*.vbproj,*.vjsproj,*.vcproj,*.sln";
-
             StringBuilder sb = new StringBuilder();
             bool nunit = _model.NUnitProjectSupport;
             bool vs = _model.VisualStudioSupport;

--- a/src/TestEngine/src/NUnitEngine/nunit.engine.api/IProjectService.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine.api/IProjectService.cs
@@ -23,7 +23,7 @@
 
 using NUnit.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace NUnit.Engine
 {
     /// <summary>
     /// The IProjectService interface is implemented by ProjectService.

--- a/src/TestEngine/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/TestEngine/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -96,6 +96,18 @@ namespace NUnit.Engine
         public string ID { get; private set; }
 
         /// <summary>
+        /// Set the ID on a package that has already been created. This is separate from the
+        /// ID property itself because it's a temporary addition, necessitated by the way
+        /// projects work. It allows us to reload a project using a new config without changing
+        /// the test IDs. A broad engine API change may be needed to handle this correctly.
+        /// </summary>
+        /// <param name="id"></param>
+        public void SetID(string id)
+        {
+            ID = id;
+        }
+
+        /// <summary>
         /// Gets the name of the package
         /// </summary>
         public string Name

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -103,6 +103,9 @@ namespace TestCentric.Gui.Model
         // Reload current TestPackage
         void ReloadTests();
 
+        // Reload a specific package using the specified config
+        void ReloadPackage(TestPackage package, string config);
+
         // Run all the tests
         void RunAllTests();
 
@@ -126,6 +129,12 @@ namespace TestCentric.Gui.Model
 
         // Get the TestPackage represented by a test,if available
         TestPackage GetPackageForTest(string id);
+
+        // Get the active config name for a TestPackage representing a project
+        string GetActiveConfig(TestPackage package);
+
+        // Get a list of config names for a TestPackage representing a project
+        IList<string> GetConfigNames(TestPackage package);
 
         // Clear the results for all tests
         void ClearResults();

--- a/src/TestModel/model/ITestServices.cs
+++ b/src/TestModel/model/ITestServices.cs
@@ -39,5 +39,6 @@ namespace TestCentric.Gui.Model
         RecentFiles RecentFiles { get; }
         IExtensionService ExtensionService { get; }
         IResultService ResultService { get; }
+        IProjectService ProjectService { get; }
     }
 }

--- a/src/TestModel/model/TestServices.cs
+++ b/src/TestModel/model/TestServices.cs
@@ -47,6 +47,7 @@ namespace TestCentric.Gui.Model
             RecentFiles = new RecentFiles(settings, applicationPrefix);
             ExtensionService = GetService<IExtensionService>();
             ResultService = GetService<IResultService>();
+            ProjectService = GetService<IProjectService>();
         }
 
         #region ITestServices Implementation
@@ -58,6 +59,8 @@ namespace TestCentric.Gui.Model
         public IExtensionService ExtensionService { get; }
 
         public IResultService ResultService { get; }
+
+        public IProjectService ProjectService { get; }
 
         #endregion
 


### PR DESCRIPTION
This PR is part of issue #402.

In order to __reload__ a project with changed config, it is necesary to use the same package ID for the new package. Otherwise, when visual state is restored, no matching tests are found.

This commit takes care of that problem in what is basically a hacky manner.

1. TestPackage is given a `SetID` method, so that it's possible to set the ID of a new package back to the same value as the original package.

2. A heuristic is employed to decide when to do this. If the new config for the project contains an assembly with the same file name as the original, then the  ID for the original is substituted. This works well for VS projects and other projects that use the config to represent different builds of the same assembly like Debug and Release. However, projects are not limited to using configs in this way. An NUnit project, for example, may have entirely unrelated assemblies in the various configs. In that case, the newly loaded assemblies will not have a prior visual state and will appear unexpanded.

Since this is an entirely new feature, I plan to merge this and deal with alternative approaches in a future PR.