### PR TITLE
Integrate engine binaries with GUI output directory

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -69,9 +69,8 @@ string PACKAGE_DIR = PROJECT_DIR + "package/";
 string PACKAGE_TEST_DIR = PACKAGE_DIR + "test/";
 string CHOCO_DIR = PROJECT_DIR + "choco/";
 string BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
-string ENGINE_BIN_DIR = PROJECT_DIR + "src/TestEngine/bin/" + configuration + "/";
-string ENGINE_BIN_DIR_NET20 = ENGINE_BIN_DIR + "net20/";
-string ENGINE_BIN_DIR_NET35 = ENGINE_BIN_DIR + "net35/";
+string BIN_DIR_NET20 = BIN_DIR + "net20/";
+string BIN_DIR_NET35 = BIN_DIR + "net35/";
 
 // Packaging
 string PACKAGE_NAME = "testcentric-gui";
@@ -166,7 +165,6 @@ Task("Clean")
     .Does(() =>
 {
     CleanDirectory(BIN_DIR);
-	CleanDirectory(ENGINE_BIN_DIR);
 });
 
 //////////////////////////////////////////////////////////////////////
@@ -201,7 +199,7 @@ Task("Build")
     CopyFileToDirectory("NOTICES.txt", BIN_DIR);
     CopyFileToDirectory("CHANGES.txt", BIN_DIR);
 
-	CopyFiles(ENGINE_BIN_DIR_NET20 + "testcentric-agent*", ENGINE_BIN_DIR_NET35);
+	CopyFiles(BIN_DIR_NET20 + "testcentric-agent*", BIN_DIR_NET35);
 });
 
 //////////////////////////////////////////////////////////////////////
@@ -231,7 +229,7 @@ private void RunNUnitLite(string testName, string framework)
 {
 	bool isDotNetCore = framework.StartsWith("netcoreapp");
 	string ext = isDotNetCore ? ".dll" : ".exe";
-	string testPath = ENGINE_BIN_DIR + framework + "/" + testName + ext;
+	string testPath = BIN_DIR + framework + "/" + testName + ext;
 
 	int rc = isDotNetCore
 		? StartProcess("dotnet", testPath)

--- a/src/TestEngine/agents/testcentric-agent-x86.csproj
+++ b/src/TestEngine/agents/testcentric-agent-x86.csproj
@@ -9,6 +9,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\x86\</IntermediateOutputPath>
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Runtime.Remoting" />

--- a/src/TestEngine/agents/testcentric-agent.csproj
+++ b/src/TestEngine/agents/testcentric-agent.csproj
@@ -7,6 +7,7 @@
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Runtime.Remoting" />

--- a/src/TestEngine/mock-assembly/mock-assembly.csproj
+++ b/src/TestEngine/mock-assembly/mock-assembly.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net20;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/src/TestEngine/notest-assembly/notest-assembly.csproj
+++ b/src/TestEngine/notest-assembly/notest-assembly.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RootNamespace>notest_assembly</RootNamespace>
     <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
+++ b/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Web" />

--- a/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
+++ b/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>Full</DebugType>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net35'">
     <Reference Include="System.Configuration" />

--- a/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
+++ b/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net20;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />

--- a/src/TestEngine/testcentric.engine.tests/testcentric.engine.tests.csproj
+++ b/src/TestEngine/testcentric.engine.tests/testcentric.engine.tests.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>Full</DebugType>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net35'">
     <Reference Include="System.Configuration" />

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net20;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />


### PR DESCRIPTION
Fixes #488 

The GUI stores binaries in `bin\Debug` and `bin\Release`. This PR changes the engine build so that it's outputs are stored in subdirectories under the same locations, rather than in `src\TestEngine\bin\...`