### PR TITLE
Create agents for .NET Core 2.1

### DIFF
--- a/src/TestEngine/agents/testcentric-agent-x86.csproj
+++ b/src/TestEngine/agents/testcentric-agent-x86.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>nunit.agent</RootNamespace>
-    <TargetFrameworks>net20</TargetFrameworks>
+    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <PlatformTarget>x86</PlatformTarget>

--- a/src/TestEngine/agents/testcentric-agent.csproj
+++ b/src/TestEngine/agents/testcentric-agent.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>TestCentric.Agent</RootNamespace>
-    <TargetFrameworks>net20</TargetFrameworks>
+    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>

--- a/src/TestEngine/testcentric.engine.core/Agents/NetCoreTransport.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/NetCoreTransport.cs
@@ -1,0 +1,29 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric Engine contributors.
+// Licensed under the MIT License. See LICENSE.txt in root directory.
+// ***********************************************************************
+
+#if NETSTANDARD2_0
+using System;
+
+namespace TestCentric.Engine.Agents
+{
+    public class NetCoreTransport : TestAgentTransport
+    {
+        public NetCoreTransport(RemoteTestAgent agent) : base(agent) { }
+
+        // TODO: Start and Stop essentially do nothing in .NET Core
+        // at this point. They need to be implemented using an appropriate
+        // communications protoc0l before we actually call the code.
+        
+        public override bool Start() { return true; }
+
+        public override void Stop() { _agent.StopSignal.Set(); }
+
+        public override ITestEngineRunner CreateRunner(TestPackage package)
+        {
+            return _agent.CreateRunner(package);
+        }
+    }
+}
+#endif

--- a/src/TestEngine/testcentric.engine.core/Agents/RemoteTestAgent.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/RemoteTestAgent.cs
@@ -3,13 +3,10 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD1_6
 using System;
-using System.Runtime.Remoting.Channels;
-using System.Runtime.Remoting.Channels.Tcp;
-using System.Threading;
+using TestCentric.Common;
 using TestCentric.Engine.Internal;
-using TestCentric.Engine.Helpers;
 
 namespace TestCentric.Engine.Agents
 {
@@ -20,173 +17,34 @@ namespace TestCentric.Engine.Agents
     /// to it. Rather, it reports back to the sponsoring TestAgency upon
     /// startup so that the agency may in turn provide it to clients for use.
     /// </summary>
-    public class RemoteTestAgent : TestAgent, ITestEngineRunner
+    public class RemoteTestAgent : TestAgent
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(RemoteTestAgent));
-
-        private readonly string _agencyUrl;
-
-        private ITestEngineRunner _runner;
-        private TestPackage _package;
-
-        private readonly ManualResetEvent stopSignal = new ManualResetEvent(false);
-        private readonly CurrentMessageCounter _currentMessageCounter = new CurrentMessageCounter();
-        private TcpChannel _channel;
-        private ITestAgency _agency;
 
         /// <summary>
         /// Construct a RemoteTestAgent
         /// </summary>
-        public RemoteTestAgent(Guid agentId, string agencyUrl, IServiceLocator services)
-            : base(agentId, services)
-        {
-            _agencyUrl = agencyUrl;
-        }
+        public RemoteTestAgent(Guid agentId, IServiceLocator services)
+            : base(agentId, services) { }
 
-        public int ProcessId
-        {
-            get { return System.Diagnostics.Process.GetCurrentProcess().Id; }
-        }
+        public TestAgentTransport Transport;
 
