### PR TITLE
Reinstate built-in net-2.0 agent

### DIFF
--- a/GuiTests.nunit
+++ b/GuiTests.nunit
@@ -1,10 +1,10 @@
 ﻿<NUnitProject>
   <Config name="Release" appbase="bin/Release">
-    <assembly path="Testcentric.Gui.Tests.dll" />
-    <assembly path="Testcentric.Gui.Model.Tests.dll" />
+    <assembly path="TestCentric.Gui.Tests.dll" />
+    <assembly path="TestCentric.Gui.Model.Tests.dll" />
   </Config>
   <Config name="Debug" appbase="bin/Debug">
-    <assembly path="Testcentric.Gui.Tests.dll" />
-    <assembly path="Testcentric.Gui.Model.Tests.dll" />
+    <assembly path="TestCentric.Gui.Tests.dll" />
+    <assembly path="TestCentric.Gui.Model.Tests.dll" />
   </Config>
 </NUnitProject>

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -65,7 +65,7 @@ public class BuildParameters
 		}
 
 		MSBuildSettings = new MSBuildSettings {
-			Verbosity = Verbosity.Normal,
+			Verbosity = Verbosity.Minimal,
 			//ToolVersion = MSBuildToolVersion.Default,//The highest available MSBuild tool version//VS2017
 			Configuration = Configuration,
 			PlatformTarget = PlatformTarget.MSIL,

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -65,11 +65,11 @@ public class BuildParameters
 		}
 
 		MSBuildSettings = new MSBuildSettings {
-			Verbosity = Verbosity.Minimal,
-			ToolVersion = MSBuildToolVersion.Default,//The highest available MSBuild tool version//VS2017
+			Verbosity = Verbosity.Normal,
+			//ToolVersion = MSBuildToolVersion.Default,//The highest available MSBuild tool version//VS2017
 			Configuration = Configuration,
 			PlatformTarget = PlatformTarget.MSIL,
-			MSBuildPlatform = MSBuildPlatform.Automatic,
+			//MSBuildPlatform = MSBuildPlatform.Automatic,
 			DetailedSummary = true,
 		};
 

--- a/build/test-results.cake
+++ b/build/test-results.cake
@@ -31,8 +31,19 @@ public class ExpectedResult : ResultSummary
 		Total = Passed = Failed = Warnings = Inconclusive = Skipped = -1;
 	}
 
-	public string[] Assemblies { get; set; } = new string[0];
-	public string[] Runtimes { get; set; } = new string[0];
+	public ExpectedAssemblyResult[] Assemblies { get; set; } = new ExpectedAssemblyResult[0];
+}
+
+public class ExpectedAssemblyResult
+{
+	public ExpectedAssemblyResult(string name, string expectedRuntime)
+	{
+		Name = name;
+		Runtime = expectedRuntime;
+	}
+
+	public string Name { get; }
+	public string Runtime { get; }
 }
 
 public class ActualResult : ResultSummary
@@ -54,23 +65,17 @@ public class ActualResult : ResultSummary
 		Inconclusive = IntAttribute(Xml, "inconclusive");
 		Skipped = IntAttribute(Xml, "skipped");
 
-		var assemblies = new List<string>();
-		var runtimes = new List<string>();
+		var assemblies = new List<ActualAssemblyResult>();
 
 		foreach (XmlNode node in Xml.SelectNodes("//test-suite[@type='Assembly']"))
-		{
-			assemblies.Add(GetAttribute(node, "name"));
-			runtimes.Add(GetAttribute(node.SelectSingleNode("environment"), "clr-version"));
-		}
+			assemblies.Add(new ActualAssemblyResult(node));
 
 		Assemblies = assemblies.ToArray();
-		Runtimes = runtimes.ToArray();
 	}
 
 	public XmlNode Xml { get; }
 
-	public string[] Assemblies { get; }
-	public string[] Runtimes { get; }
+	public ActualAssemblyResult[] Assemblies { get; }
 
 	private string GetAttribute(XmlNode node, string name)
 	{
@@ -86,50 +91,105 @@ public class ActualResult : ResultSummary
 	}
 }
 
