### PR TITLE
Fix error in TestCentric.Engine.Api package creation

### DIFF
--- a/nuget/TestCentric.Engine.Api.nuspec
+++ b/nuget/TestCentric.Engine.Api.nuspec
@@ -2,7 +2,7 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>TestCentric.Agent.Api</id>
+    <id>TestCentric.Engine.Api</id>
     <version>0.0.0</version>
     <description>This package includes the testcentric.agent.api assembly, used in creating pluggable agents.</description>
     <authors>Charlie Poole</authors>


### PR DESCRIPTION
This is a problem that arose after the PR for issue #664 was merged and AppVeyor attempted to upload the Api assembly to MyGet. Unfortunately, the publishing step can only be tested fully after the change is merged. Let's see how this one does!