### PR TITLE
Create agent exe for .NET 4.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -87,11 +87,11 @@ string ALL_TESTS = "*.Tests.dll";
 
 // Engine Testing
 string ENGINE_TESTS = "testcentric.engine.tests";
-string[] ENGINE_RUNTIMES = new string[] {"net45", "netcoreapp2.1"};
+string[] ENGINE_RUNTIMES = new string[] {"net40", "netcoreapp2.1"};
 string ENGINE_CORE_TESTS = "testcentric.engine.core.tests";
 string[] ENGINE_CORE_RUNTIMES = IsRunningOnWindows()
-	? new string[] {"net45", "net35", "netcoreapp2.1", "netcoreapp1.1"}
-	: new string[] {"net45", "net35", "netcoreapp2.1"};
+	? new string[] {"net40", "net35", "netcoreapp2.1", "netcoreapp1.1"}
+	: new string[] {"net40", "net35", "netcoreapp2.1"};
 string[] AGENT_RUNTIMES =new string[] { "net20" };
 
 //////////////////////////////////////////////////////////////////////

--- a/src/TestEngine/agents/Program.cs
+++ b/src/TestEngine/agents/Program.cs
@@ -75,22 +75,6 @@ namespace TestCentric.Engine.Agents
                 Environment.Version,
                 RuntimeFramework.CurrentFramework.DisplayName);
 
-            // Restore the COMPLUS_Version env variable if it's been overridden by TestAgency::LaunchAgentProcess
-            try
-            {
-              string cpvOriginal = Environment.GetEnvironmentVariable("TestAgency_COMPLUS_Version_Original");
-              if(!string.IsNullOrEmpty(cpvOriginal))
-              {
-                log.Debug("Agent process has the COMPLUS_Version environment variable value \"{0}\" overridden with \"{1}\", restoring the original value.", cpvOriginal, Environment.GetEnvironmentVariable("COMPLUS_Version"));
-                Environment.SetEnvironmentVariable("TestAgency_COMPLUS_Version_Original", null, EnvironmentVariableTarget.Process); // Erase marker
-                Environment.SetEnvironmentVariable("COMPLUS_Version", (cpvOriginal == "NULL" ? null : cpvOriginal), EnvironmentVariableTarget.Process); // Restore original (which might be n/a)
-              }
-            }
-            catch(Exception ex)
-            {
-              log.Warning("Failed to restore the COMPLUS_Version variable. " + ex.Message); // Proceed with running tests anyway
-            }
-
             // Create CoreEngine
             var engine = new CoreEngine
             {

--- a/src/TestEngine/agents/Program.cs
+++ b/src/TestEngine/agents/Program.cs
@@ -113,7 +113,7 @@ namespace TestCentric.Engine.Agents
             log.Info("Starting RemoteTestAgent");
             Agent = new RemoteTestAgent(AgentId, engine.Services);
             Agent.Transport =
-#if NET20
+#if NET20 || NET40
                 new RemotingTransport(Agent, AgencyUrl);
 #else
                 new NetCoreTransport(Agent);

--- a/src/TestEngine/agents/testcentric-agent-x86.csproj
+++ b/src/TestEngine/agents/testcentric-agent-x86.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>nunit.agent</RootNamespace>
-    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netcoreapp2.1</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <PlatformTarget>x86</PlatformTarget>
@@ -12,6 +12,9 @@
     <OutputPath>..\..\..\bin\$(Configuration)\agents\</OutputPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
+    <Reference Include="System.Runtime.Remoting" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Runtime.Remoting" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TestEngine/agents/testcentric-agent.csproj
+++ b/src/TestEngine/agents/testcentric-agent.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>TestCentric.Agent</RootNamespace>
-    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netcoreapp2.1</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
@@ -13,6 +13,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
+    <Reference Include="System.Runtime.Remoting" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Runtime.Remoting" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TestEngine/mock-assembly/mock-assembly.csproj
+++ b/src/TestEngine/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;net45;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine-tests\</OutputPath>

--- a/src/TestEngine/notest-assembly/notest-assembly.csproj
+++ b/src/TestEngine/notest-assembly/notest-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>notest_assembly</RootNamespace>
-    <TargetFrameworks>net35;net45;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <OutputPath>..\..\..\bin\$(Configuration)\engine-tests\</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
+++ b/src/TestEngine/testcentric.engine.api/testcentric.engine.api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,7 +10,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">

--- a/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Extensibility/ExtensionAssemblyTests.cs
@@ -57,7 +57,7 @@ namespace TestCentric.Engine.Extensibility
 #if NET20 || NET35
             Assert.That(_ea.TargetFramework.ToString(), Is.EqualTo("net-2.0"));
 #else
-            Assert.That(_ea.TargetFramework.ToString(), Is.EqualTo("net-4.5"));
+            Assert.That(_ea.TargetFramework.ToString(), Is.EqualTo("net-4.0"));
 #endif
         }
 #endif

