### PR TITLE
Update which package labels to publish

### DIFF
--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -18,8 +18,8 @@ public class BuildParameters
 
 	// Pre-release labels that we publish
 	private const string LABELS_WE_PUBLISH_ON_MYGET = "dev/alpha/beta/rc";
-	private const string LABELS_WE_PUBLISH_ON_NUGET = "";
-	private const string LABELS_WE_PUBLISH_ON_CHOCOLATEY = "";
+	private const string LABELS_WE_PUBLISH_ON_NUGET = "dev/alpha/beta/rc";
+	private const string LABELS_WE_PUBLISH_ON_CHOCOLATEY = "dev/alpha/beta/rc";
 
 	private ISetupContext _context;
 	private BuildSystem _buildSystem;
@@ -130,9 +130,9 @@ public class BuildParameters
 	public bool IsPublishing => TasksToExecute.Contains("PublishPackages");
 
 	public bool ShouldPublishPackages => ShouldPublishToMyGet || ShouldPublishToNuGet || ShouldPublishToChocolatey;
-	public bool ShouldPublishToMyGet => IsPublishing && Versions.IsPreRelease && LABELS_WE_PUBLISH_ON_MYGET.Contains(Versions.PreReleaseLabel);
-	public bool ShouldPublishToNuGet => IsPublishing && !Versions.IsPreRelease;
-	public bool ShouldPublishToChocolatey => IsPublishing && !Versions.IsPreRelease;
+	public bool ShouldPublishToMyGet => IsPublishing && (!Versions.IsPreRelease || LABELS_WE_PUBLISH_ON_MYGET.Contains(Versions.PreReleaseLabel));
+	public bool ShouldPublishToNuGet => IsPublishing && (!Versions.IsPreRelease || LABELS_WE_PUBLISH_ON_NUGET.Contains(Versions.PreReleaseLabel));
+	public bool ShouldPublishToChocolatey => IsPublishing && (!Versions.IsPreRelease || LABELS_WE_PUBLISH_ON_CHOCOLATEY.Contains(Versions.PreReleaseLabel));
 	
 	public bool UsingXBuild { get; }
 	public MSBuildSettings MSBuildSettings { get; }

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -21,6 +21,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration("Release")]
 #endif
 
-[assembly: AssemblyVersion("1.3.4.0")]
-[assembly: AssemblyFileVersion("1.3.4")]
-[assembly: AssemblyInformationalVersion("1.3.4-dev1234")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3")]
+[assembly: AssemblyInformationalVersion("1.3.3-ci00008-issue-551c")]

--- a/src/TestEngine/CommonEngineAssemblyInfo.cs
+++ b/src/TestEngine/CommonEngineAssemblyInfo.cs
@@ -21,6 +21,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration("Release")]
 #endif
 
-[assembly: AssemblyVersion("1.3.4.0")]
-[assembly: AssemblyFileVersion("1.3.4")]
-[assembly: AssemblyInformationalVersion("1.3.4-dev1234")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3")]
+[assembly: AssemblyInformationalVersion("1.3.3-ci00008-issue-551c")]

--- a/src/TestEngine/testcentric.engine.api/Properties/AssemblyInfo.cs
+++ b/src/TestEngine/testcentric.engine.api/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 #endif
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.3.4")]
-[assembly: AssemblyInformationalVersion("1.3.4-dev1234")]
+[assembly: AssemblyFileVersion("1.3.3")]
+[assembly: AssemblyInformationalVersion("1.3.3-ci00008-issue-551c")]


### PR DESCRIPTION
Part of #551 

This PR pushes all published pre-released labels (dev, alpha, beta, rc) to all three feeds (myget, nuget, chocolatey) as a way of testing that the push to all feeds works correctly for pre-releases.