### PR TITLE
Change namespaces from NUnit to TestCentric

### DIFF
--- a/src/Common/components/Dialogs/ExtensionDialog.cs
+++ b/src/Common/components/Dialogs/ExtensionDialog.cs
@@ -25,8 +25,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Windows.Forms;
-using NUnit.Engine;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine;
+using TestCentric.Engine.Extensibility;
 
 namespace TestCentric.Gui
 {

--- a/src/Common/testcentric.common/InternalTrace.cs
+++ b/src/Common/testcentric.common/InternalTrace.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui
 {

--- a/src/Common/testcentric.common/Logger.cs
+++ b/src/Common/testcentric.common/Logger.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui
 {

--- a/src/Experimental/experimental-gui/AppEntry.cs
+++ b/src/Experimental/experimental-gui/AppEntry.cs
@@ -25,7 +25,7 @@ using System;
 using System.IO;
 using System.Windows.Forms;
 using Mono.Options;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui
 {

--- a/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/MainPresenter.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 using TestCentric.Gui.Model.Settings;
 
 namespace TestCentric.Gui.Presenters

--- a/src/Experimental/experimental-gui/Presenters/TestGroup.cs
+++ b/src/Experimental/experimental-gui/Presenters/TestGroup.cs
@@ -23,7 +23,7 @@
 
 using System.Text;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/Experimental/experimental-gui/Presenters/TreeViewPresenter.cs
+++ b/src/Experimental/experimental-gui/Presenters/TreeViewPresenter.cs
@@ -23,7 +23,7 @@
 
     using System.Collections.Generic;
     using System.Windows.Forms;
-    using NUnit.Engine;
+    using TestCentric.Engine;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/Experimental/experimental-gui/Views/AddinPages/AddinsView.cs
+++ b/src/Experimental/experimental-gui/Views/AddinPages/AddinsView.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
 namespace TestCentric.Gui.Views.AddinPages
 {

--- a/src/Experimental/experimental-gui/Views/AddinPages/ExtensionNodeView.cs
+++ b/src/Experimental/experimental-gui/Views/AddinPages/ExtensionNodeView.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
 namespace TestCentric.Gui.Views.AddinPages
 {

--- a/src/Experimental/experimental-gui/Views/AddinPages/ExtensionPointView.cs
+++ b/src/Experimental/experimental-gui/Views/AddinPages/ExtensionPointView.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Forms;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
 namespace TestCentric.Gui.Views.AddinPages
 {

--- a/src/Experimental/experimental-gui/Views/IAddinsView.cs
+++ b/src/Experimental/experimental-gui/Views/IAddinsView.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
 namespace TestCentric.Gui.Views
 {

--- a/src/Experimental/tests/Presenters/Main/CommandTests.cs
+++ b/src/Experimental/tests/Presenters/Main/CommandTests.cs
@@ -23,7 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
 using NSubstitute;
 

--- a/src/Experimental/tests/Presenters/Main/MainPresenterTestBase.cs
+++ b/src/Experimental/tests/Presenters/Main/MainPresenterTestBase.cs
@@ -40,7 +40,7 @@ namespace TestCentric.Gui.Presenters.Main
         {
             View = Substitute.For<IMainView>();
             Model = Substitute.For<ITestModel>();
-            Model.Services.UserSettings.Returns(new NUnit.TestUtilities.Fakes.UserSettings());
+            Model.Services.UserSettings.Returns(new TestCentric.TestUtilities.Fakes.UserSettings());
 
             Presenter = new MainPresenter(View, Model, new CommandLineOptions());
         }

--- a/src/Experimental/tests/Presenters/PresenterTestBase.cs
+++ b/src/Experimental/tests/Presenters/PresenterTestBase.cs
@@ -27,7 +27,7 @@ using System.Xml;
 using NSubstitute;
 using NUnit.Framework;
 
-using FakeUserSettings = NUnit.TestUtilities.Fakes.UserSettings;
+using FakeUserSettings = TestCentric.TestUtilities.Fakes.UserSettings;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/Experimental/tests/Presenters/TestTree/CommandTests.cs
+++ b/src/Experimental/tests/Presenters/TestTree/CommandTests.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
 using NSubstitute;
 

--- a/src/Experimental/tests/Presenters/TestTree/NUnitTreeDisplayStrategyTests.cs
+++ b/src/Experimental/tests/Presenters/TestTree/NUnitTreeDisplayStrategyTests.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
 using NSubstitute;
 
@@ -43,7 +43,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             _view = Substitute.For<ITestTreeView>();
             _model = Substitute.For<ITestModel>();
-            _settings = new NUnit.TestUtilities.Fakes.UserSettings();
+            _settings = new TestCentric.TestUtilities.Fakes.UserSettings();
             _model.Services.UserSettings.Returns(_settings);
 
             _strategy = GetDisplayStrategy();

--- a/src/Experimental/tests/Presenters/TestTree/TestTreePresenterTestBase.cs
+++ b/src/Experimental/tests/Presenters/TestTree/TestTreePresenterTestBase.cs
@@ -40,7 +40,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             _view = Substitute.For<ITestTreeView>();
             _model = Substitute.For<ITestModel>();
-            _model.Services.UserSettings.Returns(new NUnit.TestUtilities.Fakes.UserSettings());
+            _model.Services.UserSettings.Returns(new TestCentric.TestUtilities.Fakes.UserSettings());
 
             new TreeViewPresenter(_view, _model);
 

--- a/src/Experimental/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/Experimental/tests/Presenters/TreeViewPresenterTests.cs
@@ -42,7 +42,7 @@ namespace TestCentric.Gui.Presenters
         {
             _view = Substitute.For<ITestTreeView>();
             _model = Substitute.For<ITestModel>();
-            _model.Services.UserSettings.Returns(new NUnit.TestUtilities.Fakes.UserSettings());
+            _model.Services.UserSettings.Returns(new TestCentric.TestUtilities.Fakes.UserSettings());
 
             _presenter = new TreeViewPresenter(_view, _model);
 

--- a/src/Experimental/tests/Presenters/UserSettingsFake.cs
+++ b/src/Experimental/tests/Presenters/UserSettingsFake.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -24,9 +24,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.Gui.Presenters
+namespace TestCentric.Gui.Presenters
 {
     // TODO: With latest changes, this is no longer used.
     // Keeping it for a while, as we may end up wanting

--- a/src/GuiException/tests/data/TestResource.cs
+++ b/src/GuiException/tests/data/TestResource.cs
@@ -24,7 +24,7 @@
 
 namespace NUnit.UiException.Tests.data
 {
-    public class TestResource : NUnit.TestUtilities.TempResourceFile
+    public class TestResource : TestCentric.TestUtilities.TempResourceFile
     {
         public TestResource(string name)
             : base(typeof(TestResource), name)

--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -25,7 +25,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui
 {

--- a/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
@@ -23,7 +23,7 @@
 
 using System;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -29,7 +29,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -27,7 +27,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/TestCentric/tests/Presenters/PresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/PresenterTestBase.cs
@@ -27,7 +27,7 @@ using System.Xml;
 using NSubstitute;
 using NUnit.Framework;
 
-using FakeUserSettings = NUnit.TestUtilities.Fakes.UserSettings;
+using FakeUserSettings = TestCentric.TestUtilities.Fakes.UserSettings;
 
 namespace TestCentric.Gui.Presenters
 {

--- a/src/TestCentric/tests/Views/ErrorsAndFailuresViewTests.cs
+++ b/src/TestCentric/tests/Views/ErrorsAndFailuresViewTests.cs
@@ -23,7 +23,7 @@
 
 using System.Windows.Forms;
 using NUnit.Framework;
-using NUnit.TestUtilities;
+using TestCentric.TestUtilities;
 
 namespace TestCentric.Gui.Views
 {

--- a/src/TestEngine/agents/AgentExitCodes.cs
+++ b/src/TestEngine/agents/AgentExitCodes.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Common
+namespace TestCentric.Common
 {
     internal static class AgentExitCodes
     {

--- a/src/TestEngine/agents/Program.cs
+++ b/src/TestEngine/agents/Program.cs
@@ -8,14 +8,14 @@ using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Security;
-using NUnit.Common;
-using NUnit.Engine;
-using NUnit.Engine.Agents;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services;
-using NUnit.Engine.Helpers;
+using TestCentric.Common;
+using TestCentric.Engine;
+using TestCentric.Engine.Agents;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Agent
+namespace TestCentric.Agent
 {
     public class NUnitTestAgent
     {

--- a/src/TestEngine/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
+++ b/src/TestEngine/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
@@ -5,7 +5,7 @@
 
 using NUnit.Framework;
 
-namespace NUnit.Tests
+namespace TestCentric.Tests
 {
     public class AccessesCurrentTestContextDuringDiscovery
     {

--- a/src/TestEngine/mock-assembly/MockAssembly.cs
+++ b/src/TestEngine/mock-assembly/MockAssembly.cs
@@ -7,7 +7,7 @@ using System;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace NUnit.Tests
+namespace TestCentric.Tests
 {
     namespace Assemblies
     {

--- a/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineException.cs
+++ b/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineException.cs
@@ -8,7 +8,7 @@ using System;
 using System.Runtime.Serialization;
 #endif
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// NUnitEngineException is thrown when the engine has been

--- a/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineNotFoundException.cs
+++ b/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineNotFoundException.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The exception that is thrown if a valid test engine is not found

--- a/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineUnloadException.cs
+++ b/src/TestEngine/testcentric.engine.api/Exceptions/NUnitEngineUnloadException.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 #endif
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
 
     /// <summary>

--- a/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionAttribute.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionAttribute.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The ExtensionAttribute is used to identify a class that is intended
@@ -15,7 +15,7 @@ namespace NUnit.Engine.Extensibility
     public class ExtensionAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NUnit.Engine.Extensibility.ExtensionAttribute"/> class.
+        /// Initializes a new instance of the <see cref="TestCentric.Engine.Extensibility.ExtensionAttribute"/> class.
         /// </summary>
         public ExtensionAttribute()
         {

--- a/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionPointAttribute.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionPointAttribute.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// ExtensionPointAttribute is used at the assembly level to identify and

--- a/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionPropertyAttribute.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/ExtensionPropertyAttribute.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The ExtensionPropertyAttribute is used to specify named properties for an extension.

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IDriverFactory.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IDriverFactory.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Reflection;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// Interface implemented by a Type that knows how to create a driver for a test assembly.

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IExtensionNode.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IExtensionNode.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The IExtensionNode interface is implemented by a class that represents a
@@ -20,7 +20,7 @@ namespace NUnit.Engine.Extensibility
         string TypeName { get; }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="NUnit.Engine.Extensibility.IExtensionNode"/> is enabled.
+        /// Gets a value indicating whether this <see cref="TestCentric.Engine.Extensibility.IExtensionNode"/> is enabled.
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
         bool Enabled { get; }

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IExtensionPoint.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IExtensionPoint.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// An ExtensionPoint represents a single point in the TestEngine

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IFrameworkDriver.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IFrameworkDriver.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Xml;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The IFrameworkDriver interface is implemented by a class that

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IProject.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IProject.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// Interface for the various project types that the engine can load.

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IProjectLoader.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IProjectLoader.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The IProjectLoader interface is implemented by any class

--- a/src/TestEngine/testcentric.engine.api/Extensibility/IResultWriter.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/IResultWriter.cs
@@ -6,7 +6,7 @@
 using System.IO;
 using System.Xml;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// Common interface for objects that process and write out test results

--- a/src/TestEngine/testcentric.engine.api/Extensibility/TypeExtensionPointAttribute.cs
+++ b/src/TestEngine/testcentric.engine.api/Extensibility/TypeExtensionPointAttribute.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// TypeExtensionPointAttribute is used to bind an extension point

--- a/src/TestEngine/testcentric.engine.api/IAvailableRuntimes.cs
+++ b/src/TestEngine/testcentric.engine.api/IAvailableRuntimes.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface that returns a list of available runtime frameworks.

--- a/src/TestEngine/testcentric.engine.api/IExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.api/IExtensionService.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The IExtensionService interface allows a runner to manage extensions.

--- a/src/TestEngine/testcentric.engine.api/ILogger.cs
+++ b/src/TestEngine/testcentric.engine.api/ILogger.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface for logging within the engine

--- a/src/TestEngine/testcentric.engine.api/ILogging.cs
+++ b/src/TestEngine/testcentric.engine.api/ILogging.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface to abstract getting loggers

--- a/src/TestEngine/testcentric.engine.api/IProjectService.cs
+++ b/src/TestEngine/testcentric.engine.api/IProjectService.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The IProjectService interface is implemented by ProjectService.

--- a/src/TestEngine/testcentric.engine.api/IResultService.cs
+++ b/src/TestEngine/testcentric.engine.api/IResultService.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System.Xml;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// IResultWriterService provides result writers for a specified

--- a/src/TestEngine/testcentric.engine.api/IRuntimeFramework.cs
+++ b/src/TestEngine/testcentric.engine.api/IRuntimeFramework.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface implemented by objects representing a runtime framework.

--- a/src/TestEngine/testcentric.engine.api/IRuntimeFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine.api/IRuntimeFrameworkService.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Implemented by a type that provides information about the

--- a/src/TestEngine/testcentric.engine.api/IService.cs
+++ b/src/TestEngine/testcentric.engine.api/IService.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Enumeration representing the status of a service

--- a/src/TestEngine/testcentric.engine.api/IServiceLocator.cs
+++ b/src/TestEngine/testcentric.engine.api/IServiceLocator.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// IServiceLocator allows clients to locate any NUnit services

--- a/src/TestEngine/testcentric.engine.api/ISettings.cs
+++ b/src/TestEngine/testcentric.engine.api/ISettings.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Event handler for settings changes

--- a/src/TestEngine/testcentric.engine.api/ITestEngine.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestEngine.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Xml;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// ITestEngine represents an instance of the test engine.

--- a/src/TestEngine/testcentric.engine.api/ITestEventListener.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestEventListener.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The ITestListener interface is used to receive notices of significant

--- a/src/TestEngine/testcentric.engine.api/ITestFilterBuilder.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestFilterBuilder.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface to a TestFilterBuilder, which is used to create TestFilters

--- a/src/TestEngine/testcentric.engine.api/ITestFilterService.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestFilterService.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The TestFilterService provides builders that can create TestFilters

--- a/src/TestEngine/testcentric.engine.api/ITestRun.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestRun.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The ITestRun class represents an ongoing test run.

--- a/src/TestEngine/testcentric.engine.api/ITestRunner.cs
+++ b/src/TestEngine/testcentric.engine.api/ITestRunner.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface implemented by all test runners.

--- a/src/TestEngine/testcentric.engine.api/InternalTraceLevel.cs
+++ b/src/TestEngine/testcentric.engine.api/InternalTraceLevel.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// InternalTraceLevel is an enumeration controlling the

--- a/src/TestEngine/testcentric.engine.api/TestEngineActivator.cs
+++ b/src/TestEngine/testcentric.engine.api/TestEngineActivator.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// TestEngineActivator creates an instance of the test engine and returns an ITestEngine interface.
@@ -19,13 +19,13 @@ namespace NUnit.Engine
         internal static readonly Version DefaultMinimumVersion = new Version(0, 0);
 
         private const string DefaultAssemblyName = "testcentric.engine.dll";
-        internal const string DefaultTypeName = "NUnit.Engine.TestEngine";
+        internal const string DefaultTypeName = "TestCentric.Engine.TestEngine";
 
 #if NETSTANDARD1_6
         /// <summary>
         /// Create an instance of the test engine.
         /// </summary>
-        /// <returns>An <see cref="NUnit.Engine.ITestEngine"/></returns>
+        /// <returns>An <see cref="TestCentric.Engine.ITestEngine"/></returns>
         public static ITestEngine CreateInstance()
         {
             var apiLocation = typeof(TestEngineActivator).GetTypeInfo().Assembly.Location;
@@ -40,7 +40,7 @@ namespace NUnit.Engine
         /// <summary>
         /// Create an instance of the test engine.
         /// </summary>
-        /// <returns>An <see cref="NUnit.Engine.ITestEngine"/></returns>
+        /// <returns>An <see cref="TestCentric.Engine.ITestEngine"/></returns>
         public static ITestEngine CreateInstance()
         {
             var apiLocation = typeof(TestEngineActivator).Assembly.Location;
@@ -57,7 +57,7 @@ namespace NUnit.Engine
         /// </summary>
         /// <param name="unused">This parameter is no longer used but has not been removed to ensure API compatibility.</param>
         /// <exception cref="NUnitEngineNotFoundException">Thrown when a test engine of the required minimum version is not found</exception>
-        /// <returns>An <see cref="NUnit.Engine.ITestEngine"/></returns>
+        /// <returns>An <see cref="TestCentric.Engine.ITestEngine"/></returns>
         public static ITestEngine CreateInstance(bool unused = false)
         {
             return CreateInstance(DefaultMinimumVersion, unused);

--- a/src/TestEngine/testcentric.engine.api/TestFilter.cs
+++ b/src/TestEngine/testcentric.engine.api/TestFilter.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Xml;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Abstract base for all test filters. A filter is represented

--- a/src/TestEngine/testcentric.engine.api/TestPackage.cs
+++ b/src/TestEngine/testcentric.engine.api/TestPackage.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// TestPackage holds information about a set of test files to

--- a/src/TestEngine/testcentric.engine.api/TestSelectionParserException.cs
+++ b/src/TestEngine/testcentric.engine.api/TestSelectionParserException.cs
@@ -8,7 +8,7 @@ using System;
 using System.Runtime.Serialization;
 #endif
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// TestSelectionParserException is thrown when an error

--- a/src/TestEngine/testcentric.engine.core.tests/Api/TestFilterTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Api/TestFilterTests.cs
@@ -6,7 +6,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Api
+namespace TestCentric.Engine.Api
 {
     public class TestFilterTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Api/TestPackageTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Api/TestPackageTests.cs
@@ -6,7 +6,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Api
+namespace TestCentric.Engine.Api
 {
     public class TestPackageTests_SingleAssembly
     {

--- a/src/TestEngine/testcentric.engine.core.tests/AsyncTestEngineResultTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/AsyncTestEngineResultTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.Xml;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class AsyncTestEngineResultTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Compatibility/FrameworkNameTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Compatibility/FrameworkNameTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.Runtime.Versioning;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Compatibility
+namespace TestCentric.Engine.Compatibility
 {
     /// <summary>
     /// Tests of our compatible implementation of FrameworkName, based on corefx implementation

--- a/src/TestEngine/testcentric.engine.core.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -7,12 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
+using TestCentric.Tests.Assemblies;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using NUnit.Tests.Assemblies;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     // Functional tests of the NUnitFrameworkDriver calling into the framework.
     public class NUnit3FrameworkDriverTests

--- a/src/TestEngine/testcentric.engine.core.tests/Drivers/NUnitNetStandardDriverTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Drivers/NUnitNetStandardDriverTests.cs
@@ -8,12 +8,12 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
-using NUnit.Tests.Assemblies;
+using TestCentric.Tests.Assemblies;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
 using NUnit.Framework;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Helpers;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     [TestOf(typeof(NUnitNetStandardDriver))]
     public class NUnitNetStandardDriverTests

--- a/src/TestEngine/testcentric.engine.core.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -8,10 +8,10 @@ using System.IO;
 using System.Xml;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     // Functional tests of the NUnitFrameworkDriver calling into the framework.
     public abstract class NotRunnableFrameworkDriverTests

--- a/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.Reflection;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     public class ExtensionAssemblyTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionSelectorTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionSelectorTests.cs
@@ -8,7 +8,7 @@ using System;
 using NSubstitute;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     internal class ExtensionSelectorTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/HangingAppDomainFixture.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/HangingAppDomainFixture.cs
@@ -7,7 +7,7 @@ using System;
 using System.Threading;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     [Explicit]
     public class HangingAppDomainFixture

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/AssemblyHelperTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/AssemblyHelperTests.cs
@@ -7,7 +7,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     [TestFixture]
     public class AssemblyHelperTests

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/DirectoryFinderTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/DirectoryFinderTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Text;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public class DirectoryFinderTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/PathUtilTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/PathUtilTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
 	[TestFixture]
 	public class PathUtilTests : PathUtils

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/ProcessUtilsTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/ProcessUtilsTests.cs
@@ -6,7 +6,7 @@
 using NUnit.Framework;
 using System.Text;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public static class ProcessUtilsTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/ResultHelperTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/ResultHelperTests.cs
@@ -4,11 +4,10 @@
 // ***********************************************************************
 
 using System.Xml;
+using NUnit.Framework;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
-    using Framework;
-
     public class ResultHelperTests
     {
         private const string resultText1 = "<test-assembly result=\"Passed\" total=\"23\" passed=\"23\" failed=\"0\" inconclusive=\"0\" skipped=\"0\" asserts=\"40\" />";

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/XmlHelperTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/XmlHelperTests.cs
@@ -6,7 +6,7 @@
 using System.Xml;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public class XmlHelperTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Integration/DirectoryWithNeededAssemblies.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Integration/DirectoryWithNeededAssemblies.cs
@@ -6,9 +6,9 @@
 #if !NETCOREAPP1_1
 using System;
 using System.IO;
-using NUnit.Engine.TestUtilities;
+using TestCentric.Engine.TestUtilities;
 
-namespace NUnit.Engine.Integration
+namespace TestCentric.Engine.Integration
 {
     internal sealed class DirectoryWithNeededAssemblies : IDisposable
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Integration/IntegrationTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Integration/IntegrationTests.cs
@@ -5,7 +5,7 @@
 
 using NUnit.Framework;
 
-namespace NUnit.Engine.Integration
+namespace TestCentric.Engine.Integration
 {
     [TestFixture, Category("Integration")]
     public abstract class IntegrationTests

--- a/src/TestEngine/testcentric.engine.core.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
@@ -8,7 +8,7 @@ using System;
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Integration
+namespace TestCentric.Engine.Integration
 {
     internal sealed class MockAssemblyInDirectoryWithFramework : IDisposable
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Integration/RemoteAgentTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Integration/RemoteAgentTests.cs
@@ -5,10 +5,10 @@
 
 #if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System.Diagnostics;
-using NUnit.Engine.TestUtilities;
+using TestCentric.Engine.TestUtilities;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Integration
+namespace TestCentric.Engine.Integration
 {
     public sealed class RemoteAgentTests : IntegrationTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Integration/RunnerInDirectoryWithoutFramework.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Integration/RunnerInDirectoryWithoutFramework.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Threading;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Integration
+namespace TestCentric.Engine.Integration
 {
     internal sealed class RunnerInDirectoryWithoutFramework : IDisposable
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Internal/Extensibility/ExtensionAttributeTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Internal/Extensibility/ExtensionAttributeTests.cs
@@ -6,7 +6,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     public class ExtensionAttributeTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Internal/TcpChannelUtilsTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Internal/TcpChannelUtilsTests.cs
@@ -7,11 +7,11 @@
 using System;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
-using NUnit.Engine.TestUtilities;
+using TestCentric.Engine.TestUtilities;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     [TestFixture]
     [Parallelizable(ParallelScope.None)] // GetTcpChannel affects the whole AppDomain

--- a/src/TestEngine/testcentric.engine.core.tests/Program.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Program.cs
@@ -7,7 +7,7 @@
 using System.Reflection;
 using NUnitLite;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     class Program
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Runners/DirectTestRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Runners/DirectTestRunnerTests.cs
@@ -7,10 +7,10 @@ using System;
 using System.Collections.Generic;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     using Fakes;
 

--- a/src/TestEngine/testcentric.engine.core.tests/Runners/Fakes/EmptyDirectTestRunner.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Runners/Fakes/EmptyDirectTestRunner.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NUnit.Engine.Runners.Fakes
+namespace TestCentric.Engine.Runners.Fakes
 {
     internal class EmptyDirectTestRunner : Engine.Runners.DirectTestRunner
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.Threading;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public class ParallelTaskWorkerPoolTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/RuntimeFrameworkTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/RuntimeFrameworkTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.Runtime.Versioning;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     using Helpers;
 

--- a/src/TestEngine/testcentric.engine.core.tests/RuntimeTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/RuntimeTests.cs
@@ -6,7 +6,7 @@
 using System.Reflection;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public static class RuntimeTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerStaticTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerStaticTests.cs
@@ -10,7 +10,7 @@ using System.Configuration;
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public static class DomainManagerStaticTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerTests.cs
@@ -7,9 +7,9 @@
 using System;
 using System.IO;
 using NUnit.Framework;
-using NUnit.Tests.Assemblies;
+using TestCentric.Tests.Assemblies;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class DomainManagerTests
     {

--- a/src/TestEngine/testcentric.engine.core.tests/Services/DriverServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Services/DriverServiceTests.cs
@@ -6,9 +6,9 @@
 using System;
 using System.IO;
 using NUnit.Framework;
-using NUnit.Engine.Drivers;
+using TestCentric.Engine.Drivers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     [TestFixture]
     public class DriverServiceTests

--- a/src/TestEngine/testcentric.engine.core.tests/Services/InProcessTestRunnerFactoryTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Services/InProcessTestRunnerFactoryTests.cs
@@ -4,10 +4,10 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Runners;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     //using Fakes;
 

--- a/src/TestEngine/testcentric.engine.core.tests/TestEngineResultTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/TestEngineResultTests.cs
@@ -4,10 +4,10 @@
 // ***********************************************************************
 
 using System.Xml;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     [TestFixture]
     public class TestEngineResultTests

--- a/src/TestEngine/testcentric.engine.core.tests/TestUtilities/On.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/TestUtilities/On.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Threading;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class On
     {

--- a/src/TestEngine/testcentric.engine.core.tests/TestUtilities/ProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/TestUtilities/ProcessRunner.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class ProcessRunner
     {

--- a/src/TestEngine/testcentric.engine.core.tests/TestUtilities/ShadowCopyUtils.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/TestUtilities/ShadowCopyUtils.cs
@@ -11,7 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class ShadowCopyUtils
     {

--- a/src/TestEngine/testcentric.engine.core.tests/TestUtilities/StackEnumerator.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/TestUtilities/StackEnumerator.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class StackEnumerator
     {

--- a/src/TestEngine/testcentric.engine.core.tests/WorkingDirectoryTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/WorkingDirectoryTests.cs
@@ -6,7 +6,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     [NonParallelizable]
     class WorkingDirectoryTests

--- a/src/TestEngine/testcentric.engine.core/Agents/RemoteTestAgent.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/RemoteTestAgent.cs
@@ -8,10 +8,10 @@ using System;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Threading;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Agents
+namespace TestCentric.Engine.Agents
 {
     /// <summary>
     /// RemoteTestAgent represents a remote agent executing in another process

--- a/src/TestEngine/testcentric.engine.core/Agents/TestAgent.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/TestAgent.cs
@@ -6,7 +6,7 @@
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 
-namespace NUnit.Engine.Agents
+namespace TestCentric.Engine.Agents
 {
     /// <summary>
     /// Abstract base for all types of TestAgents.

--- a/src/TestEngine/testcentric.engine.core/AsyncTestEngineResult.cs
+++ b/src/TestEngine/testcentric.engine.core/AsyncTestEngineResult.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Threading;
 using System.Xml;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The TestRun class encapsulates an ongoing test run.

--- a/src/TestEngine/testcentric.engine.core/CallbackHandler.cs
+++ b/src/TestEngine/testcentric.engine.core/CallbackHandler.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Web.UI;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class CallbackHandler : MarshalByRefObject, ICallbackEventHandler
     {

--- a/src/TestEngine/testcentric.engine.core/Compatibility/FrameworkName.cs
+++ b/src/TestEngine/testcentric.engine.core/Compatibility/FrameworkName.cs
@@ -5,7 +5,7 @@
 
 #if NET20 || NET35
 using System.Diagnostics;
-using NUnit.Common;
+using TestCentric.Common;
 
 namespace System.Runtime.Versioning
 {

--- a/src/TestEngine/testcentric.engine.core/CoreEngine.cs
+++ b/src/TestEngine/testcentric.engine.core/CoreEngine.cs
@@ -8,11 +8,11 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The CoreEngine provides services that are used by both

--- a/src/TestEngine/testcentric.engine.core/Drivers/NUnit2DriverFactory.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NUnit2DriverFactory.cs
@@ -7,10 +7,10 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     public class NUnit2DriverFactory : IDriverFactory
     {

--- a/src/TestEngine/testcentric.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -5,10 +5,10 @@
 
 using System;
 using System.Reflection;
-using NUnit.Common;
-using NUnit.Engine.Extensibility;
+using TestCentric.Common;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     public class NUnit3DriverFactory : IDriverFactory
     {

--- a/src/TestEngine/testcentric.engine.core/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NUnit3FrameworkDriver.cs
@@ -9,11 +9,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
-using NUnit.Common;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Extensibility;
+using TestCentric.Common;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     /// <summary>
     /// NUnitFrameworkDriver is used by the test-runner to load and run

--- a/src/TestEngine/testcentric.engine.core/Drivers/NUnitNetStandardDriver.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NUnitNetStandardDriver.cs
@@ -7,12 +7,12 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 using System.Reflection;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 using Mono.Cecil;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     /// <summary>
     /// NUnitNetStandardDriver is used by the test-runner to load and run

--- a/src/TestEngine/testcentric.engine.core/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NotRunnableFrameworkDriver.cs
@@ -5,10 +5,10 @@
 
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 using System.Reflection;
 
-namespace NUnit.Engine.Drivers
+namespace TestCentric.Engine.Drivers
 {
     public abstract class NotRunnableFrameworkDriver : IFrameworkDriver
     {

--- a/src/TestEngine/testcentric.engine.core/EnginePackageSettings.cs
+++ b/src/TestEngine/testcentric.engine.core/EnginePackageSettings.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit
+namespace TestCentric
 {
     /// <summary>
     /// EngineSettings contains constant values that

--- a/src/TestEngine/testcentric.engine.core/Extensibility/EngineExtensionPoints.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/EngineExtensionPoints.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
 // Extension points supported by the engine
 

--- a/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionAssembly.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionAssembly.cs
@@ -7,9 +7,9 @@
 using System;
 using System.IO;
 using Mono.Cecil;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     internal class ExtensionAssembly : IExtensionAssembly
     {

--- a/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionNode.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionNode.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 using System.Linq;
 #endif
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// The ExtensionNode class represents a single extension being installed
@@ -52,7 +52,7 @@ namespace NUnit.Engine.Extensibility
         public IRuntimeFramework TargetFramework { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
+        /// Gets or sets a value indicating whether this <see cref="TestCentric.Engine.Extensibility.ExtensionNode"/> is enabled.
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
         public bool Enabled	{ get; set; }

--- a/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionPoint.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionPoint.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     /// <summary>
     /// An ExtensionPoint represents a single point in the TestEngine

--- a/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionSelector.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionSelector.cs
@@ -5,9 +5,9 @@
 
 #if !NETSTANDARD1_6
 using System;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     internal static class ExtensionSelector
     {

--- a/src/TestEngine/testcentric.engine.core/Extensibility/IExtensionAssembly.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/IExtensionAssembly.cs
@@ -6,7 +6,7 @@
 #if !NETSTANDARD1_6
 using System;
 
-namespace NUnit.Engine.Extensibility
+namespace TestCentric.Engine.Extensibility
 {
     internal interface IExtensionAssembly
     {

--- a/src/TestEngine/testcentric.engine.core/FrameworkIdentifers.cs
+++ b/src/TestEngine/testcentric.engine.core/FrameworkIdentifers.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public static class FrameworkIdentifiers
     {

--- a/src/TestEngine/testcentric.engine.core/Guard.cs
+++ b/src/TestEngine/testcentric.engine.core/Guard.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Common
+namespace TestCentric.Common
 {
     /// <summary>
     /// Class used to guard against unexpected argument values

--- a/src/TestEngine/testcentric.engine.core/Helpers/AssemblyHelper.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/AssemblyHelper.cs
@@ -8,7 +8,7 @@ using System;
 using System.IO;
 using System.Reflection;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// AssemblyHelper provides static methods for working

--- a/src/TestEngine/testcentric.engine.core/Helpers/CecilExtensions.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/CecilExtensions.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using Mono.Cecil;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// Extension methods that make it easier to work with Mono.Cecil.

--- a/src/TestEngine/testcentric.engine.core/Helpers/DirectoryFinder.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/DirectoryFinder.cs
@@ -7,9 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// DirectoryFinder is a utility class used for extended wildcard

--- a/src/TestEngine/testcentric.engine.core/Helpers/ExceptionHelper.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/ExceptionHelper.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public static class ExceptionHelper
     {

--- a/src/TestEngine/testcentric.engine.core/Helpers/NUnitConfiguration.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/NUnitConfiguration.cs
@@ -8,9 +8,9 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// Provides static methods for accessing configuration info

--- a/src/TestEngine/testcentric.engine.core/Helpers/PathUtils.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/PathUtils.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Text;
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// Static methods for manipulating project paths, including both directories

--- a/src/TestEngine/testcentric.engine.core/Helpers/ProcessUtils.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/ProcessUtils.cs
@@ -5,7 +5,7 @@
 
 using System.Text;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public static class ProcessUtils
     {

--- a/src/TestEngine/testcentric.engine.core/Helpers/ResultHelper.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/ResultHelper.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Xml;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// ResultHelper provides static methods for working with

--- a/src/TestEngine/testcentric.engine.core/Helpers/TestPackageExtensions.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/TestPackageExtensions.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     public delegate bool TestPackageSelectorDelegate(TestPackage p);
 

--- a/src/TestEngine/testcentric.engine.core/Helpers/XmlHelper.cs
+++ b/src/TestEngine/testcentric.engine.core/Helpers/XmlHelper.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.CompilerServices
     sealed class ExtensionAttribute : Attribute { }
 }
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// XmlHelper provides static methods for basic XML operations.

--- a/src/TestEngine/testcentric.engine.core/IDriverService.cs
+++ b/src/TestEngine/testcentric.engine.core/IDriverService.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The IDriverService interface is implemented by the driver service, which is able

--- a/src/TestEngine/testcentric.engine.core/ITestAgency.cs
+++ b/src/TestEngine/testcentric.engine.core/ITestAgency.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The ITestAgency interface is implemented by a TestAgency in 

--- a/src/TestEngine/testcentric.engine.core/ITestAgent.cs
+++ b/src/TestEngine/testcentric.engine.core/ITestAgent.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The ITestAgent interface is implemented by remote test agents.

--- a/src/TestEngine/testcentric.engine.core/ITestEngineRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/ITestEngineRunner.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Interface implemented by all internal test runners in

--- a/src/TestEngine/testcentric.engine.core/ITestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine.core/ITestRunnerFactory.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// A Test Runner factory can supply a suitable test runner for a given package

--- a/src/TestEngine/testcentric.engine.core/Internal/CurrentMessageCounter.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/CurrentMessageCounter.cs
@@ -5,7 +5,7 @@
 
 using System.Threading;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     public sealed class CurrentMessageCounter
     {

--- a/src/TestEngine/testcentric.engine.core/Internal/DomainDetailsBuilder.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/DomainDetailsBuilder.cs
@@ -8,9 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Helpers
+namespace TestCentric.Engine.Helpers
 {
     /// <summary>
     /// DomainDetailsBuilder provides human readable information on

--- a/src/TestEngine/testcentric.engine.core/Internal/DomainUsage.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/DomainUsage.cs
@@ -4,7 +4,7 @@
 // ***********************************************************************
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// Represents the manner in which test assemblies use

--- a/src/TestEngine/testcentric.engine.core/Internal/Logging/InternalTrace.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/Logging/InternalTrace.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// InternalTrace provides facilities for tracing the execution

--- a/src/TestEngine/testcentric.engine.core/Internal/Logging/InternalTraceWriter.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/Logging/InternalTraceWriter.cs
@@ -5,7 +5,7 @@
 
 using System.IO;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// A trace listener that writes to a separate file per domain

--- a/src/TestEngine/testcentric.engine.core/Internal/Logging/Logger.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/Logging/Logger.cs
@@ -6,7 +6,7 @@
 using System;
 using System.IO;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// Provides internal logging to the NUnit framework

--- a/src/TestEngine/testcentric.engine.core/Internal/ProvidedPathsAssemblyResolver.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/ProvidedPathsAssemblyResolver.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using System.IO;
 using System.Diagnostics;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     public class ProvidedPathsAssemblyResolver
     {

--- a/src/TestEngine/testcentric.engine.core/Internal/ServerBase.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/ServerBase.cs
@@ -10,7 +10,7 @@ using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// Summary description for ServerBase.

--- a/src/TestEngine/testcentric.engine.core/Internal/TargetFrameworkHelper.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/TargetFrameworkHelper.cs
@@ -6,7 +6,7 @@
 using System;
 using Mono.Cecil;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     public class TargetFrameworkHelper
     {

--- a/src/TestEngine/testcentric.engine.core/Internal/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Messaging;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     partial class TcpChannelUtils
     {

--- a/src/TestEngine/testcentric.engine.core/Internal/TcpChannelUtils.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/TcpChannelUtils.cs
@@ -11,9 +11,9 @@ using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Runtime.Serialization.Formatters;
 using System.Threading;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// A collection of utility methods used to create, retrieve

--- a/src/TestEngine/testcentric.engine.core/InternalEnginePackageSettings.cs
+++ b/src/TestEngine/testcentric.engine.core/InternalEnginePackageSettings.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// InternalEngineSettings contains constant values that

--- a/src/TestEngine/testcentric.engine.core/RunTestsCallbackHandler.cs
+++ b/src/TestEngine/testcentric.engine.core/RunTestsCallbackHandler.cs
@@ -8,7 +8,7 @@ using System;
 using System.Diagnostics;
 using System.Web.UI;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class RunTestsCallbackHandler : MarshalByRefObject, ICallbackEventHandler
     {

--- a/src/TestEngine/testcentric.engine.core/Runners/AbstractTestRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/AbstractTestRunner.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.ComponentModel;
-using NUnit.Engine.Services;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// AbstractTestRunner is the base class for all internal runners

--- a/src/TestEngine/testcentric.engine.core/Runners/AggregatingTestRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/AggregatingTestRunner.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// AggregatingTestRunner runs tests using multiple

--- a/src/TestEngine/testcentric.engine.core/Runners/DirectTestRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/DirectTestRunner.cs
@@ -6,11 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// DirectTestRunner is the abstract base for runners

--- a/src/TestEngine/testcentric.engine.core/Runners/ITestExecutionTask.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/ITestExecutionTask.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public interface ITestExecutionTask
     {

--- a/src/TestEngine/testcentric.engine.core/Runners/LocalTestRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/LocalTestRunner.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// LocalTestRunner runs tests in the current application domain.

--- a/src/TestEngine/testcentric.engine.core/Runners/MultipleTestDomainRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/MultipleTestDomainRunner.cs
@@ -4,7 +4,7 @@
 // ***********************************************************************
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// MultipleTestDomainRunner runs tests using separate

--- a/src/TestEngine/testcentric.engine.core/Runners/ParallelTaskWorkerPool.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/ParallelTaskWorkerPool.cs
@@ -8,9 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public class ParallelTaskWorkerPool
     {

--- a/src/TestEngine/testcentric.engine.core/Runners/TestDomainRunner.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/TestDomainRunner.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-using NUnit.Engine.Services;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// TestDomainRunner loads and runs tests in a separate

--- a/src/TestEngine/testcentric.engine.core/Runners/TestExecutionTask.cs
+++ b/src/TestEngine/testcentric.engine.core/Runners/TestExecutionTask.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public class TestExecutionTask : ITestExecutionTask
     {

--- a/src/TestEngine/testcentric.engine.core/Runtime.cs
+++ b/src/TestEngine/testcentric.engine.core/Runtime.cs
@@ -8,7 +8,7 @@ using System;
 using System.Linq;
 #endif
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Runtime class represents a specific Runtime, which may be

--- a/src/TestEngine/testcentric.engine.core/RuntimeFramework.cs
+++ b/src/TestEngine/testcentric.engine.core/RuntimeFramework.cs
@@ -9,9 +9,9 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
-using NUnit.Common;
+using TestCentric.Common;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     using Helpers;
 

--- a/src/TestEngine/testcentric.engine.core/RuntimeType.cs
+++ b/src/TestEngine/testcentric.engine.core/RuntimeType.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Enumeration identifying all known (to the engine) runtimes

--- a/src/TestEngine/testcentric.engine.core/ServiceContext.cs
+++ b/src/TestEngine/testcentric.engine.core/ServiceContext.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Services;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The ServiceContext is used by services, runners and

--- a/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
@@ -14,11 +14,11 @@ using System.Diagnostics;
 using System.Security;
 using System.Security.Policy;
 using System.Security.Principal;
-using NUnit.Common;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Helpers;
+using TestCentric.Common;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// The DomainManager class handles the creation and unloading

--- a/src/TestEngine/testcentric.engine.core/Services/DriverService.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/DriverService.cs
@@ -8,12 +8,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Mono.Cecil;
-using NUnit.Common;
-using NUnit.Engine.Drivers;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Helpers;
+using TestCentric.Common;
+using TestCentric.Engine.Drivers;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// The DriverService provides drivers able to load and run tests

--- a/src/TestEngine/testcentric.engine.core/Services/ExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/ExtensionService.cs
@@ -9,11 +9,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Mono.Cecil;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// The ExtensionService discovers ExtensionPoints and Extensions and
@@ -418,7 +418,7 @@ namespace NUnit.Engine.Services
 
                 foreach (var type in assembly.MainModule.GetTypes())
                 {
-                    CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");
+                    CustomAttribute extensionAttr = type.GetAttribute("TestCentric.Engine.Extensibility.ExtensionAttribute");
 
                     if (extensionAttr == null)
                         continue;
@@ -437,7 +437,7 @@ namespace NUnit.Engine.Services
 
                     log.Info("  Found ExtensionAttribute on Type " + type.Name);
 
-                    foreach (var attr in type.GetAttributes("NUnit.Engine.Extensibility.ExtensionPropertyAttribute"))
+                    foreach (var attr in type.GetAttributes("TestCentric.Engine.Extensibility.ExtensionPropertyAttribute"))
                     {
                         string name = attr.ConstructorArguments[0].Value as string;
                         string value = attr.ConstructorArguments[1].Value as string;

--- a/src/TestEngine/testcentric.engine.core/Services/InProcessTestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/InProcessTestRunnerFactory.cs
@@ -3,11 +3,11 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Runners;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// InProcessTestRunnerFactory handles creation of a suitable test

--- a/src/TestEngine/testcentric.engine.core/Services/Service.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/Service.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// Abstract base class for services that can use it. Some Services

--- a/src/TestEngine/testcentric.engine.core/Services/ServiceManager.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/ServiceManager.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// ServiceManager handles access to all services - global

--- a/src/TestEngine/testcentric.engine.core/TestEngineResult.cs
+++ b/src/TestEngine/testcentric.engine.core/TestEngineResult.cs
@@ -7,9 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Xml;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// Wrapper class for the xml-formatted results produced

--- a/src/TestEngine/testcentric.engine.tests/Api/ServiceLocatorTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Api/ServiceLocatorTests.cs
@@ -6,7 +6,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Api
+namespace TestCentric.Engine.Api
 
 {
     public class ServiceLocatorTests

--- a/src/TestEngine/testcentric.engine.tests/DummyExtensions.cs
+++ b/src/TestEngine/testcentric.engine.tests/DummyExtensions.cs
@@ -8,9 +8,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Xml;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     [Extension]
     public class DummyFrameworkDriverExtension : IDriverFactory

--- a/src/TestEngine/testcentric.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Internal/SettingsGroupTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using System.Drawing;
 #endif
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     [TestFixture]
     public class SettingsGroupTests

--- a/src/TestEngine/testcentric.engine.tests/Internal/SettingsStoreTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Internal/SettingsStoreTests.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Xml.Schema;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     [TestFixture]
     public class SettingsStoreTests

--- a/src/TestEngine/testcentric.engine.tests/Program.cs
+++ b/src/TestEngine/testcentric.engine.tests/Program.cs
@@ -7,7 +7,7 @@
 using System.Reflection;
 using NUnitLite;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     class Program
     {

--- a/src/TestEngine/testcentric.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -9,12 +9,12 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using NUnit.Framework;
-using NUnit.Tests.Assemblies;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Services;
-using NUnit.Engine.Services.Fakes;
+using TestCentric.Tests.Assemblies;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Services;
+using TestCentric.Engine.Services.Fakes;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     [TestFixtureSource(nameof(FixtureData))]
     public class MasterTestRunnerTests : ITestEventListener

--- a/src/TestEngine/testcentric.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
@@ -7,7 +7,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public class MultipleTestProcessRunnerTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -7,11 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 using NUnit.Framework;
-using NUnit.Tests.Assemblies;
+using TestCentric.Tests.Assemblies;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     // Temporarily commenting out Process tests due to
     // intermittent errors, probably due to the test

--- a/src/TestEngine/testcentric.engine.tests/Runners/TestPackageValidatorTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/TestPackageValidatorTests.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 using NSubstitute;
 
 #if !NETCOREAPP1_1 && !NETCOREAPP2_1
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     public class TestPackageValidatorTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
@@ -6,7 +6,7 @@
 #if !NETCOREAPP1_1 && !NETCOREAPP2_0
 using System;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public partial class AgentStoreTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/AgentStoreTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/AgentStoreTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using System.Threading;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public static partial class AgentStoreTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ExtensionServiceTests.cs
@@ -7,13 +7,13 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class ExtensionServiceTests
     {
@@ -87,12 +87,12 @@ namespace NUnit.Engine.Services
 
 #pragma warning disable 414
         private static readonly string[] KnownExtensions = {
-            "NUnit.Engine.DummyFrameworkDriverExtension",
-            "NUnit.Engine.DummyProjectLoaderExtension",
-            "NUnit.Engine.DummyResultWriterExtension",
-            "NUnit.Engine.DummyEventListenerExtension",
-            "NUnit.Engine.DummyServiceExtension",
-            "NUnit.Engine.V2DriverExtension"
+            "TestCentric.Engine.DummyFrameworkDriverExtension",
+            "TestCentric.Engine.DummyProjectLoaderExtension",
+            "TestCentric.Engine.DummyResultWriterExtension",
+            "TestCentric.Engine.DummyEventListenerExtension",
+            "TestCentric.Engine.DummyServiceExtension",
+            "TestCentric.Engine.V2DriverExtension"
         };
 #pragma warning restore 414
 
@@ -119,17 +119,17 @@ namespace NUnit.Engine.Services
         public void ExtensionMayBeDisabledByDefault()
         {
             Assert.That(_serviceInterface.Extensions,
-                Has.One.Property(nameof(ExtensionNode.TypeName)).EqualTo("NUnit.Engine.DummyDisabledExtension")
+                Has.One.Property(nameof(ExtensionNode.TypeName)).EqualTo("TestCentric.Engine.DummyDisabledExtension")
                    .And.Property(nameof(ExtensionNode.Enabled)).False);
         }
 
         [Test]
         public void DisabledExtensionMayBeEnabled()
         {
-            _serviceInterface.EnableExtension("NUnit.Engine.DummyDisabledExtension", true);
+            _serviceInterface.EnableExtension("TestCentric.Engine.DummyDisabledExtension", true);
 
             Assert.That(_serviceInterface.Extensions,
-                Has.One.Property(nameof(ExtensionNode.TypeName)).EqualTo("NUnit.Engine.DummyDisabledExtension")
+                Has.One.Property(nameof(ExtensionNode.TypeName)).EqualTo("TestCentric.Engine.DummyDisabledExtension")
                    .And.Property(nameof(ExtensionNode.Enabled)).True);
         }
 

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Services.Fakes
+namespace TestCentric.Engine.Services.Fakes
 {
     public class FakeProjectService : FakeService, IProjectService
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace NUnit.Engine.Services.Fakes
+namespace TestCentric.Engine.Services.Fakes
 {
     public class FakeRuntimeService : FakeService, IRuntimeFrameworkService
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeService.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine.Services.Fakes
+namespace TestCentric.Engine.Services.Fakes
 {
     public class FakeService : IService
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeSettingsService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeSettingsService.cs
@@ -4,9 +4,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services.Fakes
+namespace TestCentric.Engine.Services.Fakes
 {
     public class FakeSettingsService : SettingsStore, IService
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
@@ -7,7 +7,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class ProjectServiceTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/ResultServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ResultServiceTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class ResultServiceTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/ResultWriters/XmlOutputTest.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ResultWriters/XmlOutputTest.cs
@@ -7,15 +7,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
+using NUnit.Framework;
 
-namespace NUnit.Engine.Services.ResultWriters
+namespace TestCentric.Engine.Services.ResultWriters
 {
-    using Engine;
-    using Engine.Internal;
-    using Framework;
-
     using Runner = NUnit.Framework.Api.NUnitTestAssemblyRunner;
     using Builder = NUnit.Framework.Api.DefaultTestAssemblyBuilder;
     using TestListener = NUnit.Framework.Internal.TestListener;

--- a/src/TestEngine/testcentric.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
@@ -7,7 +7,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.ResultWriters
+namespace TestCentric.Engine.Services.ResultWriters
 {
     public class XmlTransformResultWriterTests : XmlOutputTest
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class RuntimeFrameworkServiceTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/ServiceDependencyTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ServiceDependencyTests.cs
@@ -6,7 +6,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     using Fakes;
 

--- a/src/TestEngine/testcentric.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ServiceManagerTests.cs
@@ -6,7 +6,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     using Fakes;
 

--- a/src/TestEngine/testcentric.engine.tests/Services/SettingsServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/SettingsServiceTests.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class SettingsServiceTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TestAgencyTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestAgencyTests.cs
@@ -6,7 +6,7 @@
 #if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     using Fakes;
 

--- a/src/TestEngine/testcentric.engine.tests/Services/TestFilterBuilderTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestFilterBuilderTests.cs
@@ -5,10 +5,10 @@
 
 using System;
 using System.Xml;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class TestFilterBuilderTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TestFilteringTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestFilteringTests.cs
@@ -7,9 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
-using NUnit.Tests.Assemblies;
+using TestCentric.Tests.Assemblies;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     using Drivers;
 
@@ -38,13 +38,13 @@ namespace NUnit.Engine.Services
 
         // TODO: Uncomment the "double negative" tests when we are using an updated framework that handles them correctly.
         [TestCase("<filter/>", MockAssembly.Tests)]
-        [TestCase("<filter><test>NUnit.Tests.Assemblies.MockTestFixture</test></filter>", MockTestFixture.Tests)]
-        //[TestCase("<filter><not><not><test>NUnit.Tests.Assemblies.MockTestFixture</test></not></not></filter>", MockTestFixture.Tests)]
-        [TestCase("<filter><test>NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest</test></filter>", 1)]
-        //[TestCase("<filter><not><not><test>NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest</test></not></not></filter>", 1)]
-        [TestCase("<filter><class>NUnit.Tests.Assemblies.MockTestFixture</class></filter>", MockTestFixture.Tests)]
+        [TestCase("<filter><test>TestCentric.Tests.Assemblies.MockTestFixture</test></filter>", MockTestFixture.Tests)]
+        //[TestCase("<filter><not><not><test>TestCentric.Tests.Assemblies.MockTestFixture</test></not></not></filter>", MockTestFixture.Tests)]
+        [TestCase("<filter><test>TestCentric.Tests.Assemblies.MockTestFixture.IgnoreTest</test></filter>", 1)]
+        //[TestCase("<filter><not><not><test>TestCentric.Tests.Assemblies.MockTestFixture.IgnoreTest</test></not></not></filter>", 1)]
+        [TestCase("<filter><class>TestCentric.Tests.Assemblies.MockTestFixture</class></filter>", MockTestFixture.Tests)]
         [TestCase("<filter><name>IgnoreTest</name></filter>", 1)]
-        [TestCase("<filter><name>MockTestFixture</name></filter>", MockTestFixture.Tests + NUnit.Tests.TestAssembly.MockTestFixture.Tests)]
+        [TestCase("<filter><name>MockTestFixture</name></filter>", MockTestFixture.Tests + TestCentric.Tests.TestAssembly.MockTestFixture.Tests)]
         [TestCase("<filter><method>IgnoreTest</method></filter>", 1)]
         [TestCase("<filter><cat>FixtureCategory</cat></filter>", MockTestFixture.Tests)]
         //[TestCase("<filter><not><not><cat>FixtureCategory</cat></not></not></filter>", MockTestFixture.Tests)]
@@ -53,8 +53,8 @@ namespace NUnit.Engine.Services
             Assert.That(_driver.CountTestCases(filter), Is.EqualTo(count));
         }
 
-        [TestCase("NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
-        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest", 1, TestName = "{m}_MockTest4")]
+        [TestCase("TestCentric.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
+        [TestCase("TestCentric.Tests.Assemblies.MockTestFixture.IgnoreTest", 1, TestName = "{m}_MockTest4")]
         public void UsingTestFilterBuilderAddTest(string testName, int count)
         {
             var builder = new TestFilterBuilder();
@@ -64,11 +64,11 @@ namespace NUnit.Engine.Services
 
         }
 
-        [TestCase("test==NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
-        [TestCase("test==NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest", 1, TestName = "{m}_MockTest4")]
-        [TestCase("class==NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests)]
+        [TestCase("test==TestCentric.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
+        [TestCase("test==TestCentric.Tests.Assemblies.MockTestFixture.IgnoreTest", 1, TestName = "{m}_MockTest4")]
+        [TestCase("class==TestCentric.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests)]
         [TestCase("name==IgnoreTest", 1)]
-        [TestCase("name==MockTestFixture", MockTestFixture.Tests + NUnit.Tests.TestAssembly.MockTestFixture.Tests)]
+        [TestCase("name==MockTestFixture", MockTestFixture.Tests + TestCentric.Tests.TestAssembly.MockTestFixture.Tests)]
         [TestCase("method==IgnoreTest", 1)]
         [TestCase("cat==FixtureCategory", MockTestFixture.Tests)]
         public void UsingTestFilterBuilderSelectWhere(string expression, int count)

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ExpectedRunnerResults.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ExpectedRunnerResults.cs
@@ -4,10 +4,10 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Runners;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests.Results
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests.Results
 {
 #if !NETCOREAPP
     internal static class Net20ExpectedRunnerResults

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Runners;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests
 {
     public class RunnerResult
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerResultComparer.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerResultComparer.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests
 {
     internal class RunnerResultComparer : IEqualityComparer<RunnerResult>
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -5,11 +5,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Engine.Runners;
-using NUnit.Engine.Services.TestRunnerFactoryTests.TestCases;
+using TestCentric.Engine.Runners;
+using TestCentric.Engine.Services.TestRunnerFactoryTests.TestCases;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests
 {
     using Fakes;
 

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20AssemblyTestCases.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20AssemblyTestCases.cs
@@ -6,12 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Runners;
-using NUnit.Engine.Services.TestRunnerFactoryTests.Results;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Runners;
+using TestCentric.Engine.Services.TestRunnerFactoryTests.Results;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests.TestCases
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests.TestCases
 {
 #if !NETCOREAPP
     internal static class Net20AssemblyTestCases

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20MixedProjectAndAssemblyTestCases.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20MixedProjectAndAssemblyTestCases.cs
@@ -7,11 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services.TestRunnerFactoryTests.Results;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services.TestRunnerFactoryTests.Results;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests.TestCases
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests.TestCases
 {
 #if !NETCOREAPP
     internal class Net20MixedProjectAndAssemblyTestCases

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20ProjectTestCases.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/Net20ProjectTestCases.cs
@@ -6,11 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services.TestRunnerFactoryTests.Results;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services.TestRunnerFactoryTests.Results;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests.TestCases
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests.TestCases
 {
 #if !NETCOREAPP
     internal static class Net20ProjectTestCases

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -4,10 +4,10 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Runners;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests.TestCases
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests.TestCases
 {
 #if NETCOREAPP1_1 || NETCOREAPP2_1
     internal static class NetStandardTestCases

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestPackageFactory.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/TestPackageFactory.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine.Services.TestRunnerFactoryTests
+namespace TestCentric.Engine.Services.TestRunnerFactoryTests
 {
     internal static class TestPackageFactory
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TestSelectionParserTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestSelectionParserTests.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Xml;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class TestSelectionParserTests
     {

--- a/src/TestEngine/testcentric.engine.tests/Services/TokenizerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TokenizerTests.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class TokenizerTests
     {

--- a/src/TestEngine/testcentric.engine.tests/TestUtilities/On.cs
+++ b/src/TestEngine/testcentric.engine.tests/TestUtilities/On.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Threading;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class On
     {

--- a/src/TestEngine/testcentric.engine.tests/TestUtilities/ProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine.tests/TestUtilities/ProcessRunner.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class ProcessRunner
     {

--- a/src/TestEngine/testcentric.engine.tests/TestUtilities/ShadowCopyUtils.cs
+++ b/src/TestEngine/testcentric.engine.tests/TestUtilities/ShadowCopyUtils.cs
@@ -11,7 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class ShadowCopyUtils
     {

--- a/src/TestEngine/testcentric.engine.tests/TestUtilities/StackEnumerator.cs
+++ b/src/TestEngine/testcentric.engine.tests/TestUtilities/StackEnumerator.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
-namespace NUnit.Engine.TestUtilities
+namespace TestCentric.Engine.TestUtilities
 {
     public static class StackEnumerator
     {

--- a/src/TestEngine/testcentric.engine/Agents/RemoteTestAgentProxy.cs
+++ b/src/TestEngine/testcentric.engine/Agents/RemoteTestAgentProxy.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace NUnit.Engine.Agents
+namespace TestCentric.Engine.Agents
 {
     /// <summary>
     /// RemoteTestAgentProxy wraps a RemoteTestAgent so that certain

--- a/src/TestEngine/testcentric.engine/Internal/ProcessModel.cs
+++ b/src/TestEngine/testcentric.engine/Internal/ProcessModel.cs
@@ -6,7 +6,7 @@
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// Represents the manner in which test assemblies are

--- a/src/TestEngine/testcentric.engine/Internal/SettingsGroup.cs
+++ b/src/TestEngine/testcentric.engine/Internal/SettingsGroup.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// SettingsGroup is the base class representing a group

--- a/src/TestEngine/testcentric.engine/Internal/SettingsStore.cs
+++ b/src/TestEngine/testcentric.engine/Internal/SettingsStore.cs
@@ -13,7 +13,7 @@ using System.Xml;
 using System.Xml.Linq;
 #endif
 
-namespace NUnit.Engine.Internal
+namespace TestCentric.Engine.Internal
 {
     /// <summary>
     /// SettingsStore extends SettingsGroup to provide for

--- a/src/TestEngine/testcentric.engine/Runners/MasterTestRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/MasterTestRunner.cs
@@ -10,10 +10,10 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xml;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Services;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// MasterTestRunner implements the ITestRunner interface, which

--- a/src/TestEngine/testcentric.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/MultipleTestProcessRunner.cs
@@ -6,7 +6,7 @@
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// MultipleTestProcessRunner runs tests using separate

--- a/src/TestEngine/testcentric.engine/Runners/ProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/ProcessRunner.cs
@@ -7,11 +7,11 @@
 using System;
 using System.Diagnostics;
 using System.Net.Sockets;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// ProcessRunner loads and runs a set of tests in a single agent process.

--- a/src/TestEngine/testcentric.engine/Runners/TestEventDispatcher.cs
+++ b/src/TestEngine/testcentric.engine/Runners/TestEventDispatcher.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// TestEventDispatcher is used to send test events to a number of listeners

--- a/src/TestEngine/testcentric.engine/Runners/TestPackageValidator.cs
+++ b/src/TestEngine/testcentric.engine/Runners/TestPackageValidator.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     internal class TestPackageValidator
     {

--- a/src/TestEngine/testcentric.engine/Runners/WorkItemTracker.cs
+++ b/src/TestEngine/testcentric.engine/Runners/WorkItemTracker.cs
@@ -7,9 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Xml;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Runners
+namespace TestCentric.Engine.Runners
 {
     /// <summary>
     /// WorkItemTracker examines test events and keeps track of those

--- a/src/TestEngine/testcentric.engine/Services/AgentStatus.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStatus.cs
@@ -4,7 +4,7 @@
 // ***********************************************************************
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// Enumeration used to report AgentStatus

--- a/src/TestEngine/testcentric.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStore.AgentRecord.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Diagnostics;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     internal sealed partial class AgentStore
     {

--- a/src/TestEngine/testcentric.engine/Services/AgentStore.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStore.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// Defines the agent tracking operations that must be done atomically.

--- a/src/TestEngine/testcentric.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine/Services/DefaultTestRunnerFactory.cs
@@ -3,11 +3,11 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Runners;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Runners;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// DefaultTestRunnerFactory handles creation of a suitable test

--- a/src/TestEngine/testcentric.engine/Services/ProjectService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ProjectService.cs
@@ -6,10 +6,10 @@
 #if !NETSTANDARD1_6
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Common;
-using NUnit.Engine.Extensibility;
+using TestCentric.Common;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// Summary description for ProjectService.

--- a/src/TestEngine/testcentric.engine/Services/ResultService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultService.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class ResultService : Service, IResultService
     {

--- a/src/TestEngine/testcentric.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -7,10 +7,10 @@ using System;
 using System.Text;
 using System.Xml;
 using System.IO;
-using NUnit.Engine.Extensibility;
-using NUnit.Engine.Helpers;
+using TestCentric.Engine.Extensibility;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     using Internal;
 

--- a/src/TestEngine/testcentric.engine/Services/ResultWriters/TestCaseResultWriter.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultWriters/TestCaseResultWriter.cs
@@ -6,9 +6,9 @@
 using System.IO;
 using System.Text;
 using System.Xml;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class TestCaseResultWriter : IResultWriter
     {

--- a/src/TestEngine/testcentric.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -9,10 +9,10 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Xsl;
-using NUnit.Common;
-using NUnit.Engine.Extensibility;
+using TestCentric.Common;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class XmlTransformResultWriter : IResultWriter
     {

--- a/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
@@ -11,11 +11,11 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
 using Mono.Cecil;
-using NUnit.Common;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
+using TestCentric.Common;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class RuntimeFrameworkService : Service, IRuntimeFrameworkService, IAvailableRuntimes
     {

--- a/src/TestEngine/testcentric.engine/Services/SettingsService.cs
+++ b/src/TestEngine/testcentric.engine/Services/SettingsService.cs
@@ -5,10 +5,10 @@
 
 using System;
 using System.IO;
-using NUnit.Engine.Helpers;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// Summary description for UserSettingsService.

--- a/src/TestEngine/testcentric.engine/Services/TestAgency.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestAgency.cs
@@ -9,12 +9,12 @@ using System.IO;
 using System.Threading;
 using System.Diagnostics;
 using System.Text;
-using NUnit.Common;
-using NUnit.Engine.Agents;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Helpers;
+using TestCentric.Common;
+using TestCentric.Engine.Agents;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Helpers;
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     /// <summary>
     /// The TestAgency class provides RemoteTestAgents

--- a/src/TestEngine/testcentric.engine/Services/TestFilterBuilder.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestFilterBuilder.cs
@@ -9,7 +9,7 @@ using System.Text;
 // Missing XML Docs
 #pragma warning disable 1591
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class TestFilterBuilder : ITestFilterBuilder
     {

--- a/src/TestEngine/testcentric.engine/Services/TestFilterService.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestFilterService.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-namespace NUnit.Engine.Services
+namespace TestCentric.Engine.Services
 {
     public class TestFilterService : Service, ITestFilterService
     {

--- a/src/TestEngine/testcentric.engine/Services/TestSelectionParser.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestSelectionParser.cs
@@ -10,7 +10,7 @@ using System.Text;
 // Missing XML Docs
 #pragma warning disable 1591
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public class TestSelectionParser
     {

--- a/src/TestEngine/testcentric.engine/Services/Tokenizer.cs
+++ b/src/TestEngine/testcentric.engine/Services/Tokenizer.cs
@@ -9,7 +9,7 @@ using System.Text;
 // Missing XML Docs
 #pragma warning disable 1591
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     public enum TokenKind
     {

--- a/src/TestEngine/testcentric.engine/TestEngine.cs
+++ b/src/TestEngine/testcentric.engine/TestEngine.cs
@@ -8,10 +8,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using NUnit.Engine.Internal;
-using NUnit.Engine.Services;
+using TestCentric.Engine.Internal;
+using TestCentric.Engine.Services;
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// The TestEngine provides services that allow a client

--- a/src/TestModel/model/EnginePackageSettings.cs
+++ b/src/TestModel/model/EnginePackageSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.Engine
+namespace TestCentric.Engine
 {
     /// <summary>
     /// EngineSettings contains constant values that

--- a/src/TestModel/model/Filters.cs
+++ b/src/TestModel/model/Filters.cs
@@ -24,7 +24,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/ITestItem.cs
+++ b/src/TestModel/model/ITestItem.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -23,7 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/ITestServices.cs
+++ b/src/TestModel/model/ITestServices.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/Services/RecentFiles.cs
+++ b/src/TestModel/model/Services/RecentFiles.cs
@@ -23,7 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Services
 {

--- a/src/TestModel/model/Settings/EngineSettings.cs
+++ b/src/TestModel/model/Settings/EngineSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/ErrorDisplaySettings.cs
+++ b/src/TestModel/model/Settings/ErrorDisplaySettings.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Windows.Forms;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/GuiSettings.cs
+++ b/src/TestModel/model/Settings/GuiSettings.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Drawing;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/MainFormSettings.cs
+++ b/src/TestModel/model/Settings/MainFormSettings.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Drawing;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/MiniFormSettings.cs
+++ b/src/TestModel/model/Settings/MiniFormSettings.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System.Drawing;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/RecentProjectsSettings.cs
+++ b/src/TestModel/model/Settings/RecentProjectsSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/TestTreeSettings.cs
+++ b/src/TestModel/model/Settings/TestTreeSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/TextOutputSettings.cs
+++ b/src/TestModel/model/Settings/TextOutputSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/Settings/UserSettings.cs
+++ b/src/TestModel/model/Settings/UserSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/model/SettingsGroup.cs
+++ b/src/TestModel/model/SettingsGroup.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/TestEventDispatcher.cs
+++ b/src/TestModel/model/TestEventDispatcher.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {
@@ -38,8 +38,8 @@ namespace TestCentric.Gui.Model
         static Logger log = InternalTrace.GetLogger(typeof(TestModel));
 
         private const string PROJECT_LOADER_EXTENSION_PATH = "/NUnit/Engine/TypeExtensions/IProjectLoader";
-        private const string NUNIT_PROJECT_LOADER = "NUnit.Engine.Services.ProjectLoaders.NUnitProjectLoader";
-        private const string VISUAL_STUDIO_PROJECT_LOADER = "NUnit.Engine.Services.ProjectLoaders.VisualStudioProjectLoader";
+        private const string NUNIT_PROJECT_LOADER = "TestCentric.Engine.Services.ProjectLoaders.NUnitProjectLoader";
+        private const string VISUAL_STUDIO_PROJECT_LOADER = "TestCentric.Engine.Services.ProjectLoaders.VisualStudioProjectLoader";
 
         // Our event dispatcher. Events are exposed through the Events
         // property. This is used when firing events from the model.

--- a/src/TestModel/model/TestNode.cs
+++ b/src/TestModel/model/TestNode.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/TestSelection.cs
+++ b/src/TestModel/model/TestSelection.cs
@@ -23,7 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/model/TestServices.cs
+++ b/src/TestModel/model/TestServices.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/tests/AvailableRuntimesTest.cs
+++ b/src/TestModel/tests/AvailableRuntimesTest.cs
@@ -23,10 +23,10 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
-using RuntimeFramework = NUnit.TestUtilities.Fakes.RuntimeFramework;
+using TestCentric.TestUtilities.Fakes;
+using RuntimeFramework = TestCentric.TestUtilities.Fakes.RuntimeFramework;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/tests/FakeSettingsService.cs
+++ b/src/TestModel/tests/FakeSettingsService.cs
@@ -22,9 +22,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine.Internal;
+using TestCentric.Engine.Internal;
 
-namespace NUnit.Engine.Services.Tests
+namespace TestCentric.Engine.Services.Tests
 {
     public class FakeSettingsService : SettingsStore, IService
     {

--- a/src/TestModel/tests/MakeTestPackageTests.cs
+++ b/src/TestModel/tests/MakeTestPackageTests.cs
@@ -25,9 +25,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
+using TestCentric.TestUtilities.Fakes;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/tests/Services/RecentFilesTests.cs
+++ b/src/TestModel/tests/Services/RecentFilesTests.cs
@@ -23,7 +23,7 @@
 
 using System;
 using NUnit.Framework;
-using NUnit.Engine.Services.Tests;
+using TestCentric.Engine.Services.Tests;
 
 namespace TestCentric.Gui.Model.Services
 {

--- a/src/TestModel/tests/SettingsGroupTests.cs
+++ b/src/TestModel/tests/SettingsGroupTests.cs
@@ -24,7 +24,7 @@
 using System.Drawing;
 using System.ComponentModel;
 using NUnit.Framework;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NSubstitute;
 
 namespace TestCentric.Gui.Model

--- a/src/TestModel/tests/SettingsTests.cs
+++ b/src/TestModel/tests/SettingsTests.cs
@@ -28,8 +28,8 @@ using System.Reflection;
 using System.Security.Principal;
 using System.Windows.Forms;
 using NUnit.Framework;
-using NUnit.Engine;
-using NUnit.TestUtilities.Fakes;
+using TestCentric.Engine;
+using TestCentric.TestUtilities.Fakes;
 
 namespace TestCentric.Gui.Model.Settings
 {

--- a/src/TestModel/tests/TestModelAssemblyTests.cs
+++ b/src/TestModel/tests/TestModelAssemblyTests.cs
@@ -22,9 +22,9 @@
 // ***********************************************************************
 
 using System.IO;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
-using NUnit.Tests.Assemblies;
+using TestCentric.Tests.Assemblies;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/TestModel/tests/TestModelCreationTests.cs
+++ b/src/TestModel/tests/TestModelCreationTests.cs
@@ -26,9 +26,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using NUnit.Engine;
+using TestCentric.Engine;
 using NUnit.Framework;
-using NUnit.TestUtilities.Fakes;
+using TestCentric.TestUtilities.Fakes;
 
 namespace TestCentric.Gui.Model
 {

--- a/src/tests/mock-assembly-v2/MockAssembly.cs
+++ b/src/tests/mock-assembly-v2/MockAssembly.cs
@@ -7,7 +7,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Tests
+namespace TestCentric.Tests
 {
     namespace Assemblies
     {

--- a/src/tests/mock-assembly/MockAssembly.cs
+++ b/src/tests/mock-assembly/MockAssembly.cs
@@ -24,7 +24,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.Tests
+namespace TestCentric.Tests
 {
     namespace Assemblies
     {

--- a/src/tests/test-utilities/Fakes/AvailableRuntimesService.cs
+++ b/src/tests/test-utilities/Fakes/AvailableRuntimesService.cs
@@ -22,9 +22,9 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class AvailableRuntimesService : IAvailableRuntimes
     {

--- a/src/tests/test-utilities/Fakes/ExtensionService.cs
+++ b/src/tests/test-utilities/Fakes/ExtensionService.cs
@@ -23,10 +23,10 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class ExtensionService : IExtensionService
     {
@@ -41,17 +41,17 @@ namespace NUnit.TestUtilities.Fakes
             // ExtensionPoints are all known, so we add in constructor. Extensions
             // may vary, so we use a method to add them.
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/NUnitV2Driver", "NUnit.Engine.Extensibility.IDriverFactory", "Driver for NUnit tests using the V2 framework."));
+                "/NUnit/Engine/NUnitV2Driver", "TestCentric.Engine.Extensibility.IDriverFactory", "Driver for NUnit tests using the V2 framework."));
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/TypeExtensions/IService", "NUnit.Engine.Extensibility.IService", "Provides a service within the engine and possibly externally as well."));
+                "/NUnit/Engine/TypeExtensions/IService", "TestCentric.Engine.Extensibility.IService", "Provides a service within the engine and possibly externally as well."));
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/TypeExtensions/ITestEventListener", "NUnit.Engine.Extensibility.ITestEventListener", "Allows an extension to process progress reports and other events from the test."));
+                "/NUnit/Engine/TypeExtensions/ITestEventListener", "TestCentric.Engine.Extensibility.ITestEventListener", "Allows an extension to process progress reports and other events from the test."));
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/TypeExtensions/IDriverFactory", "NUnit.Engine.Extensibility.IDriverFactory", "Supplies a driver to run tests that use a specific test framework."));
+                "/NUnit/Engine/TypeExtensions/IDriverFactory", "TestCentric.Engine.Extensibility.IDriverFactory", "Supplies a driver to run tests that use a specific test framework."));
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/TypeExtensions/IProjectLoader", "NUnit.Engine.Extensibility.IProjectLoader", "Recognizes and loads assemblies from various types of project formats."));
+                "/NUnit/Engine/TypeExtensions/IProjectLoader", "TestCentric.Engine.Extensibility.IProjectLoader", "Recognizes and loads assemblies from various types of project formats."));
             _extensionPoints.Add(new ExtensionPoint(
-                "/NUnit/Engine/TypeExtensions/IResultWriter", "NUnit.Engine.Extensibility.IResultWriter", "Supplies a writer to write the result of a test to a file using a specific format."));
+                "/NUnit/Engine/TypeExtensions/IResultWriter", "TestCentric.Engine.Extensibility.IResultWriter", "Supplies a writer to write the result of a test to a file using a specific format."));
         }
 
         public void AddExtensions(params IExtensionNode[] extensions)

--- a/src/tests/test-utilities/Fakes/FakeUserSettings.cs
+++ b/src/tests/test-utilities/Fakes/FakeUserSettings.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class UserSettings : TestCentric.Gui.Model.Settings.UserSettings
     {

--- a/src/tests/test-utilities/Fakes/MockTestEngine.cs
+++ b/src/tests/test-utilities/Fakes/MockTestEngine.cs
@@ -22,9 +22,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class MockTestEngine : ITestEngine
     {

--- a/src/tests/test-utilities/Fakes/ResultService.cs
+++ b/src/tests/test-utilities/Fakes/ResultService.cs
@@ -22,10 +22,10 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
-using NUnit.Engine.Extensibility;
+using TestCentric.Engine;
+using TestCentric.Engine.Extensibility;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class ResultService : IResultService
     {

--- a/src/tests/test-utilities/Fakes/RuntimeFramework.cs
+++ b/src/tests/test-utilities/Fakes/RuntimeFramework.cs
@@ -22,9 +22,9 @@
 // ***********************************************************************
 
 using System;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class RuntimeFramework : IRuntimeFramework
     {

--- a/src/tests/test-utilities/Fakes/ServiceLocator.cs
+++ b/src/tests/test-utilities/Fakes/ServiceLocator.cs
@@ -23,9 +23,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class ServiceLocator : IServiceLocator
     {

--- a/src/tests/test-utilities/Fakes/SettingsService.cs
+++ b/src/tests/test-utilities/Fakes/SettingsService.cs
@@ -23,9 +23,9 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Engine;
+using TestCentric.Engine;
 
-namespace NUnit.TestUtilities.Fakes
+namespace TestCentric.TestUtilities.Fakes
 {
     public class SettingsService : ISettings
     {

--- a/src/tests/test-utilities/FormTester.cs
+++ b/src/tests/test-utilities/FormTester.cs
@@ -26,7 +26,7 @@ using System.Collections;
 using System.Windows.Forms;
 using NUnit.Framework;
 
-namespace NUnit.TestUtilities
+namespace TestCentric.TestUtilities
 {
     /// <summary>
     /// TestFixtures that test Forms inherit from this class.

--- a/src/tests/test-utilities/TempResourceFile.cs
+++ b/src/tests/test-utilities/TempResourceFile.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-namespace NUnit.TestUtilities
+namespace TestCentric.TestUtilities
 {
     using System;
     using System.IO;


### PR DESCRIPTION
Now that we are modifying code independently of the NUnit Project, it's important not to have confusing names that imply the code is the same as that in the NUnit engine. This PR changes the NUnit.Engine namespace and several related namespaces to be TestCentric.Engine (or TestCentric.OTHER).

The only remaining "NUnit" namespace is NUnit.GuiException, because that's a class we haven't modified from NUnit V2.