### PR TITLE
Add package checking tasks to build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -345,7 +345,7 @@ Task("CheckChocolateyPackage")
 			HasDirectory("tools/Images/Tree/Circles").WithFiles(TREE_ICONS_JPG),
 			HasDirectory("tools/Images/Tree/Classic").WithFiles(TREE_ICONS_JPG),
 			HasDirectory("tools/Images/Tree/Default").WithFiles(TREE_ICONS_PNG),
-			HasDirectory("tools/Images/Tree/Visual Studio").WithFiles(TREE_ICONS_PNG)))
+			HasDirectory("tools/Images/Tree/Visual%20Studio").WithFiles(TREE_ICONS_PNG)))
 		{
 			ErrorDetail.Add($"Package check failed for {parameters.ChocolateyPackageName}");
 		}

--- a/build/package-checks.cake
+++ b/build/package-checks.cake
@@ -1,0 +1,138 @@
+string[] ENGINE_FILES = { 
+    "testcentric.engine.dll", "testcentric.engine.core.dll", "testcentric.engine.api.dll", "testcentric.engine.metadata.dll", "Mono.Cecil.dll"};
+string[] AGENT_FILES = { 
+    "testcentric-agent.exe", "testcentric-agent.exe.config", "testcentric-agent-x86.exe", "testcentric-agent-x86.exe.config",
+    "testcentric.engine.core.dll", "testcentric.engine.api.dll", "testcentric.engine.metadata.dll" };
+string[] GUI_FILES = {
+	"testcentric.exe", "testcentric.exe.config", "tc-next.exe", "tc-next.exe.config", "nunit.uiexception.dll",
+	"TestCentric.Gui.Runner.dll", "Experimental.Gui.Runner.dll", "TestCentric.Gui.Model.dll", "TestCentric.Common.dll" };
+string[] TREE_ICONS_JPG = {
+    "Success.jpg", "Failure.jpg", "Ignored.jpg", "Inconclusive.jpg", "Skipped.jpg" };
+string[] TREE_ICONS_PNG = {
+    "Success.png", "Failure.png", "Ignored.png", "Inconclusive.png", "Skipped.png" };
+
+private class PackageChecker
+{
+    protected string _packageName;
+    protected string _packageDir;
+
+    public PackageChecker(string packageName, string packageDir)
+    {
+        _packageName = packageName;
+        _packageDir = packageDir;
+    }
+
+    public bool RunChecks(params Check[] checks)
+    {
+        bool allPassed = true;
+
+        if (checks.Length == 0)
+        {
+            Console.WriteLine("  Package found but no checks were specified.");
+        }
+        else
+        {
+            foreach (var check in checks)
+                allPassed &= check.Apply(_packageDir);
+
+            if (allPassed)
+                Console.WriteLine("  All checks passed!");
+        }
+
+        return allPassed;
+    }
+}
+
+private abstract class Check
+{
+    public abstract bool Apply(string dir);
+
+    protected static void RecordError(string msg)
+    {
+        Console.WriteLine("  ERROR: " + msg);
+    }
+}
+
+private class FileCheck : Check
+{
+    string[] _paths;
+
+    public FileCheck(string[] paths)
+    {
+        _paths = paths;
+    }
+
+    public override bool Apply(string dir)
+    {
+        var isOK = true;
+
+        foreach (string path in _paths)
+        {
+            if (!System.IO.File.Exists(dir + path))
+            {
+                RecordError($"File {path} was not found.");
+                isOK = false;
+            }
+        }
+
+        return isOK;
+    }
+}
+
+private class DirectoryCheck : Check
+{
+    private string _path;
+    private List<string> _files = new List<string>();
+
+    public DirectoryCheck(string path)
+    {
+        _path = path;
+    }
+
+    public DirectoryCheck WithFiles(params string[] files)
+    {
+        _files.AddRange(files);
+        return this;
+    }
+
+    public DirectoryCheck AndFiles(params string[] files)
+    {
+        return WithFiles(files);
+    }
+
+    public DirectoryCheck WithFile(string file)
+    {
+        _files.Add(file);
+        return this;
+    }
+
+    public override bool Apply(string dir)
+    {
+        if (!System.IO.Directory.Exists(dir + _path))
+        {
+            RecordError($"Directory {_path} was not found.");
+            return false;
+        }
+
+        bool isOK = true;
+
+        if (_files != null)
+        {
+            foreach (var file in _files)
+            {
+                if (!System.IO.File.Exists(System.IO.Path.Combine(dir + _path, file)))
+                {
+                    RecordError($"File {file} was not found in directory {_path}.");
+                    isOK = false;
+                }
+            }
+        }
+
+        return isOK;
+    }
+}
+
+private FileCheck HasFile(string file) => HasFiles(new [] { file });
+private FileCheck HasFiles(params string[] files) => new FileCheck(files);  
+
+private DirectoryCheck HasDirectory(string dir) => new DirectoryCheck(dir);

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -19,9 +19,13 @@ public class BuildParameters
 		NuGetTestDirectory = PackageDirectory + "test/nuget/";
 		ChocolateyTestDirectory = PackageDirectory + "test/choco/";
 