+public class ActualAssemblyResult
+{
+	public ActualAssemblyResult(XmlNode xml)
+    {
+		Name = xml.Attributes["name"]?.Value;
+
+		var env = xml.SelectSingleNode("environment");
+		var settings = xml.SelectSingleNode("settings");
+
+		// If TargetRuntimeFramework setting is not present, the GUI will have crashed anyway
+		var runtimeSetting = settings.SelectSingleNode("setting[@name='TargetRuntimeFramework']");
+		TargetRuntime = runtimeSetting?.Attributes["value"]?.Value;
+		Runtime = DeduceActualRuntime(xml);
+	}
+
+	public string Name { get; }
+	public string Runtime { get; }
+
+	public string TargetRuntime { get; }
+
+	// Code to determine the runtime actually used is adhoc
+	// and works only for the set of runtimes we use in our
+	// package  tests. We have to go through all this because
+	// sufficient information for a cleaner approach is not
+	// present in the result file.
+	// TODO: Modify result file schema so this can be cleaner
+	private static string DeduceActualRuntime(XmlNode assembly)
+	{
+		var env = assembly.SelectSingleNode("environment");
+		// If TargetRuntimeFramework setting is not present, the GUI will have crashed anyway
+		var runtimeSetting = assembly.SelectSingleNode("settings/setting[@name='TargetRuntimeFramework']");
+
+		var clrVersion = env.Attributes["clr-version"]?.Value;
+		var targetRuntime = runtimeSetting.Attributes["value"]?.Value;
+		var runtime = "UNKNOWN";
+
+		if (clrVersion.StartsWith(".NET Core 4.6") && targetRuntime == "netcore-1.1")
+			runtime = targetRuntime;
+		else if (clrVersion.StartsWith("3.1") && targetRuntime == "netcore-3.1")
+			runtime = targetRuntime;
+		else if (clrVersion.StartsWith("4.0") && targetRuntime.StartsWith("netcore-"))
+			runtime = targetRuntime;
+		else if (clrVersion.StartsWith("5.0") && targetRuntime == "netcore-5.0")
+			runtime = targetRuntime;
+		else if (clrVersion.StartsWith("2.0") && targetRuntime == "net-2.0")
+			runtime = targetRuntime;
+		else if (clrVersion.StartsWith("4.0") && targetRuntime.StartsWith("net-"))
+			runtime = targetRuntime;
+
+		return runtime;
+	}
+}
+
 public class PackageTestReport
 {
 	public PackageTest Test;
 	public ActualResult Result;
 	public List<string> Errors;
 
-	public PackageTestReport(PackageTest test, ActualResult result)
+	public PackageTestReport(PackageTest test, ActualResult actualResult)
 	{
 		Test = test;
-		Result = result;
+		Result = actualResult;
 		Errors = new List<string>();
 
-		var expected = test.ExpectedResult;
+		var expectedResult = test.ExpectedResult;
 
 		ReportMissingFiles();
 
-		if (result.OverallResult == null)
-			Errors.Add("     The test-run element has no result attribute.");
-		else if (expected.OverallResult != result.OverallResult)
-			Errors.Add($"     Expected: Overall Result = {expected.OverallResult}\n    But was: {result.OverallResult}");
-		CheckCounter("Test Count", expected.Total, result.Total);
-		CheckCounter("Passed", expected.Passed, result.Passed);
-		CheckCounter("Failed", expected.Failed, result.Failed);
-		CheckCounter("Warnings", expected.Warnings, result.Warnings);
-		CheckCounter("Inconclusive", expected.Inconclusive, result.Inconclusive);
-		CheckCounter("Skipped", expected.Skipped, result.Skipped);
+		if (actualResult.OverallResult == null)
+			Errors.Add("   The test-run element has no result attribute.");
+		else if (expectedResult.OverallResult != actualResult.OverallResult)
+			Errors.Add($"   Expected: Overall Result = {expectedResult.OverallResult}\n   But was: {actualResult.OverallResult}");
+		CheckCounter("Test Count", expectedResult.Total, actualResult.Total);
+		CheckCounter("Passed", expectedResult.Passed, actualResult.Passed);
+		CheckCounter("Failed", expectedResult.Failed, actualResult.Failed);
+		CheckCounter("Warnings", expectedResult.Warnings, actualResult.Warnings);
+		CheckCounter("Inconclusive", expectedResult.Inconclusive, actualResult.Inconclusive);
+		CheckCounter("Skipped", expectedResult.Skipped, actualResult.Skipped);
 
-		string expectedAssemblies = string.Join(" ", expected.Assemblies);
-		string actualAssemblies = string.Join(" ", result.Assemblies);
+		var expectedAssemblies = expectedResult.Assemblies;
+		var actualAssemblies = actualResult.Assemblies;
 
-		if (expectedAssemblies != actualAssemblies)
-		{
-			Errors.Add($"     Expected assemblies {expectedAssemblies}\n    But was: {actualAssemblies}");
-			return;
-		}
-
-		for (int i = 0; i < expected.Assemblies.Length && i < expected.Runtimes.Length && i < result.Runtimes.Length; i++)
+		for (int i = 0; i < expectedAssemblies.Length && i < actualAssemblies.Length; i++)
         {
-			string assembly = expected.Assemblies[i];
-			string expectedRuntime = expected.Runtimes[i];
-			string resultRuntime = result.Runtimes[i];
-			if (!resultRuntime.StartsWith(expectedRuntime))
-				Errors.Add($"    Expected assembly {assembly} to use CLR {expectedRuntime}\n    But it ran under {resultRuntime}");
+			var expected = expectedAssemblies[i];
+			var actual = actualAssemblies[i];
+
+			if (expected.Name != actual.Name)
+				Errors.Add($"   Expected: {expected.Name}\n    But was: { actual.Name}");
+			else if (!actual.Runtime.StartsWith(expected.Runtime))
+				Errors.Add($"   Assembly {actual.Name}\n     Expected: {expected.Runtime}\n      But was: {actual.Runtime}");
         }
+
+		for (int i = actualAssemblies.Length; i < expectedAssemblies.Length; i++)
+			Errors.Add($"   Assembly {expectedAssemblies[i].Name} was not found");
+
+		for (int i = expectedAssemblies.Length; i < actualAssemblies.Length; i++)
+			Errors.Add($"   Found unexpected assembly {actualAssemblies[i].Name}");
 	}
 
 	public PackageTestReport(PackageTest test, Exception ex)
@@ -165,7 +225,7 @@ public class PackageTestReport
 
 		// If there is no top-level suite, it generally means the file format could not be interpreted
 		if (suites.Count == 0)
-			Errors.Add("     No top-level suites! Possible empty command-line or misformed project.");
+			Errors.Add("   No top-level suites! Possible empty command-line or misformed project.");
 
 		foreach (XmlNode suite in suites)
 		{
@@ -177,7 +237,7 @@ public class PackageTestReport
 			if (runState == "NotRunnable" || suiteResult == "Failed" && site == "Test" && (label == "Invalid" || label == "Error"))
 			{
 				string message = suite.SelectSingleNode("reason/message")?.InnerText;
-				Errors.Add($"     {message}");
+				Errors.Add($"   {message}");
 			}
 		}
 	}
