### PR TITLE
Update to engine 2.0.0-dev00524 and drop net20 agent

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ const string DEFAULT_CONFIGURATION = "Release";
 // NOTE: This must match what is actually referenced by
 // the GUI test model project. Hopefully, this is a temporary
 // fix, which we can get rid of in the future.
-const string REF_ENGINE_VERSION = "2.0.0-dev00522";
+const string REF_ENGINE_VERSION = "2.0.0-dev00524";
 
 const string PACKAGE_NAME = "testcentric-gui";
 const string NUGET_PACKAGE_NAME = "TestCentric.GuiRunner";
@@ -185,7 +185,6 @@ Task("VerifyZipPackage")
 		Check.That(parameters.ZipTestDirectory,
 			HasFiles("CHANGES.txt", "LICENSE.txt", "NOTICES.txt"),
 			HasDirectory("bin").WithFiles(GUI_FILES).AndFiles(ENGINE_FILES).AndFile("testcentric.zip.addins"),
-			HasDirectory("bin/agents/net20").WithFiles(NET_FRAMEWORK_AGENT_FILES),
 			HasDirectory("bin/agents/net40").WithFiles(NET_FRAMEWORK_AGENT_FILES),
 			HasDirectory("bin/agents/netcoreapp2.1").WithFiles(NET_CORE_AGENT_FILES),
 			HasDirectory("bin/agents/netcoreapp3.1").WithFiles(NET_CORE_AGENT_FILES),
@@ -242,7 +241,6 @@ Task("VerifyNuGetPackage")
 		Check.That(parameters.NuGetTestDirectory,
 			HasFiles("CHANGES.txt", "LICENSE.txt", "NOTICES.txt", "testcentric.png"),
 			HasDirectory("tools").WithFiles(GUI_FILES).AndFiles(ENGINE_FILES).AndFile("testcentric.nuget.addins"),
-			HasDirectory("tools/agents/net20").WithFiles(NET_FRAMEWORK_AGENT_FILES).AndFiles(ENGINE_CORE_FILES).AndFile("testcentric-agent.nuget.addins"),
 			HasDirectory("tools/agents/net40").WithFiles(NET_FRAMEWORK_AGENT_FILES).AndFiles(ENGINE_CORE_FILES).AndFile("testcentric-agent.nuget.addins"),
 			HasDirectory("tools/agents/netcoreapp2.1").WithFiles(NET_CORE_AGENT_FILES).AndFiles(ENGINE_CORE_FILES).AndFile("testcentric-agent.nuget.addins"),
 			HasDirectory("tools/agents/netcoreapp3.1").WithFiles(NET_CORE_AGENT_FILES).AndFiles(ENGINE_CORE_FILES).AndFile("testcentric-agent.nuget.addins"),
@@ -300,7 +298,6 @@ Task("VerifyChocolateyPackage")
 	{
 		Check.That(parameters.ChocolateyTestDirectory,
 			HasDirectory("tools").WithFiles("CHANGES.txt", "LICENSE.txt", "NOTICES.txt", "VERIFICATION.txt", "testcentric.choco.addins").AndFiles(GUI_FILES).AndFiles(ENGINE_FILES).AndFile("testcentric.choco.addins"),
-			HasDirectory("tools/agents/net20").WithFiles(NET_FRAMEWORK_AGENT_FILES).AndFile("testcentric-agent.choco.addins"),
 			HasDirectory("tools/agents/net40").WithFiles(NET_FRAMEWORK_AGENT_FILES).AndFile("testcentric-agent.choco.addins"),
 			HasDirectory("tools/agents/netcoreapp2.1").WithFiles(NET_CORE_AGENT_FILES).AndFile("testcentric-agent.choco.addins"),
 			HasDirectory("tools/agents/netcoreapp3.1").WithFiles(NET_CORE_AGENT_FILES).AndFile("testcentric-agent.choco.addins"),

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -122,10 +122,25 @@ public abstract class PackageTester : GuiTester
 				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "net-4.5") }
 			})) ;
 
-        PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET 3.5", StandardRunner,
-            "net35/mock-assembly.dll",
-            new ExpectedResult("Failed")
-            {
+		PackageTests.Add(new PackageTest(1, "Run net35 mock-assembly.dll under .NET 4.0", StandardRunner,
+		"net35/mock-assembly.dll",
+		new ExpectedResult("Failed")
+		{
+			Total = 40,
+			Passed = 22,
+			Failed = 6,
+			Warnings = 0,
+			Inconclusive = 5,
+			Skipped = 7,
+			Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "net-2.0") }
+		},
+		"NUnit.Extension.Net20PluggableAgent"));
+
+
+		PackageTests.Add(new PackageTest(1, "Run net35 mock-assembly.dll under .NET 2.0 pluggable agent", StandardRunner,
+			"net35/mock-assembly.dll",
+			new ExpectedResult("Failed")
+			{
 				Total = 40,
 				Passed = 22,
 				Failed = 6,
@@ -133,9 +148,10 @@ public abstract class PackageTester : GuiTester
 				Inconclusive = 5,
 				Skipped = 7,
 				Assemblies = new[] { new ExpectedAssemblyResult("mock-assembly.dll", "net-2.0") }
-            }));
+			},
+			"NUnit.Extension.Net20PluggableAgent"));
 
