### PR TITLE
Remove unneded references from projects

### DIFF
--- a/src/TestEngine/testcentric.agent.api/testcentric.agent.api.csproj
+++ b/src/TestEngine/testcentric.agent.api/testcentric.agent.api.csproj
@@ -19,14 +19,6 @@
   <ItemGroup>
     <Compile Include="..\CommonEngineAssemblyInfo.cs" Link="Properties\CommonEngineAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.7.0" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit.Engine.Api" Version="3.11.1" />
   </ItemGroup>

--- a/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
+++ b/src/TestEngine/testcentric.engine.core/testcentric.engine.core.csproj
@@ -20,14 +20,15 @@
     <Compile Include="..\CommonEngineAssemblyInfo.cs" Link="Properties\CommonEngineAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-	  <ProjectReference Include="..\testcentric.engine.metadata\testcentric.engine.metadata.csproj" />
-	  <ProjectReference Include="..\testcentric.agent.api\testcentric.agent.api.csproj" />
+	<ProjectReference Include="..\testcentric.engine.metadata\testcentric.engine.metadata.csproj" />
+	<ProjectReference Include="..\testcentric.agent.api\testcentric.agent.api.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.7.0" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+	<PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.7.0" />
+	<PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -11,18 +11,6 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Internal\**" />
-    <EmbeddedResource Remove="Internal\**" />
-    <None Remove="Internal\**" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\agents\AgentExitCodes.cs" LinkBase="Agents" />
     <Compile Include="..\CommonEngineAssemblyInfo.cs" Link="Properties\CommonEngineAssemblyInfo.cs" />


### PR DESCRIPTION
This refactoring ports changes made to the NUnit engine in issue nunit/nunit-console#928 to the TestCentric engine. In our case, we continue to support a .NET Standard 1.6 build of `testcentric.engine.core.dll`, so the fix had been modified accordingly.