### PR TITLE
Disable Run As X86 menu item when no test is loaded

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -309,6 +309,7 @@ namespace TestCentric.Gui.Presenters
                 _view.CloseCommand.Enabled = isPackageLoaded && !isTestRunning;
 
                 _view.ReloadTestsCommand.Enabled = isPackageLoaded && !isTestRunning;
+                _view.RunAsX86.Enabled = isPackageLoaded && !isTestRunning;
 
                 _view.RuntimeMenu.Visible = _model.AvailableRuntimes.Count > 1;
 


### PR DESCRIPTION
Fixes #719