-		ZipPackage = new FilePath($"{PackageDirectory}{PACKAGE_NAME}-{PackageVersion}.zip");
-		NuGetPackage = new FilePath($"{PackageDirectory}{NUGET_PACKAGE_NAME}.{PackageVersion}.nupkg");
-		ChocolateyPackage = new FilePath($"{PackageDirectory}{PACKAGE_NAME}.{PackageVersion}.nupkg");
+		ZipPackageName = $"{PACKAGE_NAME}-{PackageVersion}.zip";
+		NuGetPackageName = $"{NUGET_PACKAGE_NAME}.{PackageVersion}.nupkg";
+		ChocolateyPackageName = $"{PACKAGE_NAME}.{PackageVersion}.nupkg";
+
+		ZipPackage = new FilePath(PackageDirectory + ZipPackageName);
+		NuGetPackage = new FilePath(PackageDirectory + NuGetPackageName);
+		ChocolateyPackage = new FilePath(PackageDirectory + ChocolateyPackageName);
 
 		UsingXBuild = context.EnvironmentVariable("USE_XBUILD") != null;
 
@@ -70,6 +74,10 @@ public class BuildParameters
 	public string ZipTestDirectory { get; } 
 	public string NuGetTestDirectory { get; } 
 	public string ChocolateyTestDirectory { get; } 
+
+	public string ZipPackageName { get; }
+	public string NuGetPackageName { get; }
+	public string ChocolateyPackageName { get; }
 
 	public FilePath ZipPackage { get; }
 	public FilePath NuGetPackage { get; }

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -60,7 +60,7 @@ public class BuildParameters
 		SupportedCoreRuntimes = context.IsRunningOnWindows()
 			? new string[] {"net40", "net35", "netcoreapp2.1", "netcoreapp1.1"}
 			: new string[] {"net40", "net35", "netcoreapp2.1"};
-		SupportedAgentRuntimes = new string[] { "net20" };
+		SupportedAgentRuntimes = new string[] { "net20", "net40" };
 	}
 
 	public string Configuration { get; }


### PR DESCRIPTION
This is part of #534. **Ready to Merge**

~I'm ready to merge this even though the CI builds are failing, becaues they are failing in the way they are supposed to fail and pointing out a problem we already had! :smiley_cat:~
CORRECTION: The missing agents are covered by a separate issue, but it's probably better to keep master clean and fix the problem right in this same PR.

That is, the checks show that none of the three packages contain the net40 agents, which is the point of critical bug #537. I want to fix that tomorrow and do an immediate release.

Note that the way I implemented the check tasks is that they fail the build but they do __not__ stop subsequent tasks that run tests against the packages. That's because the package tests really only test the engine, not the gui. The tests themselves are run using NUnit Console. I anticipate changing this in the future, at which point the tests would depend on the checks.