### PR TITLE
Cleanup unneeded conditionals

### DIFF
--- a/src/TestEngine/testcentric.engine/Agents/RemoteTestAgentProxy.cs
+++ b/src/TestEngine/testcentric.engine/Agents/RemoteTestAgentProxy.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/TestEngine/testcentric.engine/Internal/ProcessModel.cs
+++ b/src/TestEngine/testcentric.engine/Internal/ProcessModel.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 
 namespace TestCentric.Engine.Internal

--- a/src/TestEngine/testcentric.engine/Internal/SettingsStore.cs
+++ b/src/TestEngine/testcentric.engine/Internal/SettingsStore.cs
@@ -9,9 +9,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using System.Xml;
-#if NETSTANDARD1_6
-using System.Xml.Linq;
-#endif
 
 namespace TestCentric.Engine.Internal
 {
@@ -86,29 +83,6 @@ namespace TestCentric.Engine.Internal
                 if (!Directory.Exists(dirPath))
                     Directory.CreateDirectory(dirPath);
 
-#if NETSTANDARD1_6
-                var settings = new XElement("Settings");
-
-                List<string> keys = new List<string>(_settings.Keys);
-                keys.Sort();
-
-                foreach (string name in keys)
-                {
-                    object val = GetSetting(name);
-                    if (val != null)
-                    {
-                        settings.Add(new XElement("Setting",
-                                                    new XAttribute("name", name),
-                                                    new XAttribute("value", TypeDescriptor.GetConverter(val.GetType()).ConvertToInvariantString(val))
-                                                    ));
-                    }
-                }
-                var doc = new XDocument(new XElement("NUnitSettings", settings));
-                using (var file = new FileStream(_settingsFile, FileMode.Create, FileAccess.Write))
-                {
-                    doc.Save(file);
-                }
-#else
                 var stream = new MemoryStream();
                 using (var writer = new XmlTextWriter(stream, Encoding.UTF8))
                 {
@@ -143,7 +117,6 @@ namespace TestCentric.Engine.Internal
                     var contents = reader.ReadToEnd();
                     File.WriteAllText(_settingsFile, contents, Encoding.UTF8);
                 }
-#endif
             }
             catch (Exception)
             {

--- a/src/TestEngine/testcentric.engine/Properties/AssemblyInfo.cs
+++ b/src/TestEngine/testcentric.engine/Properties/AssemblyInfo.cs
@@ -10,13 +10,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-#if NETSTANDARD1_6
-[assembly: AssemblyTitle("NUnit .NET Standard Engine")]
-[assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests in .NET Core and .NET Standard")]
-#else
 [assembly: AssemblyTitle("NUnit Engine")]
 [assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests")]
-#endif
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/src/TestEngine/testcentric.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/MultipleTestProcessRunner.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 
 namespace TestCentric.Engine.Runners

--- a/src/TestEngine/testcentric.engine/Runners/ProcessRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/ProcessRunner.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Diagnostics;
 using System.Net.Sockets;

--- a/src/TestEngine/testcentric.engine/Runners/TestEventDispatcher.cs
+++ b/src/TestEngine/testcentric.engine/Runners/TestEventDispatcher.cs
@@ -11,11 +11,7 @@ namespace TestCentric.Engine.Runners
     /// <summary>
     /// TestEventDispatcher is used to send test events to a number of listeners
     /// </summary>
-    public class TestEventDispatcher :
-#if !NETSTANDARD1_6
-        MarshalByRefObject, 
-#endif
-        ITestEventListener
+    public class TestEventDispatcher : MarshalByRefObject, ITestEventListener
     {
         private object _eventLock = new object();
 
@@ -35,11 +31,9 @@ namespace TestCentric.Engine.Runners
             }
         }
 
-#if !NETSTANDARD1_6
         public override object InitializeLifetimeService()
         {
             return null;
         }
-#endif
     }
 }