--- a/src/TestEngine/testcentric.engine.core.tests/Program.cs
+++ b/src/TestEngine/testcentric.engine.core.tests/Program.cs
@@ -12,7 +12,7 @@ namespace TestCentric.Engine
     {
         static int Main(string[] args)
         {
-#if NET35
+#if NETFRAMEWORK
             return new AutoRun().Execute(args);
 #else
             return new TextRunner(typeof(Program).GetTypeInfo().Assembly).Execute(args);

--- a/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
+++ b/src/TestEngine/testcentric.engine.core.tests/testcentric.engine.core.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net35;net45;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -13,12 +13,15 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net35'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TestEngine/testcentric.engine.core/Agents/RemotingTransport.cs
+++ b/src/TestEngine/testcentric.engine.core/Agents/RemotingTransport.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if NET20
+#if NETFRAMEWORK
 using System;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;

--- a/src/TestEngine/testcentric.engine.core/Internal/Logging/Logger.cs
+++ b/src/TestEngine/testcentric.engine.core/Internal/Logging/Logger.cs
@@ -128,7 +128,7 @@ namespace TestCentric.Engine.Internal
             _writer.WriteLine(TraceFmt,
                 DateTime.Now.ToString(TimeFmt),
                 level,
-#if NET20
+#if NET20 || NET30 || NET35 || NET40
                 System.Threading.Thread.CurrentThread.ManagedThreadId,
 #else
                 Environment.CurrentManagedThreadId,

--- a/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
+++ b/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine\</OutputPath>
@@ -10,7 +10,7 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/TestEngine/testcentric.engine.metadata/testcentric.engine.metadata.csproj
+++ b/src/TestEngine/testcentric.engine.metadata/testcentric.engine.metadata.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine\</OutputPath>
-    <DefineConstants>TRACE;TESTCENTRIC</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;TESTCENTRIC</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net20|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 </Project>

--- a/src/TestEngine/testcentric.engine.tests/Program.cs
+++ b/src/TestEngine/testcentric.engine.tests/Program.cs
@@ -12,7 +12,7 @@ namespace TestCentric.Engine
     {
         static int Main(string[] args)
         {
-#if NET35
+#if NETFRAMEWORK
             return new AutoRun().Execute(args);
 #else
             return new TextRunner(typeof(Program).GetTypeInfo().Assembly).Execute(args);

--- a/src/TestEngine/testcentric.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ExtensionServiceTests.cs
@@ -139,11 +139,9 @@ namespace TestCentric.Engine.Services
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
 
 #if NETCOREAPP2_1
-            string other = "net45"; // Attempt to load the .NET 3.5 version of the extensions from the .NET Core 2.0 tests
-            var assemblyName = Path.Combine(GetSiblingDirectory(other), "testcentric.engine.tests.exe");
-#elif NET45
-            string other = "netcoreapp2.1"; // Attempt to load the .NET Core 2.1 version of the extensions from the .NET 3.5 tests
-            var assemblyName = Path.Combine(GetSiblingDirectory(other), "testcentric.engine.tests.dll");
+            var assemblyName = Path.Combine(GetNetFrameworkSiblingDirectory(), "testcentric.engine.tests.exe");
+#elif NET40
+            var assemblyName = Path.Combine(GetNetCoreSiblingDirectory(), "testcentric.engine.tests.dll");
 #endif
             Assert.That(assemblyName, Does.Exist);
 
@@ -222,13 +220,13 @@ namespace TestCentric.Engine.Services
 
             var extNetStandard = new ExtensionAssembly(netstandard.Location, false);
             var extNetCore = new ExtensionAssembly(netcore.Location, false);
-            var extNetFramework = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("net45"), "testcentric.engine.dll"), false);
+            var extNetFramework = new ExtensionAssembly(Path.Combine(GetNetFrameworkSiblingDirectory(), "testcentric.engine.dll"), false);
 
             yield return new TestCaseData(new FrameworkCombo(netcore, extNetFramework)).SetName("InvalidCombo(.NET Core, .NET Framework)");
 #else
             Assembly netFramework = typeof(ExtensionService).Assembly;
 
-            var netCoreAppDir = GetSiblingDirectory("netcoreapp2.1");
+            var netCoreAppDir = GetNetCoreSiblingDirectory();
             var extNetStandard = new ExtensionAssembly(Path.Combine(netCoreAppDir, "testcentric.engine.core.dll"), false);
             var extNetCoreApp = new ExtensionAssembly(Path.Combine(netCoreAppDir, "testcentric.engine.tests.dll"), false);
 
@@ -245,7 +243,7 @@ namespace TestCentric.Engine.Services
 
             var extNetStandard = new ExtensionAssembly(netstandard.Location, false);
             var extNetCore = new ExtensionAssembly(netcore.Location, false);
-            var extNetFramework = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("net45"), "testcentric.engine.dll"), false);
+            var extNetFramework = new ExtensionAssembly(Path.Combine(GetNetFrameworkSiblingDirectory(), "testcentric.engine.dll"), false);
 
             yield return new TestCaseData(new FrameworkCombo(netstandard, extNetStandard)).SetName("InvalidCombo(.NET Standard, .NET Standard)");
             yield return new TestCaseData(new FrameworkCombo(netstandard, extNetCore)).SetName("InvalidCombo(.NET Standard, .NET Core)");
@@ -267,6 +265,16 @@ namespace TestCentric.Engine.Services
         {
             var file = new FileInfo(AssemblyHelper.GetAssemblyPath(typeof(ExtensionServiceTests).Assembly));
             return Path.Combine(file.Directory.Parent.FullName, dir);
+        }
+
+        private static string GetNetFrameworkSiblingDirectory()
+        {
+            return GetSiblingDirectory("net40");
+        }
+
+        private static string GetNetCoreSiblingDirectory()
+        {
+            return GetSiblingDirectory("netcoreapp2.1");
         }
     }
 }

--- a/src/TestEngine/testcentric.engine.tests/testcentric.engine.tests.csproj
+++ b/src/TestEngine/testcentric.engine.tests/testcentric.engine.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -13,7 +13,7 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net40'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TestCentric.Engine</RootNamespace>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\$(Configuration)\engine\</OutputPath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\testcentric.engine.api\testcentric.engine.api.csproj" />
     <ProjectReference Include="..\testcentric.engine.core\testcentric.engine.core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net20'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Content Include="nunit.engine.addins">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fixes #518

This modifies the logic of the engine so that tests targeting .NET Framework 2.0-3.5 use the .NET 2.0 build of the test agent, while those targeting a higher level use the .NET 4.0 agent.