### PR TITLE
Update to beta4 engine and latest agents

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,10 @@
 // NOTE: This must match what is actually referenced by
 // the GUI test model project. Hopefully, this is a temporary
 // fix, which we can get rid of in the future.
-const string REF_ENGINE_VERSION = "2.0.0-dev00030";
+const string REF_ENGINE_VERSION = "2.0.0-dev00035";
 
 // Load the recipe
-#load nuget:?package=TestCentric.Cake.Recipe&version=1.1.0-dev00063
+#load nuget:?package=TestCentric.Cake.Recipe&version=1.1.0-dev00065
 // Comment out above line and uncomment below for local tests of recipe changes
 //#load ../TestCentric.Cake.Recipe/recipe/*.cake
 
@@ -74,9 +74,10 @@ var nugetPackage = new NuGetPackage(
 			new DirectoryContent("tools/Images/Tree/Visual Studio").WithFiles(
 				"Images/Tree/Visual Studio/Success.png", "Images/Tree/Visual Studio/Failure.png", "Images/Tree/Visual Studio/Ignored.png", "Images/Tree/Visual Studio/Inconclusive.png", "Images/Tree/Visual Studio/Skipped.png") )
 		.WithDependencies(
-			KnownExtensions.Net462PluggableAgent.SetVersion("2.4.0-dev00011").NuGetPackage,
-			KnownExtensions.Net60PluggableAgent.SetVersion("2.4.0-dev00009").NuGetPackage,
-			KnownExtensions.Net70PluggableAgent.SetVersion("2.4.0-dev00012").NuGetPackage
+			KnownExtensions.Net462PluggableAgent.NuGetPackage,
+			KnownExtensions.Net60PluggableAgent.NuGetPackage,
+			KnownExtensions.Net70PluggableAgent.NuGetPackage,
+			KnownExtensions.Net80PluggableAgent.NuGetPackage
 		),
 	testRunner: new GuiSelfTester(BuildSettings.NuGetTestDirectory + "TestCentric.GuiRunner." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {
@@ -113,9 +114,10 @@ var chocolateyPackage = new ChocolateyPackage(
 			new DirectoryContent("tools/Images/Tree/Visual Studio").WithFiles(
 				"Images/Tree/Visual Studio/Success.png", "Images/Tree/Visual Studio/Failure.png", "Images/Tree/Visual Studio/Ignored.png", "Images/Tree/Visual Studio/Inconclusive.png", "Images/Tree/Visual Studio/Skipped.png") )
 		.WithDependencies(
-			KnownExtensions.Net462PluggableAgent.SetVersion("2.4.0-dev00011").ChocoPackage,
-			KnownExtensions.Net60PluggableAgent.SetVersion("2.4.0-dev00009").ChocoPackage,
-			KnownExtensions.Net70PluggableAgent.SetVersion("2.4.0-dev00012").ChocoPackage
+			KnownExtensions.Net462PluggableAgent.ChocoPackage,
+			KnownExtensions.Net60PluggableAgent.ChocoPackage,
+			KnownExtensions.Net70PluggableAgent.ChocoPackage,
+			KnownExtensions.Net80PluggableAgent.ChocoPackage
 		),
 	testRunner: new GuiSelfTester(BuildSettings.ChocolateyTestDirectory + "testcentric-gui." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {
@@ -123,7 +125,7 @@ var chocolateyPackage = new ChocolateyPackage(
 		HasDirectory("tools/Images/Tree/Circles").WithFiles(TREE_ICONS_JPG),
 		HasDirectory("tools/Images/Tree/Classic").WithFiles(TREE_ICONS_JPG),
 		HasDirectory("tools/Images/Tree/Default").WithFiles(TREE_ICONS_PNG),
-		HasDirectory("tools/Images/Tree/Visual Studio").WithFiles(TREE_ICONS_PNG)
+		HasDirectory("tools/Images/Tree/Visual Studio").WithFiles(TREE_ICONS_PNG),
 	},
 	tests: PackageTests
 );

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -83,6 +83,14 @@ public static void DefinePackageTests()
             Assemblies = new [] { new ExpectedAssemblyResult("aspnetcore-test.dll", "Net70AgentLauncher") }
         }));
 
+    // TODO: Need a --runtime command-line option to do this test
+    //// We can't yet mock-assembly under .NET 8.0 until we use VS 17.8, so we just run the .NET 7.0
+    //// build under .NET 8.0. On AppVeyor, we can't even do that.
+    //if (!BuildSettings.IsRunningOnAppVeyor)
+    //    packageTests.Add(new PackageTest(1, "Net80Test", "Run mock-assembly.dll targeting .NET 7.0 under .NET 8.0",
+    //        "engine-tests/net7.0/mock-assembly.dll --trace:Debug --runtime:netcore-8.0",
+    //        MockAssemblyExpectedResult("Net80AgentLauncher")));
+
 	// Windows Forms Tests
 
     PackageTests.Add(new PackageTest(1, "Net50WindowsFormsTest", "Run test using windows forms under .NET 5.0",

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -15,8 +15,8 @@
   
 	<ItemGroup>
 		<PackageReference Include="Mono.Options" Version="6.12.0.148" />
-		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00030" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00036" />
+		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00035" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta4" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.0.0" />
 	</ItemGroup>

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnitLite" Version="3.13.2" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00036" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta4" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.0.0" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />


### PR DESCRIPTION
This is a test run aimed at resolving #1031. In this PR we are not referencing the beta4 engine, since that has not yet been released. But we're referencing  the dev00035 build, which is intended to become the beta4 release.