### PR TITLE
Fix error in Package tests

### DIFF
--- a/GuiTests.nunit
+++ b/GuiTests.nunit
@@ -1,10 +1,9 @@
 ﻿<NUnitProject>
-  <Settings processModel="Default" domainUsage="Default" />
-  <Config name="Debug" appbase="bin/Debug">
+  <Config name="Release" appbase="bin/Release">
     <assembly path="Testcentric.Gui.Tests.dll" />
     <assembly path="Testcentric.Gui.Model.Tests.dll" />
   </Config>
-  <Config name="Release" appbase="bin/Release">
+  <Config name="Debug" appbase="bin/Debug">
     <assembly path="Testcentric.Gui.Tests.dll" />
     <assembly path="Testcentric.Gui.Model.Tests.dll" />
   </Config>

--- a/build/testing.cake
+++ b/build/testing.cake
@@ -230,12 +230,16 @@ public abstract class PackageTester : GuiTester
 				Skipped = 14
 			}));
 
-		// TODO: Make test work on AppVeyor - currently runs locally only
-		if (_parameters.IsLocalBuild)
-			PackageTests.Add( new PackageTest(2, "Run an NUnit project, specifying Release config", StandardRunner,
-				"../../GuiTests.nunit --config=Release --trace=Debug",
-				new ExpectedResult("Passed"),
-				NUnitProjectLoader));
+			// TODO: Use --config option when it's supported by the extension.
+			// Current test relies on the fact that the Release config appears
+			// first in the project file.
+			if (_parameters.Configuration == "Release")
+			{
+				PackageTests.Add(new PackageTest(2, "Run an NUnit project", StandardRunner,
+					"../../GuiTests.nunit --trace=Debug",
+					new ExpectedResult("Passed"),
+					NUnitProjectLoader));
+			}
 	}
 
 	protected abstract string PackageName { get; }


### PR DESCRIPTION
The CI build has an error due to what seems to be a bug in the nunit project loader extension. This PR implements a workaround to be used until that bug is fixed.