### PR TITLE
Use mocks or fakes for services where possible in tests

### DIFF
--- a/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
@@ -8,6 +8,7 @@ using System;
 using NUnit.Engine;
 using NUnit.Framework;
 using TestCentric.Engine.Services;
+using TestCentric.Engine.Services.Fakes;
 
 namespace TestCentric.Engine.Runners
 {
@@ -35,7 +36,7 @@ namespace TestCentric.Engine.Runners
         {
             var package = new TestPackage("junk.dll");
             var context = new ServiceContext();
-            context.Add(new TestRunnerFactory());
+            context.Add(new FakeTestRunnerFactory());
             var runner = new AggregatingTestRunner(context, package);
             Assert.That(runner.LevelOfParallelism, Is.EqualTo(0));
         }

--- a/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -11,6 +11,7 @@ using NUnit.Engine;
 using NUnit.Framework;
 using TestCentric.Engine.Internal;
 using TestCentric.Engine.Services;
+using TestCentric.Engine.Services.Fakes;
 using TestCentric.Tests.Assemblies;
 
 namespace TestCentric.Engine.Runners
@@ -48,16 +49,16 @@ namespace TestCentric.Engine.Runners
         {
             // Add all services needed by any of our TestEngineRunners
             _services = new ServiceContext();
-            _services.Add(new Services.ExtensionService());
-            _services.Add(new Services.ProjectService());
-            _services.Add(new Services.TestFrameworkService());
-            var packageSettingsService = new Services.TestPackageAnalyzer();
+            _services.Add(new FakeExtensionService());
+            _services.Add(new FakeProjectService());
+            _services.Add(new TestFrameworkService());
+            var packageSettingsService = new TestPackageAnalyzer();
             _services.Add(packageSettingsService);
 #if !NETCOREAPP2_1
-            _services.Add(new Services.RuntimeFrameworkService());
-            _services.Add(new Services.TestAgency("ProcessRunnerTests", 0));
+            _services.Add(new FakeRuntimeService());
+            _services.Add(new TestAgency("ProcessRunnerTests", 0));
 #endif
-            _services.Add(new Services.TestRunnerFactory());
+            _services.Add(new FakeTestRunnerFactory());
             _services.ServiceManager.StartServices();
 
             var mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");

--- a/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -19,6 +19,8 @@ namespace TestCentric.Engine.Runners
     // Temporarily commenting out Process tests due to
     // intermittent errors, probably due to the test
     // fixture rather than the engine.
+    // TODO: Split agent runner tests from engine runner tests
+    // and move to agent test assembly.
     [TestFixture(typeof(LocalTestRunner))]
 #if !NETCOREAPP2_1
     //[TestFixture(typeof(TestDomainRunner))]
@@ -56,9 +58,9 @@ namespace TestCentric.Engine.Runners
             _services.Add(packageSettingsService);
 #if !NETCOREAPP2_1
             _services.Add(new FakeRuntimeService());
-            _services.Add(new TestAgency("ProcessRunnerTests", 0));
+            //_services.Add(new TestAgency("ProcessRunnerTests", 0));
 #endif
-            _services.Add(new FakeTestRunnerFactory());
+            //_services.Add(new FakeTestRunnerFactory());
             _services.ServiceManager.StartServices();
 
             var mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
@@ -15,7 +15,7 @@ namespace TestCentric.Engine.Services.Fakes
         {
             get
             {
-                throw new System.NotImplementedException();
+                return new IExtensionPoint[0];
             }
         }
 
@@ -23,23 +23,23 @@ namespace TestCentric.Engine.Services.Fakes
         {
             get
             {
-                throw new System.NotImplementedException();
+                return new IExtensionNode[0];
             }
         }
 
         public void EnableExtension(string typeName, bool enabled)
         {
-            throw new System.NotImplementedException();
+            
         }
 
         public IEnumerable<IExtensionNode> GetExtensionNodes(string path)
         {
-            throw new System.NotImplementedException();
+            return new IExtensionNode[0];
         }
 
         public IExtensionPoint GetExtensionPoint(string path)
         {
-            throw new System.NotImplementedException();
+            return null;
         }
     }
 }

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using NUnit.Engine;
+using NUnit.Engine.Extensibility;
+
+namespace TestCentric.Engine.Services.Fakes
+{
+    public class FakeExtensionService : FakeService, IExtensionService
+    {
+        public IEnumerable<IExtensionPoint> ExtensionPoints
+        {
+            get
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        public IEnumerable<IExtensionNode> Extensions
+        {
+            get
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        public void EnableExtension(string typeName, bool enabled)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<IExtensionNode> GetExtensionNodes(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IExtensionPoint GetExtensionPoint(string path)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeExtensionService.cs
@@ -1,3 +1,8 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric GUI contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
 using System.Collections.Generic;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -4,6 +4,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using NUnit.Engine;
 
 namespace TestCentric.Engine.Services.Fakes
@@ -12,12 +13,16 @@ namespace TestCentric.Engine.Services.Fakes
     {
         bool IRuntimeFrameworkService.IsAvailable(string framework)
         {
-            return true;
+            return AvailableRuntimes.Contains(framework);
         }
 
         string IRuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
         {
-            return string.Empty;
+            return SelectedRuntime;
         }
+
+        public List<string> AvailableRuntimes { get; set; } = new List<string>(new [] { "NONE" });
+
+        public string SelectedRuntime { get; set; } = "NONE";
     }
 }

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeService.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeService.cs
@@ -9,22 +9,22 @@ namespace TestCentric.Engine.Services.Fakes
 {
     public class FakeService : IService
     {
-        IServiceLocator IService.ServiceContext { get; set; }
+        public IServiceLocator ServiceContext { get; set; }
 
         private ServiceStatus _status;
-        ServiceStatus IService.Status
+        public ServiceStatus Status
         {
             get { return _status; }
         }
 
-        void IService.StartService()
+        public virtual void StartService()
         {
             _status = FailToStart
                 ? ServiceStatus.Error
                 : ServiceStatus.Started;
         }
 
-        void IService.StopService()
+        public virtual void StopService()
         {
             _status = ServiceStatus.Stopped;
         }

--- a/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeTestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/Fakes/FakeTestRunnerFactory.cs
@@ -1,0 +1,23 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric GUI contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NUnit.Engine;
+using TestCentric.Engine.Runners;
+
+namespace TestCentric.Engine.Services.Fakes
+{
+    public class FakeTestRunnerFactory : Service, ITestRunnerFactory
+    {
+        public bool CanReuse(ITestEngineRunner runner, TestPackage package)
+        {
+            return true;
+        }
+
+        public ITestEngineRunner MakeTestRunner(TestPackage package)
+        {
+            return new AssemblyRunner(ServiceContext, package);
+        }
+    }
+}

--- a/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
@@ -17,7 +17,7 @@ namespace TestCentric.Engine.Services
         public void CreateServiceContext()
         {
             var services = new ServiceContext();
-            services.Add(new ExtensionService());
+            services.Add(new Fakes.FakeExtensionService());
             _projectService = new ProjectService();
             services.Add(_projectService);
             services.ServiceManager.StartServices();

--- a/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ProjectServiceTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 namespace TestCentric.Engine.Services
 {
+    // TODO: More tests needed!
     public class ProjectServiceTests
     {
         private ProjectService _projectService;

--- a/src/TestEngine/testcentric.engine.tests/Services/ResultServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ResultServiceTests.cs
@@ -18,7 +18,6 @@ namespace TestCentric.Engine.Services
         public void CreateService()
         {
             var services = new ServiceContext();
-            services.Add(new ExtensionService());
             _resultService = new ResultService();
             services.Add(_resultService);
             services.ServiceManager.StartServices();

--- a/src/TestEngine/testcentric.engine.tests/Services/ServiceDependencyTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/ServiceDependencyTests.cs
@@ -14,33 +14,87 @@ namespace TestCentric.Engine.Services
     public class ServiceDependencyTests
     {
         private ServiceContext _services;
+        private FakeService _fake1;
+        private FakeService _fake2;
 
         [SetUp]
         public void CreateServiceContext()
         {
+            _fake1 = new FakeService1();
+            _fake2 = new FakeService2();
             _services = new ServiceContext();
         }
 
-        //[Test]
-        //public void DefaultTestRunnerFactory_ProjectServiceError()
-        //{
-        //    var fake = new FakeProjectService();
-        //    fake.FailToStart = true;
-        //    _services.Add(fake);
-        //    var service = new DefaultTestRunnerFactory();
-        //    _services.Add(service);
-        //    ((IService)fake).StartService();
-        //    service.StartService();
-        //    Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
-        //}
+        [Test]
+        public void BothServicesStart()
+        {
+            _services.Add(_fake1);
+            _services.Add(_fake2);
+            _services.ServiceManager.StartServices();
+            Assert.That(_fake1.Status, Is.EqualTo(ServiceStatus.Started));
+            Assert.That(_fake2.Status, Is.EqualTo(ServiceStatus.Started));
+        }
 
-        //[Test]
-        //public void DefaultTestRunnerFactory_ProjectServiceMissing()
-        //{
-        //    var service = new DefaultTestRunnerFactory();
-        //    _services.Add(service);
-        //    service.StartService();
-        //    Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
-        //}
+        [Test]
+        public void FirstServiceFailsToStart()
+        {
+            _services.Add(_fake1);
+            _services.Add(_fake2);
+            _fake1.FailToStart = true;
+            Assert.That(
+                () => _services.ServiceManager.StartServices(),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(_fake1.Status, Is.EqualTo(ServiceStatus.Error));
+            Assert.That(_fake2.Status, Is.EqualTo(ServiceStatus.Stopped));
+        }
+
+        [Test]
+        public void SecondServiceFailsToStart()
+        {
+            _services.Add(_fake1);
+            _services.Add(_fake2);
+            _fake2.FailToStart = true;
+            Assert.That(
+                () => _services.ServiceManager.StartServices(),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(_fake1.Status, Is.EqualTo(ServiceStatus.Started));
+            Assert.That(_fake2.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void Service1NotAdded()
+        {
+            _services.Add(_fake2);
+            Assert.That(
+                () => _services.ServiceManager.StartServices(),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(_fake2.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        [Test]
+        public void ServicesAddedInWrongOrder()
+        {
+            _services.Add(_fake2);
+            _services.Add(_fake1);
+            Assert.That(
+                () => _services.ServiceManager.StartServices(),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(_fake1.Status, Is.EqualTo(ServiceStatus.Stopped));
+            Assert.That(_fake2.Status, Is.EqualTo(ServiceStatus.Error));
+        }
+
+        private class FakeService1 : FakeService { }
+
+        private class FakeService2 : FakeService
+        {
+            public override void StartService()
+            {
+                var fake1 = ServiceContext.GetService<FakeService1>();
+                if (fake1 == null || fake1.Status != ServiceStatus.Started)
+                    FailToStart = true;
+
+                base.StartService();
+            }
+        }
     }
 }

--- a/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
@@ -24,7 +24,7 @@ namespace TestCentric.Engine.Services
         private static readonly string CURRENT_RUNTIME = RuntimeFramework.CurrentFramework.Id;
 
         private TestPackage _package;
-        private TestPackageAnalyzer _validator;
+        private TestPackageAnalyzer _analyzer;
 
         public interface ITestRuntimeService : IRuntimeFrameworkService, IService { }
 
@@ -46,8 +46,8 @@ namespace TestCentric.Engine.Services
             context.Add(Substitute.For<ProjectService>());
             context.Add(Substitute.For<TestFrameworkService>());
 
-            _validator = new TestPackageAnalyzer();
-            context.Add(_validator);
+            _analyzer = new TestPackageAnalyzer();
+            context.Add(_analyzer);
 
             context.ServiceManager.StartServices();
         }
@@ -108,7 +108,7 @@ namespace TestCentric.Engine.Services
 
         private void Validate()
         {
-            _validator.ValidatePackageSettings(_package);
+            _analyzer.ValidatePackageSettings(_package);
         }
 
         private void CheckMessageContent(string message, params string[] errors)

--- a/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -44,7 +44,7 @@ namespace TestCentric.Engine.Services.TestRunnerFactoryTests
             projectService.Add("amb.nunit", "a.dll", MOCK_ASSEMBLY, "b.dll");
             projectService.Add("mbm.nunit", MOCK_ASSEMBLY, "b.dll", MOCK_ASSEMBLY);
 
-            _services.Add(new ExtensionService());
+            _services.Add(new FakeExtensionService());
             _services.Add(projectService);
             _services.Add(new TestRunnerFactory());
             _services.Add(new FakeRuntimeService());

--- a/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
@@ -37,7 +37,7 @@ namespace TestCentric.Engine.Runners
             get
             {
                 var maxAgents = TestPackage.GetSetting(EnginePackageSettings.MaxAgents, Environment.ProcessorCount);
-                return Math.Min(maxAgents, TestPackage.SubPackages.Count);
+                return Math.Min(maxAgents, TestPackage.Select(p => !p.HasSubPackages()).Count);
             }
         }
 

--- a/src/TestEngine/testcentric.engine/Services/ProjectService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ProjectService.cs
@@ -15,6 +15,9 @@ namespace TestCentric.Engine.Services
     /// <summary>
     /// Summary description for ProjectService.
     /// </summary>
+    /// <remarks>
+    /// Depends on ExtensionService (optional)
+    /// </remarks>
     public class ProjectService : Service, IProjectService
     {
         Dictionary<string, ExtensionNode> _extensionIndex = new Dictionary<string, ExtensionNode>();

--- a/src/TestEngine/testcentric.engine/Services/ResultService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ResultService.cs
@@ -14,7 +14,7 @@ namespace TestCentric.Engine.Services
     public class ResultService : Service, IResultService
     {
         private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases", "user" };
-        private IEnumerable<ExtensionNode> _extensionNodes;
+        private IEnumerable<ExtensionNode> _extensionNodes = new ExtensionNode[0];
 
         private string[] _formats;
         public string[] Formats


### PR DESCRIPTION
Fixes #716

Most service and runner tests now use mocks or fakes where possible. There are a few tests, which will require more work in the future in order to ensure that only the target component is being tested.