### PR TITLE
Resolve conflicts between Action/Func polyfills and the targeted framework

### DIFF
--- a/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Action.cs
+++ b/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Action.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if NET20 || NET35
+#if NET20
 namespace System
 {
     public delegate void Action<T>(T arg);

--- a/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Action.cs
+++ b/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Action.cs
@@ -6,7 +6,6 @@
 #if NET20
 namespace System
 {
-    public delegate void Action<T>(T arg);
     public delegate void Action<T1, T2>(T1 arg1, T2 arg2);
     public delegate void Action<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3);
 }

--- a/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Func.cs
+++ b/src/TestEngine/testcentric.engine.metadata/Compatibility/System/Func.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in root directory.
 // ***********************************************************************
 
-#if NET20 || NET35
+#if NET20
 namespace System
 {
     public delegate TResult Func<out TResult>();


### PR DESCRIPTION
All of these are already present on .NET Framework 3.5:

https://docs.microsoft.com/en-us/dotnet/api/system.func-1?view=netframework-3.5#applies-to
https://docs.microsoft.com/en-us/dotnet/api/system.func-2?view=netframework-3.5#applies-to
https://docs.microsoft.com/en-us/dotnet/api/system.func-3?view=netframework-3.5#applies-to
https://docs.microsoft.com/en-us/dotnet/api/system.action-1?view=netframework-3.5#applies-to
https://docs.microsoft.com/en-us/dotnet/api/system.action-2?view=netframework-3.5#applies-to
https://docs.microsoft.com/en-us/dotnet/api/system.action-3?view=netframework-3.5#applies-to

This one is also already present on .NET Framework 2.0:
https://docs.microsoft.com/en-us/dotnet/api/system.action-1?view=netframework-2.0#applies-to

When types are defined with the same namespace and name, they cause a compiler warning (https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0436) when used inside the same compilation that defines them, with the compiler breaking the ambiguity in favor of things defined within the same compilation. After compilation, when this assembly is referenced by another compilation, the conflict between these declarations and the ones already in the BCL causes a compiler error (https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0433) that can only be avoided with extern aliasing which is typically not a pleasure to deal with.