-        public override ITestEngineRunner CreateRunner(TestPackage package)
-        {
-            _package = package;
-            _runner = Services.GetService<ITestRunnerFactory>().MakeTestRunner(_package);
-            return this;
-        }
+        public int ProcessId => System.Diagnostics.Process.GetCurrentProcess().Id;
 
         public override bool Start()
         {
-            log.Info("Agent starting");
-
-            // Open the TCP channel so we can activate an ITestAgency instance from _agencyUrl
-            _channel = TcpChannelUtils.GetTcpChannel(_currentMessageCounter);
-
-            log.Info("Connecting to TestAgency at {0}", _agencyUrl);
-            try
-            {
-                // Direct cast, not safe cast. If the cast fails we need a clear InvalidCastException message, not a null _agency.
-                _agency = (ITestAgency)Activator.GetObject(typeof(ITestAgency), _agencyUrl);
-            }
-            catch (Exception ex)
-            {
-                log.Error("Unable to connect: {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
-            }
-
-            try
-            {
-                _agency.Register(this);
-                log.Debug("Registered with TestAgency");
-            }
-            catch (Exception ex)
-            {
-                log.Error("RemoteTestAgent: Failed to register with TestAgency. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
-                return false;
-            }
-
-            return true;
+            Guard.OperationValid(Transport != null, "Transport must be set before calling Start().");
+            return Transport.Start();
         }
 
         public override void Stop()
         {
-            log.Info("Stopping");
-
-            // Do this on a different thread since we need to wait until all messages are through,
-            // including the message which is waiting for this method to return so it can report back.
-            ThreadPool.QueueUserWorkItem(_ =>
-            {
-                log.Info("Waiting for messages to complete");
-
-                // Wait till all messages are finished
-                _currentMessageCounter.WaitForAllCurrentMessages();
-
-                log.Info("Attempting shut down channel");
-
-                // Shut down nicely
-                _channel.StopListening(null);
-                ChannelServices.UnregisterChannel(_channel);
-
-                // Signal to other threads that it's okay to exit the process or start a new channel, etc.
-                log.Info("Set stop signal");
-                stopSignal.Set();
-            });
+            Transport.Stop();
         }
 
-        public bool WaitForStop(int timeout)
+        public override ITestEngineRunner CreateRunner(TestPackage package)
         {
-            return stopSignal.WaitOne(timeout);
-        }
-
-        /// <summary>
-        /// Explore a loaded TestPackage and return information about
-        /// the tests found.
-        /// </summary>
-        /// <param name="filter">Criteria used to filter the search results</param>
-        /// <returns>A TestEngineResult.</returns>
-        public TestEngineResult Explore(TestFilter filter)
-        {
-            return _runner.Explore(filter);
-        }
-
-        public TestEngineResult Load()
-        {
-            return _runner.Load();
-        }
-
-        public void Unload()
-        {
-            if (_runner != null)
-                _runner.Unload();
-        }
-
-        public TestEngineResult Reload()
-        {
-            return _runner.Reload();
-        }
-
-        /// <summary>
-        /// Count the test cases that would be run under
-        /// the specified filter.
-        /// </summary>
-        /// <param name="filter">A TestFilter</param>
-        /// <returns>The count of test cases</returns>
-        public int CountTestCases(TestFilter filter)
-        {
-            return _runner.CountTestCases(filter);
-        }
-
-        /// <summary>
-        /// Run the tests in the loaded TestPackage and return a test result. The tests
-        /// are run synchronously and the listener interface is notified as it progresses.
-        /// </summary>
-        /// <param name="listener">An ITestEventHandler to receive events</param>
-        /// <param name="filter">A TestFilter used to select tests</param>
-        /// <returns>A TestEngineResult giving the result of the test execution</returns>
-        public TestEngineResult Run(ITestEventListener listener, TestFilter filter)
-        {
-            return _runner.Run(listener, filter);
-        }
-
-        /// <summary>
-        /// Start a run of the tests in the loaded TestPackage. The tests are run
-        /// asynchronously and the listener interface is notified as it progresses.
-        /// </summary>
-        /// <param name="listener">An ITestEventHandler to receive events</param>
-        /// <param name="filter">A TestFilter used to select tests</param>
-        /// <returns>A <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
-        public AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter)
-        {
-            return _runner.RunAsync(listener, filter);
-        }
-
-        /// <summary>
-        /// Cancel the ongoing test run. If no  test is running, the call is ignored.
-        /// </summary>
-        /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
-        public void StopRun(bool force)
-        {
-            if (_runner != null)
-                _runner.StopRun(force);
+            return Services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
         }
     }
 }