@@ -186,7 +246,7 @@ public class PackageTestReport
 	{
 		// If expected value of counter is negative, it means no check is needed
 		if (expected >= 0 && expected != actual)
-			Errors.Add($"     Expected: {label} = {expected}\n      But was: {actual}");
+			Errors.Add($"   Expected: {label} = {expected}\n    But was: {actual}");
 	}
 
 	private string GetAttribute(XmlNode node, string name)

--- a/build/testing.cake
+++ b/build/testing.cake
@@ -122,14 +122,6 @@ public abstract class PackageTester : GuiTester
 		PackageTests = new List<PackageTest>();
 
 		// Level 1 tests are run each time we build the packages
-		PackageTests.Add(new PackageTest(2, "Re-run tests of the TestCentric model", StandardRunner,
-			"TestCentric.Gui.Model.Tests.dll",
-			new ExpectedResult("Passed")
-			{
-				Assemblies = new[] { "TestCentric.Gui.Model.Tests.dll" },
-				Runtimes = new[] { "4.0.30319" }
-			})); ;
-
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 4.5", StandardRunner,
 			"mock-assembly.dll",
 			new ExpectedResult("Failed")
@@ -140,9 +132,8 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { "4.0.30319" }
-			}));
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "net-4.5") }
+			})) ;
 		
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 3.5", StandardRunner,
 			"engine-tests/net35/mock-assembly.dll",
