### PR TITLE
Temporary fix for running checked tests

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -41,10 +41,10 @@ namespace TestCentric.Gui.Presenters
 
             _treeSettings = _model.Settings.Gui.TestTree;
 
-            _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
+            _view.ShowCheckBoxes.Checked = _view.Tree.CheckBoxes = _treeSettings.ShowCheckBoxes;
             _view.AlternateImageSet = _treeSettings.AlternateImageSet;
 
-            InitializeRunCommands();
+            //InitializeRunCommands();
 
             WireUpEvents();
         }
@@ -61,7 +61,7 @@ namespace TestCentric.Gui.Presenters
                 EnsureNonRunnableFilesAreVisible(ea.Test);
 
                 Strategy.OnTestLoaded(ea.Test);
-                InitializeRunCommands();
+                //InitializeRunCommands();
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
             };
@@ -71,13 +71,13 @@ namespace TestCentric.Gui.Presenters
                 EnsureNonRunnableFilesAreVisible(ea.Test);
 
                 Strategy.OnTestLoaded(ea.Test);
-                InitializeRunCommands();
+                //InitializeRunCommands();
             };
 
             _model.Events.TestUnloaded += (ea) =>
             {
                 Strategy.OnTestUnloaded();
-                InitializeRunCommands();
+                //InitializeRunCommands();
             };
 
             _model.Events.TestsUnloading += ea =>
@@ -89,13 +89,13 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.RunStarting += (ea) =>
             {
-                InitializeRunCommands();
+                //InitializeRunCommands();
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
             };
             _model.Events.RunFinished += (ea) =>
             {
-                InitializeRunCommands();
+                //InitializeRunCommands();
             };
 
             _model.Events.TestFinished += OnTestFinished;
@@ -128,16 +128,15 @@ namespace TestCentric.Gui.Presenters
             // Test for null is a hack that allows us to avoid
             // a problem under Linux creating a ContextMenuStrip
             // when no display is present.
-            if (_view.Tree.ContextMenuStrip != null)
-                _view.Tree.ContextMenuStrip.Opening += (s, e) => InitializeContextMenu();
+            _view.ContextMenuOpening += (s, e) => InitializeContextMenu();
 
             _view.CollapseAllCommand.Execute += () => _view.CollapseAll();
             _view.ExpandAllCommand.Execute += () => _view.ExpandAll();
             _view.CollapseToFixturesCommand.Execute += () => Strategy.CollapseToFixtures();
             _view.ShowCheckBoxes.CheckedChanged += () =>
             {
-                _view.RunCheckedCommand.Visible =
-                _view.DebugCheckedCommand.Visible =
+                //_view.RunCheckedCommand.Visible =
+                //_view.DebugCheckedCommand.Visible =
                 _view.Tree.CheckBoxes = _view.ShowCheckBoxes.Checked;
             };
 
@@ -343,7 +342,7 @@ namespace TestCentric.Gui.Presenters
 
         private void InitializeContextMenu()
         {
-            // TODO: Menu is hidden until changing the config actually works
+            // TODO: Config Menu is hidden until changing the config actually works
             bool displayConfigMenu = false;
             //var test = _view.ContextNode?.Tag as TestNode;
             //if (test != null && test.IsProject)
@@ -367,21 +366,24 @@ namespace TestCentric.Gui.Presenters
             //    }
             //}
 
+            _view.RunCheckedCommand.Visible =
+            _view.DebugCheckedCommand.Visible = _view.ShowCheckBoxes.Checked;
+
             _view.ActiveConfiguration.Visible = displayConfigMenu;
 
             var layout = _model.Settings.Gui.GuiLayout;
             _view.TestPropertiesCommand.Visible = layout == "Mini";
         }
 