-        PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 2.1", StandardRunner,
+		PackageTests.Add(new PackageTest(1, "Run mock-assembly.dll under .NET Core 2.1", StandardRunner,
             "netcoreapp2.1/mock-assembly.dll",
             new ExpectedResult("Failed")
             {

--- a/cake/test-reports.cake
+++ b/cake/test-reports.cake
@@ -39,9 +39,9 @@ public class PackageTestReport
 			var actual = actualAssemblies[i];
 
 			if (expected.Name != actual.Name)
-				Errors.Add($"   Expected: {expected.Name}\n    But was: { actual.Name}");
+				Errors.Add($"   Expected: {expected.Name}\r\n    But was: { actual.Name}");
 			else if (!actual.Runtime.StartsWith(expected.Runtime))
-				Errors.Add($"   Assembly {actual.Name}\n     Expected: {expected.Runtime}\n      But was: {actual.Runtime}");
+				Errors.Add($"   Assembly {actual.Name}\r\n     Expected: {expected.Runtime}\r\n      But was: {actual.Runtime}");
         }
 
 		for (int i = actualAssemblies.Length; i < expectedAssemblies.Length; i++)

--- a/choco/testcentric-gui.nuspec
+++ b/choco/testcentric-gui.nuspec
@@ -90,15 +90,6 @@ Projects with tests to be run under **TestCentric** must already have some versi
     <file src="$BIN$Images/Tree/Visual Studio/Skipped.png" target="tools/Images/Tree/Visual Studio" />
     <file src="$BIN$Images/Tree/Visual Studio/Success.png" target="tools/Images/Tree/Visual Studio" />
 
-    <file src="$BIN$agents/net20/nunit.engine.api.dll" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric.engine.metadata.dll" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric.engine.core.dll" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric-agent.exe" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric-agent.exe.config" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric-agent-x86.exe" target="tools/agents/net20" />
-    <file src="$BIN$agents/net20/testcentric-agent-x86.exe.config" target="tools/agents/net20" />
-    <file src="testcentric-agent.choco.addins" target="tools/agents/net20" />
-
     <file src="$BIN$agents/net40/nunit.engine.api.dll" target="tools/agents/net40" />
     <file src="$BIN$agents/net40/testcentric.engine.metadata.dll" target="tools/agents/net40" />
     <file src="$BIN$agents/net40/testcentric.engine.core.dll" target="tools/agents/net40" />

--- a/nuget/TestCentric.GuiRunner.nuspec
+++ b/nuget/TestCentric.GuiRunner.nuspec
@@ -64,15 +64,6 @@
     <file src="Images/Tree/Visual Studio/Skipped.png" target="tools/Images/Tree/Visual Studio" />
     <file src="Images/Tree/Visual Studio/Success.png" target="tools/Images/Tree/Visual Studio" />
 
-    <file src="agents/net20/nunit.engine.api.dll" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric.engine.metadata.dll" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric.engine.core.dll" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric-agent.exe" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric-agent.exe.config" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric-agent-x86.exe" target="tools/agents/net20" />
-    <file src="agents/net20/testcentric-agent-x86.exe.config" target="tools/agents/net20" />
-    <file src="../../nuget/testcentric-agent.nuget.addins" target="tools/agents/net20" />
-
     <file src="agents/net40/nunit.engine.api.dll" target="tools/agents/net40" />
     <file src="agents/net40/testcentric.engine.metadata.dll" target="tools/agents/net40" />
     <file src="agents/net40/testcentric.engine.core.dll" target="tools/agents/net40" />

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -17,8 +17,8 @@
   
 	<ItemGroup>
     <PackageReference Include="NUnit.Engine.Api" Version="4.0.0-dev-001" />
-    <PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00522" />
-    <PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00522" />
+    <PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00524" />
+    <PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00524" />
   </ItemGroup>
   
 </Project>

--- a/src/TestModel/tests/TestModelAssemblyTests.cs
+++ b/src/TestModel/tests/TestModelAssemblyTests.cs
@@ -32,14 +32,6 @@ namespace TestCentric.Gui.Model
             _model.Dispose();
         }
 
-        [Test] // TODO: Move this to the engine tests
-        public void EnsureAgentIsAvailable()
-        {
-            var testDir = TestContext.CurrentContext.TestDirectory;
-            Assert.That(File.Exists(Path.Combine(testDir, "agents/net20/testcentric-agent.exe")), "Cannot find testcentric-agent - may cause other test failures");
-            Assert.That(File.Exists(Path.Combine(testDir, "agents/net20/testcentric-agent-x86.exe")), "Cannot find testcentric-agent-x86 - may cause other test failures");
-        }
-
         [Test]
         public void CheckStateAfterLoading()
         {


### PR DESCRIPTION
.NET Framework 2.0 and 3.5 Tests will no longer be run under a .NET 2.0 agent by default. Users wanting to run under .NET 2.0 will need to use the Net20 Agent as an extension.