@@ -154,8 +145,7 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { "2.0.50727" }
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "net-2.0") }
 			}));
 		
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 2.1", StandardRunner,
@@ -168,8 +158,7 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { "4.0.30319" }
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "netcore-2.1") }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 3.1", StandardRunner,
@@ -182,8 +171,7 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { "3.1" }
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "netcore-3.1") }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll targeting .NET Core 1.1", StandardRunner,
@@ -196,8 +184,7 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { ".NET Core 4.6" }
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "netcore-1.1") }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 5.0", StandardRunner,
@@ -210,31 +197,10 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 1,
 				Skipped = 7,
-				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { "5.0" }
+				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "netcore-5.0") }
 			}));
 
-        // Level 2 tests are run for PRs and when packages will be published
-
-        // TODO: Ensure that experimental runner saves results and handles --unattended
-        // PackageTests.Add(new PackageTest(2, "Run tests of the TestCentric model using the Experimental Runner", ExperimentalRunner,
-        //     "TestCentric.Gui.Model.Tests.dll",
-        //     new ExpectedResult("Passed"));
-
-        //PackageTests.Add(new PackageTest(2, "Run mock-assembly.dll built for NUnit V2", StandardRunner,
-        //	"v2-tests/mock-assembly.dll",
-        //	new ExpectedResult("Failed")
-        //	{
-        //		Total = 28,
-        //		Passed = 18,
-        //		Failed = 5,
-        //		Warnings = 0,
-        //		Inconclusive = 1,
-        //		Skipped = 4
-        //	},
-        //	NUnitV2Driver));
-
-        PackageTests.Add( new PackageTest(2, "Run different builds of mock-assembly.dll together", StandardRunner,
+		PackageTests.Add(new PackageTest(1, "Run different builds of mock-assembly.dll together", StandardRunner,
 			"engine-tests/net35/mock-assembly.dll engine-tests/netcoreapp2.1/mock-assembly.dll",
 			new ExpectedResult("Failed")
 			{
@@ -244,23 +210,50 @@ public abstract class PackageTester : GuiTester
 				Warnings = 0,
 				Inconclusive = 2,
 				Skipped = 14,
-				Assemblies = new[] { "mock-assembly.dll", "mock-assembly.dll" },
-				Runtimes = new[] { "2.0.50727", "4.0.30319" }
+				Assemblies = new[] {
+					new ExpectedAssemblyResult("mock-assembly.dll", "net-2.0"),
+					new ExpectedAssemblyResult("mock-assembly.dll", "netcore-2.1") }
 			}));
 
-			// TODO: Use --config option when it's supported by the extension.
-			// Current test relies on the fact that the Release config appears
-			// first in the project file.
-			if (_parameters.Configuration == "Release")
+		// Level 2 tests are run for PRs and when packages will be published
+
+		PackageTests.Add(new PackageTest(2, "Re-run tests of the TestCentric model using the package", StandardRunner,
+			"TestCentric.Gui.Model.Tests.dll",
+			new ExpectedResult("Passed")
+			{
+				Assemblies = new[] { new ExpectedAssemblyResult("TestCentric.Gui.Model.Tests.dll", "net-4.5") }
+			}));
+
+		// TODO: Ensure that experimental runner saves results and handles --unattended
+		// PackageTests.Add(new PackageTest(2, "Run tests of the TestCentric model using the Experimental Runner", ExperimentalRunner,
+		//     "TestCentric.Gui.Model.Tests.dll",
+		//     new ExpectedResult("Passed"));
+
+		//PackageTests.Add(new PackageTest(2, "Run mock-assembly.dll built for NUnit V2", StandardRunner,
+		//	"v2-tests/mock-assembly.dll",
+		//	new ExpectedResult("Failed")
+		//	{
+		//		Total = 28,
+		//		Passed = 18,
+		//		Failed = 5,
+		//		Warnings = 0,
+		//		Inconclusive = 1,
+		//		Skipped = 4
+		//	},
+		//	NUnitV2Driver));
+
+		// TODO: Use --config option when it's supported by the extension.
+		// Current test relies on the fact that the Release config appears
+		// first in the project file.
+		if (_parameters.Configuration == "Release")
 			{
 				PackageTests.Add(new PackageTest(2, "Run an NUnit project", StandardRunner,
 					"../../GuiTests.nunit --trace=Debug",
 					new ExpectedResult("Passed")
 					{
 						Assemblies = new[] { 
-							"TestCentric.Gui.Tests.dll",
-							"TestCentric.Gui.Model.Tests.dll" },
-						Runtimes = new[] { "4.0.30319", "4.0.30319" }
+							new ExpectedAssemblyResult("TestCentric.Gui.Tests.dll", "net-4.5"),
+							new ExpectedAssemblyResult("TestCentric.Gui.Model.Tests.dll", "net-4.5") }
 					},
 					NUnitProjectLoader));
 			}

--- a/build/testing.cake
+++ b/build/testing.cake
@@ -124,8 +124,12 @@ public abstract class PackageTester : GuiTester
 		// Level 1 tests are run each time we build the packages
 		PackageTests.Add(new PackageTest(2, "Re-run tests of the TestCentric model", StandardRunner,
 			"TestCentric.Gui.Model.Tests.dll",
-			new ExpectedResult("Passed")));
-		
+			new ExpectedResult("Passed")
+			{
+				Assemblies = new[] { "TestCentric.Gui.Model.Tests.dll" },
+				Runtimes = new[] { "4.0.30319" }
+			})); ;
+
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 4.5", StandardRunner,
 			"mock-assembly.dll",
 			new ExpectedResult("Failed")