-        private void InitializeRunCommands()
-        {
-            bool isRunning = _model.IsTestRunning;
-            bool canRun = _model.HasTests && !isRunning;
-            bool canRunChecked = canRun && _view.ShowCheckBoxes.Checked;
+        //private void InitializeRunCommands()
+        //{
+        //    bool isRunning = _model.IsTestRunning;
+        //    bool canRun = _model.HasTests && !isRunning;
+        //    bool canRunChecked = canRun && _view.ShowCheckBoxes.Checked;
 
-            _view.RunCheckedCommand.Visible =
-            _view.DebugCheckedCommand.Visible = canRunChecked;
-        }
+        //    _view.RunCheckedCommand.Visible =
+        //    _view.DebugCheckedCommand.Visible = canRunChecked;
+        //}
 
         private void SetDefaultDisplayStrategy()
         {

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using System;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
@@ -13,6 +14,7 @@ namespace TestCentric.Gui.Views
     public interface ITestTreeView : IView
     {
         event TreeNodeActionHandler TreeNodeDoubleClick;
+        event EventHandler ContextMenuOpening;
 
         ICommand RunContextCommand { get; }
         ICommand RunCheckedCommand { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -29,6 +29,7 @@ namespace TestCentric.Gui.Views
         public const int FailureIndex = 4;
 
         public event TreeNodeActionHandler TreeNodeDoubleClick;
+        public event EventHandler ContextMenuOpening;
 
         public TestTreeView()
         {
@@ -51,9 +52,7 @@ namespace TestCentric.Gui.Views
             treeView.MouseDown += (s, e) =>
             {
                 if (e.Button == MouseButtons.Right)
-                {
                     ContextNode = treeView.GetNodeAt(e.X, e.Y);
-                }
             };
 
             treeView.MouseDoubleClick += (s, e) =>
@@ -65,6 +64,8 @@ namespace TestCentric.Gui.Views
                         TreeNodeDoubleClick(treeNode);
                 }
             };
+
+            treeView.ContextMenuStrip.Opening += (s, e) => ContextMenuOpening?.Invoke(s, e);
         }
 
         #region Properties

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -13,6 +13,8 @@ namespace TestCentric.Gui.Presenters.TestTree
     using Model;
     using Elements;
     using System.Collections.Generic;
+    using System.ComponentModel;
+    using System;
 
     public class TreeViewPresenterTests : TreeViewPresenterTestBase
     {
@@ -68,5 +70,28 @@ namespace TestCentric.Gui.Presenters.TestTree
 
         //    _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
         //}
+
+        [Test, Combinatorial]
+        public void WhenContextMenuIsDisplayed_RunCheckedCommandVisibilityIsSet(
+            [Values] bool showCheckBoxes)
+        {
+            var tree = Substitute.For<ITreeView>();
+            tree.ContextMenuStrip.Returns(new ContextMenuStrip());
+            tree.CheckBoxes.Returns(showCheckBoxes);
+            
+            var testNode = new TestNode(XmlHelper.CreateXmlNode("<test-case/>"));
+            var treeNode = new TreeNode()
+            {
+                Tag = testNode
+            };
+
+            _view.ShowCheckBoxes.Checked.Returns(showCheckBoxes);
+            _view.ContextNode.Returns(treeNode);
+            _view.Tree.Returns(tree);
+
+            _view.ClearReceivedCalls();
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+            ViewElement("RunCheckedCommand").Received().Visible = showCheckBoxes;
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
@@ -10,13 +10,6 @@ namespace TestCentric.Gui.Presenters.TestTree
 {
     public class WhenPresenterIsCreated : TreeViewPresenterTestBase
     {
-        [TestCase("RunCheckedCommand", false)]
-        [TestCase("DebugCheckedCommand", false)]
-        public void CheckElementVisibility(string propName, bool visible)
-        {
-            ViewElement(propName).Received().Visible = visible;
-        }
-
         [Test]
         public void AlternateImageSetIsSet()
         {


### PR DESCRIPTION
Partial fix to issue #854

This PR reactivates the Run Checked Tests item in the tree's context menu, giving the user a way to run checked tests. The issue remains open for further changes, however.