### PR TITLE
Cleanup for issue 593

### DIFF
--- a/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
@@ -255,40 +255,25 @@ namespace TestCentric.Gui.SettingsPages
 
         public override void ApplySettings()
         {
-            // TODO: We shouldn't need to change each item in three places!
-
             int numAgents = numberOfAgentsCheckBox.Checked
                 ? (int)numberOfAgentsUpDown.Value : 0;
+            if (numAgents != Settings.Engine.Agents)
+                PackageSettingChanges[EnginePackageSettings.MaxAgents] = numAgents;
             Settings.Engine.Agents = numAgents;
-            Model.PackageOverrides[EnginePackageSettings.MaxAgents] = numAgents;
-            Model.TestPackage.AddSetting(EnginePackageSettings.MaxAgents, numAgents);
 
             bool shadowCopyFiles = !disableShadowCopyCheckBox.Checked;
+            if (shadowCopyFiles != Settings.Engine.ShadowCopyFiles)
+                PackageSettingChanges[EnginePackageSettings.ShadowCopyFiles] = shadowCopyFiles;
             Settings.Engine.ShadowCopyFiles = shadowCopyFiles;
-            Model.PackageOverrides[EnginePackageSettings.ShadowCopyFiles] = shadowCopyFiles;
-            Model.TestPackage.AddSetting(EnginePackageSettings.ShadowCopyFiles, shadowCopyFiles);
-
-            bool setPrincipalPolicy = principalPolicyCheckBox.Checked;
-            Settings.Engine.SetPrincipalPolicy = setPrincipalPolicy;
 
             string principalPolicy = principalPolicyCheckBox.Checked
                 ? (string)principalPolicyListBox.SelectedItem
                 : nameof(PrincipalPolicy.UnauthenticatedPrincipal);
+            if (principalPolicy != Settings.Engine.PrincipalPolicy)
+                PackageSettingChanges[EnginePackageSettings.PrincipalPolicy] = principalPolicy;
             Settings.Engine.PrincipalPolicy = principalPolicy;
-            Model.PackageOverrides[EnginePackageSettings.PrincipalPolicy] = principalPolicy;
-            Model.TestPackage.AddSetting(EnginePackageSettings.PrincipalPolicy, principalPolicy);
-        }
 
-        public override bool HasChangesRequiringReload
-        {
-            get
-            {
-                return numberOfAgentsUpDown.Value != Settings.Engine.Agents
-                    || disableShadowCopyCheckBox.Checked == Settings.Engine.ShadowCopyFiles // Use == because the checkbox disables
-                    || principalPolicyCheckBox.Checked != Settings.Engine.SetPrincipalPolicy
-                    || (string)principalPolicyListBox.SelectedItem != Settings.Engine.PrincipalPolicy;
-
-            }
+            Settings.Engine.SetPrincipalPolicy = principalPolicyCheckBox.Checked;
         }
 
         private void numberOfAgentsCheckBox_CheckedChanged(object sender, EventArgs e)

--- a/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/SettingsPage.cs
@@ -4,6 +4,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui
@@ -80,11 +81,6 @@ namespace TestCentric.Gui
             get { return Settings != null; }
         }
 
-        public virtual bool HasChangesRequiringReload
-        {
-            get { return false; }
-        }
-
         public IMessageDisplay MessageDisplay
         {
             get { return _messageDisplay; }
@@ -92,6 +88,8 @@ namespace TestCentric.Gui
 
         protected ITestModel Model { get; private set; }
         protected UserSettings Settings { get; private set; }
+
+        protected IDictionary<string, object> PackageSettingChanges { get; private set; }
 
         #endregion
 
@@ -136,6 +134,7 @@ namespace TestCentric.Gui
 
                 Model = dlg.Model;
                 Settings = dlg.Settings;
+                PackageSettingChanges = dlg.PackageSettingChanges;
 
                 LoadSettings();
             }


### PR DESCRIPTION
Additional refactoring following up on #593.

In this commit, responsibility for determining which package settings changes require a reload is removed from the individual settings page and is handled by the dialog itself. Further refactoring should eventually move this to some sort of presenter but this incremental change makes the code much cleaner than before.