@@ -135,7 +139,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { "4.0.30319" }
 			}));
 		
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 3.5", StandardRunner,
@@ -147,7 +153,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { "2.0.50727" }
 			}));
 		
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 2.1", StandardRunner,
@@ -159,7 +167,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { "4.0.30319" }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 3.1", StandardRunner,
@@ -171,7 +181,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { "3.1" }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll targeting .NET Core 1.1", StandardRunner,
@@ -183,7 +195,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { ".NET Core 4.6.30015" }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 5.0", StandardRunner,
@@ -195,7 +209,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 5,
 				Warnings = 0,
 				Inconclusive = 1,
-				Skipped = 7
+				Skipped = 7,
+				Assemblies = new[] { "mock-assembly.dll" },
+				Runtimes = new[] { "5.0" }
 			}));
 
         // Level 2 tests are run for PRs and when packages will be published
@@ -227,7 +243,9 @@ public abstract class PackageTester : GuiTester
 				Failed = 10,
 				Warnings = 0,
 				Inconclusive = 2,
-				Skipped = 14
+				Skipped = 14,
+				Assemblies = new[] { "mock-assembly.dll", "mock-assembly.dll" },
+				Runtimes = new[] { "2.0.50727", "4.0.30319" }
 			}));
 
 			// TODO: Use --config option when it's supported by the extension.
@@ -237,7 +255,13 @@ public abstract class PackageTester : GuiTester
 			{
 				PackageTests.Add(new PackageTest(2, "Run an NUnit project", StandardRunner,
 					"../../GuiTests.nunit --trace=Debug",
-					new ExpectedResult("Passed"),
+					new ExpectedResult("Passed")
+					{
+						Assemblies = new[] { 
+							"TestCentric.Gui.Tests.dll",
+							"TestCentric.Gui.Model.Tests.dll" },
+						Runtimes = new[] { "4.0.30319", "4.0.30319" }
+					},
 					NUnitProjectLoader));
 			}
 	}

--- a/build/testing.cake
+++ b/build/testing.cake
@@ -197,7 +197,7 @@ public abstract class PackageTester : GuiTester
 				Inconclusive = 1,
 				Skipped = 7,
 				Assemblies = new[] { "mock-assembly.dll" },
-				Runtimes = new[] { ".NET Core 4.6.30015" }
+				Runtimes = new[] { ".NET Core 4.6" }
 			}));
 
 		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 5.0", StandardRunner,

--- a/src/TestEngine/testcentric.engine.tests/Services/AgentLauncherTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/AgentLauncherTests.cs
@@ -153,6 +153,21 @@ namespace TestCentric.Engine.Services
         }
     }
 
