### PR TITLE
Go back to previous VS 2019 image on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 
 build_script: 
   - ps: .\build.ps1 -Target "AppVeyor" -Configuration "Release"


### PR DESCRIPTION
Ideally, we should set up a global.json file that specifies versions we want. However, for now, reverting to the previous VS2019 image is the simplest way to keep builds running.