### PR TITLE
Make AdvancedLoaderSettings work immediately on reload

### DIFF
--- a/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Security.Principal;
 using System.Windows.Forms;
+using TestCentric.Common;
 
 namespace TestCentric.Gui.SettingsPages
 {
@@ -254,17 +255,28 @@ namespace TestCentric.Gui.SettingsPages
 
         public override void ApplySettings()
         {
-            Settings.Engine.Agents = numberOfAgentsCheckBox.Checked
-                ? (int)numberOfAgentsUpDown.Value
-                : 0;
+            // TODO: We shouldn't need to change each item in three places!
 
-            Settings.Engine.ShadowCopyFiles = !disableShadowCopyCheckBox.Checked;
+            int numAgents = numberOfAgentsCheckBox.Checked
+                ? (int)numberOfAgentsUpDown.Value : 0;
+            Settings.Engine.Agents = numAgents;
+            Model.PackageOverrides[EnginePackageSettings.MaxAgents] = numAgents;
+            Model.TestPackage.AddSetting(EnginePackageSettings.MaxAgents, numAgents);
 
-            Settings.Engine.SetPrincipalPolicy = principalPolicyCheckBox.Checked;
+            bool shadowCopyFiles = !disableShadowCopyCheckBox.Checked;
+            Settings.Engine.ShadowCopyFiles = shadowCopyFiles;
+            Model.PackageOverrides[EnginePackageSettings.ShadowCopyFiles] = shadowCopyFiles;
+            Model.TestPackage.AddSetting(EnginePackageSettings.ShadowCopyFiles, shadowCopyFiles);
 
-            Settings.Engine.PrincipalPolicy = principalPolicyCheckBox.Checked
+            bool setPrincipalPolicy = principalPolicyCheckBox.Checked;
+            Settings.Engine.SetPrincipalPolicy = setPrincipalPolicy;
+
+            string principalPolicy = principalPolicyCheckBox.Checked
                 ? (string)principalPolicyListBox.SelectedItem
                 : nameof(PrincipalPolicy.UnauthenticatedPrincipal);
+            Settings.Engine.PrincipalPolicy = principalPolicy;
+            Model.PackageOverrides[EnginePackageSettings.PrincipalPolicy] = principalPolicy;
+            Model.TestPackage.AddSetting(EnginePackageSettings.PrincipalPolicy, principalPolicy);
         }
 
         public override bool HasChangesRequiringReload

--- a/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 namespace TestCentric.Gui
 {
     using Dialogs;
+    using Model;
     using Model.Settings;
 
     /// <summary>
@@ -89,6 +90,7 @@ namespace TestCentric.Gui
             get { return _messageDisplay; }
         }
 
+        protected ITestModel Model { get; private set; }
         protected UserSettings Settings { get; private set; }
 
         #endregion
@@ -132,6 +134,7 @@ namespace TestCentric.Gui
                 if (dlg.Settings == null)
                     throw new InvalidOperationException("The Settings Dialog was not properly initialized");
 
+                Model = dlg.Model;
                 Settings = dlg.Settings;
 
                 LoadSettings();


### PR DESCRIPTION
Fixes #593 

It turns out that all the settings on the AdvancedLoaderSettings page had the same problem. It's an awkward fix: each change has to be posted in three different places for the reload to work correctly. This needs some redesign but the fix is in to make it work for now.