--- a/src/TestEngine/testcentric.engine/Runners/TestPackageValidator.cs
+++ b/src/TestEngine/testcentric.engine/Runners/TestPackageValidator.cs
@@ -22,7 +22,7 @@ namespace TestCentric.Engine.Runners
         // runner is putting invalid values into the package.
         public void Validate(TestPackage package)
         {
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0  // TODO: How do we validate runtime framework for .NET Standard 2.0?
+#if !NETSTANDARD2_0  // TODO: How do we validate runtime framework for .NET Standard 2.0?
             var processModel = package.GetSetting(EnginePackageSettings.ProcessModel, "Default").ToLower();
             var runningInProcess = processModel == "inprocess";
             var frameworkSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");

--- a/src/TestEngine/testcentric.engine/Services/AgentStatus.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStatus.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 namespace TestCentric.Engine.Services
 {
     /// <summary>

--- a/src/TestEngine/testcentric.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStore.AgentRecord.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Diagnostics;
 

--- a/src/TestEngine/testcentric.engine/Services/AgentStore.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentStore.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/TestEngine/testcentric.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine/Services/DefaultTestRunnerFactory.cs
@@ -16,13 +16,10 @@ namespace TestCentric.Engine.Services
     /// </summary>
     public class DefaultTestRunnerFactory : InProcessTestRunnerFactory, ITestRunnerFactory
     {
-#if !NETSTANDARD1_6
         private IProjectService _projectService;
-#endif
 
         public override void StartService()
         {
-#if !NETSTANDARD1_6
             // TestRunnerFactory requires the ProjectService
             _projectService = ServiceContext.GetService<IProjectService>();
 
@@ -30,9 +27,6 @@ namespace TestCentric.Engine.Services
             Status = _projectService != null && ((IService)_projectService).Status == ServiceStatus.Started
                 ? ServiceStatus.Started
                 : ServiceStatus.Error;
-#else
-            Status = ServiceStatus.Started;
-#endif
         }
 
         /// <summary>
@@ -45,14 +39,13 @@ namespace TestCentric.Engine.Services
         /// <returns>A TestRunner</returns>
         public override ITestEngineRunner MakeTestRunner(TestPackage package)
         {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
             if (package.SubPackages.Count > 1)
                 return new AggregatingTestRunner(ServiceContext, package);
 
             return base.MakeTestRunner(package);
         }
 #else
-
             ProcessModel processModel = GetTargetProcessModel(package);
 
             switch (processModel)
@@ -92,7 +85,7 @@ namespace TestCentric.Engine.Services
         }
 #endif
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
         /// <summary>
         /// Get the specified target process model for the package.
         /// </summary>

--- a/src/TestEngine/testcentric.engine/Services/ProjectService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ProjectService.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
 using System.Collections.Generic;
 using System.IO;
 using TestCentric.Common;
@@ -140,4 +139,3 @@ namespace TestCentric.Engine.Services
         }
     }
 }
-#endif

--- a/src/TestEngine/testcentric.engine/Services/ResultService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultService.cs
@@ -11,14 +11,8 @@ namespace TestCentric.Engine.Services
 {
     public class ResultService : Service, IResultService
     {
-#if NETSTANDARD1_6
-        private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases" };
-#else
         private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases", "user" };
-#endif
-#if !NETSTANDARD1_6
         private IEnumerable<ExtensionNode> _extensionNodes;
-#endif
 
         private string[] _formats;
         public string[] Formats
@@ -29,11 +23,9 @@ namespace TestCentric.Engine.Services
                 {
                     var formatList = new List<string>(BUILT_IN_FORMATS);
 
-#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var format in node.GetValues("Format"))
                             formatList.Add(format);
-#endif
 
                     _formats = formatList.ToArray();
                 }
@@ -56,17 +48,13 @@ namespace TestCentric.Engine.Services
                     return new NUnit3XmlResultWriter();
                 case "cases":
                     return new TestCaseResultWriter();
-#if !NETSTANDARD1_6
                 case "user":
                     return new XmlTransformResultWriter(args);
-#endif
                 default:
-#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var supported in node.GetValues("Format"))
                             if (supported == format)
                                 return node.ExtensionObject as IResultWriter;
-#endif
                     return null;
             }
         }
@@ -75,12 +63,11 @@ namespace TestCentric.Engine.Services
         {
             try
             {
-#if !NETSTANDARD1_6
                 var extensionService = ServiceContext.GetService<ExtensionService>();
 
                 if (extensionService != null && extensionService.Status == ServiceStatus.Started)
                     _extensionNodes = extensionService.GetExtensionNodes<IResultWriter>();
-#endif
+
                 // If there is no extension service, we start anyway using builtin writers
                 Status = ServiceStatus.Started;
             }

--- a/src/TestEngine/testcentric.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -59,12 +59,11 @@ namespace TestCentric.Engine.Services
             test.AddAttribute("start-time", DateTime.UtcNow.ToString("u"));
             doc.AppendChild(test);
 
-#if !NETSTANDARD1_6
             var cmd = doc.CreateElement("command-line");
             var cdata = doc.CreateCDataSection(Environment.CommandLine);
             cmd.AppendChild(cdata);
             test.AppendChild(cmd);
-#endif
+
             return doc;
         }
     }

--- a/src/TestEngine/testcentric.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Text;
@@ -78,4 +77,3 @@ namespace TestCentric.Engine.Services
         }
     }
 }
-#endif

--- a/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/TestEngine/testcentric.engine/Services/TestAgency.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestAgency.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.IO;
 using System.Threading;

--- a/src/TestEngine/testcentric.engine/TestEngine.cs
+++ b/src/TestEngine/testcentric.engine/TestEngine.cs
@@ -62,14 +62,12 @@ namespace TestCentric.Engine
                 // later.
                 Services.Add(new SettingsService(true));
                 Services.Add(new TestFilterService());
-#if !NETSTANDARD1_6
                 Services.Add(new ExtensionService());
                 Services.Add(new ProjectService());
 #if !NETSTANDARD2_0
                 Services.Add(new DomainManager());
                 Services.Add(new RuntimeFrameworkService());
                 Services.Add(new TestAgency());
-#endif
 #endif
                 Services.Add(new DriverService());
                 Services.Add(new ResultService());


### PR DESCRIPTION
Eliminating the .NET Standard 1.6 build of the engine left some unnecessary conditionals, which are being removed by this PR.