+    public class Net20AgentLauncherTests : AgentLauncherTests<Net20AgentLauncher>
+    {
+        protected override string[] SupportedRuntimes => new string[] { "net-2.0", "net-3.0", "net-3.5" };
+
+        private string AgentDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "agents/net20");
+        private string AgentName = "testcentric-agent.exe";
+        private string AgentNameX86 = "testcentric-agent-x86.exe";
+
+        protected override void CheckAgentPath(Process process, bool x86)
+        {
+            string agentPath = Path.Combine(AgentDir, x86 ? AgentNameX86 : AgentName);
+            Assert.That(process.StartInfo.FileName, Is.SamePath(agentPath));
+        }
+    }
+
     public class Net40AgentLauncherTests : AgentLauncherTests<Net40AgentLauncher>
     {
         protected override string[] SupportedRuntimes => new string[] { "net-2.0", "net-3.0", "net-3.5", "net-4.0", "net-4.5" };

--- a/src/TestEngine/testcentric.engine/Services/AgentLaunchers/Net20AgentLauncher.cs
+++ b/src/TestEngine/testcentric.engine/Services/AgentLaunchers/Net20AgentLauncher.cs
@@ -1,0 +1,72 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric GUI contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+#if NETFRAMEWORK
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using NUnit.Engine;
+using TestCentric.Engine.Internal;
+
+namespace TestCentric.Engine.Services
+{
+    public class Net20AgentLauncher : IAgentLauncher
+    {
+        public bool CanCreateProcess(TestPackage package)
+        {
+            // Get target runtime
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");
+            var framework = RuntimeFramework.Parse(runtimeSetting).FrameworkName;
+            return framework.Identifier == ".NETFramework" && framework.Version.Major < 4;
+        }
+
+        public Process CreateProcess(Guid agentId, string agencyUrl, TestPackage package)
+        {
+            // Should not be called unless runtime is one we can handle
+            if (!CanCreateProcess(package))
+                return null;
+
+            // Access other package settings
+            bool runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
+            bool debugTests = package.GetSetting(EnginePackageSettings.DebugTests, false);
+            bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
+            string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
+            bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
+            string workDirectory = package.GetSetting(EnginePackageSettings.WorkDirectory, string.Empty);
+
+            var sb = new StringBuilder($"{agentId} {agencyUrl} --pid={Process.GetCurrentProcess().Id}");
+
+            // Set options that need to be in effect before the package
+            // is loaded by using the command line.
+            if (traceLevel != "Off")
+                sb.Append(" --trace=").EscapeProcessArgument(traceLevel);
+            if (debugAgent)
+                sb.Append(" --debug-agent");
+            if (workDirectory != string.Empty)
+                sb.Append(" --work=").EscapeProcessArgument(workDirectory);
+
+            var agentName = runAsX86 ? "testcentric-agent-x86.exe" : "testcentric-agent.exe";
+            var enginePath = AssemblyHelper.GetDirectoryName(Assembly.GetExecutingAssembly());
+            var agentPath = System.IO.Path.Combine(enginePath, $"agents/net20/{agentName}");
+            var agentArgs = sb.ToString();
+
+            var process = new Process();
+            process.EnableRaisingEvents = true;
+
+            var startInfo = process.StartInfo;
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            startInfo.WorkingDirectory = Environment.CurrentDirectory;
+            startInfo.LoadUserProfile = loadUserProfile;
+
+            startInfo.FileName = agentPath;
+            startInfo.Arguments = agentArgs;
+
+            return process;
+        }
+    }
+}
+#endif

--- a/src/TestEngine/testcentric.engine/Services/TestAgency.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestAgency.cs
@@ -211,7 +211,7 @@ namespace TestCentric.Engine.Services
                     foreach (IAgentLauncher launcher in _extensionService.GetExtensions<IAgentLauncher>())
                         _launchers.Add(launcher);
 
-                //_launchers.Add(new Net20AgentLauncher());
+                _launchers.Add(new Net20AgentLauncher());
                 _launchers.Add(new Net40AgentLauncher());
                 _launchers.Add(new NetCore21AgentLauncher());
                 _launchers.Add(new NetCore31AgentLauncher());


### PR DESCRIPTION
Fixes #656

Removing the .NET 2.0 agent didn't really serve any purpose other than testing this feature. It uses pretty much the same code as all the other agents. It remains to be seen whether we will have a built-in .NET Core 1.1 agent or rely on a pluggable agent for that purpose, but this feature is now tested and available.