### PR TITLE
Net45 core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -90,8 +90,8 @@ string ENGINE_TESTS = "testcentric.engine.tests";
 string[] ENGINE_RUNTIMES = new string[] {"net45", "netcoreapp2.1"};
 string ENGINE_CORE_TESTS = "testcentric.engine.core.tests";
 string[] ENGINE_CORE_RUNTIMES = IsRunningOnWindows()
-	? new string[] {"net35", "netcoreapp2.1", "netcoreapp1.1"}
-	: new string[] {"net35", "netcoreapp2.1"};
+	? new string[] {"net45", "net35", "netcoreapp2.1", "netcoreapp1.1"}
+	: new string[] {"net45", "net35", "netcoreapp2.1"};
 string[] AGENT_RUNTIMES =new string[] { "net20" };
 
 //////////////////////////////////////////////////////////////////////

--- a/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
+++ b/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,10 +10,14 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Web" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+    <Reference Include="System.Web" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
@@ -54,7 +54,11 @@ namespace TestCentric.Engine.Extensibility
         [Test]
         public void TargetFramework()
         {
-            Assert.That(_ea.TargetFramework.ToString, Is.EqualTo("net-2.0"));
+#if NET20 || NET35
+            Assert.That(_ea.TargetFramework.ToString(), Is.EqualTo("net-2.0"));
+#else
+            Assert.That(_ea.TargetFramework.ToString(), Is.EqualTo("net-4.5"));
+#endif
         }
 #endif
     }

--- a/src/TestEngine/testcentric.engine.core.tests/Helpers/AssemblyHelperTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Helpers/AssemblyHelperTests.cs
@@ -13,7 +13,7 @@ namespace TestCentric.Engine.Helpers
     public class AssemblyHelperTests
     {
         private static readonly string THIS_ASSEMBLY_PATH =
-#if NET35
+#if NETFRAMEWORK
             "testcentric.engine.core.tests.exe";
 #else
             "testcentric.engine.core.tests.dll";

--- a/src/TestEngine/testcentric.engine.core.tests/RuntimeFrameworkTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/RuntimeFrameworkTests.cs
@@ -6,7 +6,11 @@
 #if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using NUnit.Framework;
+#if NET20 || NET35
 using FrameworkName = TestCentric.Engine.Compatibility.FrameworkName;
+#else
+using FrameworkName = System.Runtime.Versioning.FrameworkName;
+#endif
 
 namespace TestCentric.Engine
 {

--- a/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerStaticTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Services/DomainManagerStaticTests.cs
@@ -19,7 +19,7 @@ namespace TestCentric.Engine.Services
         static string path3 = TestPath("/test/utils/test3.dll");
 
         const string STANDARD_CONFIG_FILE =
-#if NET35
+#if NETFRAMEWORK
             "testcentric.engine.core.tests.exe.config";
 #else
             "testcentric.engine.core.tests.dll.config";

--- a/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
+++ b/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;net45;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -9,6 +9,11 @@
     <OutputPath>..\..\..\bin\$(Configuration)\engine-tests\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net35'">
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />

--- a/src/TestEngine/testcentric.engine.core/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/TestEngine/testcentric.engine.core/Drivers/NUnit3FrameworkDriver.cs
@@ -150,7 +150,7 @@ namespace TestCentric.Engine.Drivers
             {
                 return _testDomain.CreateInstanceAndUnwrap(
                     _reference.FullName, typeName, false, 0,
-#if !NET_4_0
+#if NET20
                     null, args, null, null, null);
 #else
                 null, args, null, null );

--- a/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionNode.cs
+++ b/src/TestEngine/testcentric.engine.core/Extensibility/ExtensionNode.cs
@@ -131,8 +131,10 @@ namespace TestCentric.Engine.Extensibility
                 return null;
             }
             return Activator.CreateInstance(typeinfo.AsType(), args);
-#else
+#elif NET20
             return AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(AssemblyPath, TypeName, false, 0, null, args, null, null, null);
+#else
+            return AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(AssemblyPath, TypeName, false, 0, null, args, null, null);
 #endif
         }
 

--- a/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
@@ -48,6 +48,7 @@ namespace TestCentric.Engine.Services
             string domainName = "domain-" + hashCode + package.Name;
             // Setup the Evidence
             Evidence evidence = new Evidence(AppDomain.CurrentDomain.Evidence);
+#pragma warning disable 618
             if (evidence.Count == 0)
             {
                 Zone zone = new Zone(SecurityZone.MyComputer);
@@ -58,6 +59,7 @@ namespace TestCentric.Engine.Services
                 Hash hash = new Hash(assembly);
                 evidence.AddHost(hash);
             }
+#pragma warning restore 618
 
             log.Info("Creating application domain " + domainName);
 

--- a/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/DomainManager.cs
@@ -46,24 +46,25 @@ namespace TestCentric.Engine.Services
             }
 
             string domainName = "domain-" + hashCode + package.Name;
-            // Setup the Evidence
-            Evidence evidence = new Evidence(AppDomain.CurrentDomain.Evidence);
-#pragma warning disable 618
-            if (evidence.Count == 0)
-            {
-                Zone zone = new Zone(SecurityZone.MyComputer);
-                evidence.AddHost(zone);
-                Assembly assembly = Assembly.GetExecutingAssembly();
-                Url url = new Url(assembly.CodeBase);
-                evidence.AddHost(url);
-                Hash hash = new Hash(assembly);
-                evidence.AddHost(hash);
-            }
-#pragma warning restore 618
+// TODO: Make sure this is not needed before deleting
+//            // Setup the Evidence
+//            Evidence evidence = new Evidence(AppDomain.CurrentDomain.Evidence);
+//#pragma warning disable 618
+//            if (evidence.Count == 0)
+//            {
+//                Zone zone = new Zone(SecurityZone.MyComputer);
+//                evidence.AddHost(zone);
+//                Assembly assembly = Assembly.GetExecutingAssembly();
+//                Url url = new Url(assembly.CodeBase);
+//                evidence.AddHost(url);
+//                Hash hash = new Hash(assembly);
+//                evidence.AddHost(hash);
+//            }
+//#pragma warning restore 618
 
             log.Info("Creating application domain " + domainName);
 
-            AppDomain runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup);
+            AppDomain runnerDomain = AppDomain.CreateDomain(domainName, /*evidence*/null, setup);
 
             // Set PrincipalPolicy for the domain if called for in the package settings
             if (package.Settings.ContainsKey(EnginePackageSettings.PrincipalPolicy))

--- a/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
+++ b/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
@@ -1,12 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
+    <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/TestEngine/testcentric.engine.metadata/testcentric.engine.metadata.csproj
+++ b/src/TestEngine/testcentric.engine.metadata/testcentric.engine.metadata.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine\</OutputPath>


### PR DESCRIPTION
This PR adds a .NET 4.5 build of the following assemblies:

 * `testcentric.engine.core.dll`
 * `testcentric.engine.metadata.dll`
 * `testcentric.engine.api.dll`
 * `testcentric.engine.core.tests.dll`

We already had a .NET 4.5 build of `testcentric.engine.dll` and its tests, so there is now a full build of the engine for .NET 4.5.

We'll add a .NET 4.5 agent eventually. At the moment, this addition is simply to make it easier to add other changes to the .NET 4.5 engine itself by building all its dependencies for .NET 4.5, which were previously only built for .NET 2.0.