--- a/src/TestEngine/testcentric.engine.core/Agents/RemotingTransport.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/RemotingTransport.cs
@@ -1,0 +1,188 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric Engine contributors.
+// Licensed under the MIT License. See LICENSE.txt in root directory.
+// ***********************************************************************
+
+#if NET20
+using System;
+using System.Runtime.Remoting.Channels;
+using System.Runtime.Remoting.Channels.Tcp;
+using System.Threading;
+using TestCentric.Engine.Helpers;
+using TestCentric.Engine.Internal;
+
+namespace TestCentric.Engine.Agents
+{
+
+    public class RemotingTransport : TestAgentTransport, ITestAgent, ITestEngineRunner
+    {
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(RemotingTransport));
+
+        private readonly string _agencyUrl;
+        private ITestEngineRunner _runner;
+
+        private TcpChannel _channel;
+        private ITestAgency _agency;
+        private readonly CurrentMessageCounter _currentMessageCounter = new CurrentMessageCounter();
+
+        public RemotingTransport(RemoteTestAgent agent, string agencyUrl)
+            : base(agent)
+        {
+            _agencyUrl = agencyUrl;
+        }
+
+        public override bool Start()
+        {
+            log.Info("Agent starting");
+
+            // Open the TCP channel so we can activate an ITestAgency instance from _agencyUrl
+            _channel = TcpChannelUtils.GetTcpChannel(_currentMessageCounter);
+
+            log.Info("Connecting to TestAgency at {0}", _agencyUrl);
+            try
+            {
+                // Direct cast, not safe cast. If the cast fails we need a clear InvalidCastException message, not a null _agency.
+                _agency = (ITestAgency)Activator.GetObject(typeof(ITestAgency), _agencyUrl);
+            }
+            catch (Exception ex)
+            {
+                log.Error("Unable to connect: {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
+            }
+
+            try
+            {
+                _agency.Register(this);
+                log.Debug("Registered agent with TestAgency");
+            }
+            catch (Exception ex)
+            {
+                log.Error("RemoteTestAgent: Failed to register with TestAgency. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
+                return false;
+            }
+
+            return true;
+        }
+
+        public override void Stop()
+        {
+            log.Info("Stopping");
+
+            // Do this on a different thread since we need to wait until all messages are through,
+            // including the message which is waiting for this method to return so it can report back.
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                log.Info("Waiting for messages to complete");
+
+                // Wait till all messages are finished
+                _currentMessageCounter.WaitForAllCurrentMessages();
+
+                log.Info("Attempting shut down channel");
+
+                // Shut down nicely
+                _channel.StopListening(null);
+                ChannelServices.UnregisterChannel(_channel);
+
+                // Signal to other threads that it's okay to exit the process or start a new channel, etc.
+                log.Info("Set stop signal");
+                _agent.StopSignal.Set();
+            });
+        }
+
+        public override ITestEngineRunner CreateRunner(TestPackage package)
+        {
+            _runner = _agent.CreateRunner(package);
+            return this;
+        }
+
+        public void Dispose()
+        {
+            _agent.Dispose();
+            _runner.Dispose();
+        }
+
+        #region ITestEngineRunner Implementation
+
+        /// <summary>
+        /// Explore a loaded TestPackage and return information about
+        /// the tests found.
+        /// </summary>
+        /// <param name="filter">Criteria used to filter the search results</param>
+        /// <returns>A TestEngineResult.</returns>
+        public TestEngineResult Explore(TestFilter filter)
+        {
+            return _runner.Explore(filter);
+        }
+
+        public TestEngineResult Load()
+        {
+            return _runner.Load();
+        }
+
+        public void Unload()
+        {
+            if (_runner != null)
+                _runner.Unload();
+        }
+
+        public TestEngineResult Reload()
+        {
+            return _runner.Reload();
+        }
+
+        /// <summary>
+        /// Count the test cases that would be run under
+        /// the specified filter.
+        /// </summary>
+        /// <param name="filter">A TestFilter</param>
+        /// <returns>The count of test cases</returns>
+        public int CountTestCases(TestFilter filter)
+        {
+            return _runner.CountTestCases(filter);
+        }
+
+        /// <summary>
+        /// Run the tests in the loaded TestPackage and return a test result. The tests
+        /// are run synchronously and the listener interface is notified as it progresses.
+        /// </summary>
+        /// <param name="listener">An ITestEventHandler to receive events</param>
+        /// <param name="filter">A TestFilter used to select tests</param>
+        /// <returns>A TestEngineResult giving the result of the test execution</returns>
+        public TestEngineResult Run(ITestEventListener listener, TestFilter filter)
+        {
+            return _runner.Run(listener, filter);
+        }
+
+        /// <summary>
+        /// Start a run of the tests in the loaded TestPackage. The tests are run
+        /// asynchronously and the listener interface is notified as it progresses.
+        /// </summary>
+        /// <param name="listener">An ITestEventHandler to receive events</param>
+        /// <param name="filter">A TestFilter used to select tests</param>
+        /// <returns>A <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
+        public AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter)
+        {
+            return _runner.RunAsync(listener, filter);
+        }
+
+        /// <summary>
+        /// Cancel the ongoing test run. If no  test is running, the call is ignored.
+        /// </summary>
+        /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
+        public void StopRun(bool force)
+        {
+            if (_runner != null)
+                _runner.StopRun(force);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Overridden to cause object to live indefinitely
+        /// </summary>
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
+    }
+}
+#endif

