### PR TITLE
Add minimal tests to ensure dialogs don't throw when created

### DIFF
--- a/src/TestCentric/tests/Dialogs/DialogCreationTests.cs
+++ b/src/TestCentric/tests/Dialogs/DialogCreationTests.cs
@@ -1,0 +1,28 @@
+using System;
+using NUnit.Framework;
+using NSubstitute;
+using TestCentric.Gui.Model;
+
+namespace TestCentric.Gui.Dialogs
+{
+    public class DialogCreationTests
+    {
+        /// <summary>
+        /// Minimal creation test for each dialog, in order to ensure
+        /// that no exception is thrown.
+        /// </summary>
+        /// <param name="dlgType"></param>
+        // TODO: We can't test TreeBasedSettingsDialog easily because
+        // it references the main presenter. This needs to be changed.
+        [TestCase(typeof(AboutBox))]
+        [TestCase(typeof(TestPropertiesDialog))]
+        [TestCase(typeof(SettingsDialogBase))]
+        [TestCase(typeof(ExtensionDialog), null)]
+        [TestCase(typeof(ParameterDialog))]
+        [TestCase(typeof(TestParametersDialog))]
+        public void CreateDialog(Type dlgType, params object[] args)
+        {
+            Activator.CreateInstance(dlgType, args);
+        }
+    }
+}


### PR DESCRIPTION
fixes #640