### PR TITLE
Ensure saved window size is honored

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -275,42 +275,6 @@ namespace TestCentric.Gui.Presenters
                     RunAllTests();
             };
 
-            _view.Move += (s, e) =>
-            {
-                if (!_view.Maximized)
-                {
-                    var location = _view.Location;
-
-                    switch (_view.DisplayFormat.SelectedItem)
-                    {
-                        case "Full":
-                        default:
-                            _settings.Gui.MainForm.Location = location;
-                            _settings.Gui.MainForm.Maximized = false;
-                            break;
-                        case "Mini":
-                            _settings.Gui.MiniForm.Location = location;
-                            _settings.Gui.MiniForm.Maximized = false;
-                            break;
-                    }
-                }
-            };
-
-            _view.Resize += (s, e) =>
-            {
-                if (!_view.Maximized)
-                {
-                    if (_view.DisplayFormat.SelectedItem == "Full")
-                    {
-                        _settings.Gui.MainForm.Size = _view.Size;
-                    }
-                    else
-                    {
-                        _settings.Gui.MiniForm.Size = _view.Size;
-                    }
-                }
-            };
-
             _view.SplitterPositionChanged += (s, e) =>
             {
                 _settings.Gui.MainForm.SplitPosition = _view.SplitterPosition;
@@ -336,6 +300,20 @@ namespace TestCentric.Gui.Presenters
 
                     if (CloseProject() == DialogResult.Cancel)
                         e.Cancel = true;
+                }
+
+                if (!e.Cancel)
+                {
+                    if (_settings.Gui.DisplayFormat == "Mini")
+                    {
+                        _settings.Gui.MiniForm.Location = _view.Location;
+                        _settings.Gui.MiniForm.Size = _view.Size;
+                    }
+                    else
+                    {
+                        _settings.Gui.MainForm.Location = _view.Location;
+                        _settings.Gui.MainForm.Size = _view.Size;
+                    }
                 }
             };
 


### PR DESCRIPTION
Fixes #449 

When the window is created at it's default size a resize event is generated. That event was causing the default to be saved in place of the previously set size.