--- a/src/TestEngine/testcentric.engine.core/Agents/TestAgentTransport.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/TestAgentTransport.cs
@@ -1,0 +1,39 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric Engine contributors.
+// Licensed under the MIT License. See LICENSE.txt in root directory.
+// ***********************************************************************
+
+#if !NETSTANDARD1_6
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestCentric.Engine.Agents
+{
+    public abstract class TestAgentTransport : MarshalByRefObject, ITestAgent
+    {
+        protected TestAgent _agent;
+
+        public TestAgentTransport(TestAgent agent)
+        {
+            _agent = agent;
+        }
+
+        public Guid Id => _agent.Id;
+
+        public abstract bool Start();
+
+        public abstract void Stop();
+
+        public abstract ITestEngineRunner CreateRunner(TestPackage package);
+
+        /// <summary>
+        /// Overridden to cause object to live indefinitely
+        /// </summary>
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
+    }
+}
+#endif

--- a/src/TestModel/tests/TestModelAssemblyTests.cs
+++ b/src/TestModel/tests/TestModelAssemblyTests.cs
@@ -23,7 +23,7 @@ namespace TestCentric.Gui.Model
             Assert.NotNull(engine, "Unable to create engine instance for testing");
 
             _model = new TestModel(engine);
-
+            _model.PackageOverrides[EnginePackageSettings.ProcessModel] = "InProcess";
             _model.LoadTests(new[] { Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY) });
         }
 


### PR DESCRIPTION
Fixes #508, which is part of the overall issue #453.

This PR accomplishes the following steps toward .NET Core test execution by the GUI...

 * We now build a separate pair of agents (AnyCPU and x86) agents for .NET Core 2.1, the first .NET Core agent we are building. 
 * Various classes, not previously built for .Net Core are now being built.
 * The particular transport protocol in use for each agent is now encapsulated in the TestTransportAgent class.
 * RemoteTestAgent has been split into two parts, the agent itself and the particular TestAgentTransport.
 * RemotingTransport has been implemented for the .NET Framework.
 * A dummy NetCoreTransport is currently being used to allow the build to complete

See issue #453 for additional steps needed to have true .Net Core functionality available for users.