### PR TITLE
Improve robustness of ProgressBar for "no test cases are selected" (Solves Issue 1087)

### DIFF
--- a/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
@@ -64,20 +64,31 @@ namespace TestCentric.Gui.Controls
 
         #region Methods
 
+        public int GetProgressWidth(Rectangle rec)
+        {
+            if (Maximum == 0)
+                return 0;
+            return (int)(rec.Width * ((double)Value / Maximum));
+        }
+
+        public int GetPercentCompleted()
+        {
+            if (Maximum == 0)
+                return 0;
+            return Value * 100 / Maximum;
+        }
+
         protected override void OnPaint(PaintEventArgs e)
         {
-            if (Maximum == 0)       // No progress can be painted in this case
-                return;
-
             Rectangle rec = this.ClientRectangle;
             rec.Inflate(-2, -2);
             if (ProgressBarRenderer.IsSupported)
                 ProgressBarRenderer.DrawHorizontalBar(e.Graphics, rec);
             rec.Inflate(-1, -1);
-            rec.Width = (int)(rec.Width * ((double)Value / Maximum));
+            rec.Width = GetProgressWidth(rec);
             e.Graphics.FillRectangle(_brush, rec); //2, 2, rec.Width, rec.Height);
 
-            int percentComplete = Value * 100 / Maximum;
+            int percentComplete = GetPercentCompleted();
             if (ShowPercentComplete && percentComplete > 0)
             {
                 string text = $"{(int)percentComplete}%";

--- a/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
+++ b/src/TestCentric/testcentric.gui/Controls/TestCentricProgressBar.cs
@@ -66,6 +66,9 @@ namespace TestCentric.Gui.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            if (Maximum == 0)       // No progress can be painted in this case
+                return;
+
             Rectangle rec = this.ClientRectangle;
             rec.Inflate(-2, -2);
             if (ProgressBarRenderer.IsSupported)

--- a/src/TestCentric/tests/Controls/TestCentricProgressBarTests.cs
+++ b/src/TestCentric/tests/Controls/TestCentricProgressBarTests.cs
@@ -1,0 +1,70 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Drawing;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Controls
+{
+    [TestFixture]
+    public class TestCentricProgressBarTests
+    {
+        [Test]
+        [TestCase(0, 0)]
+        [TestCase(50, 100)]
+        [TestCase(100, 200)]
+        public void GetProgressWidth_MaximumValueIsDefined_ReturnsExpectedValue(int progress, int expectedWidth)
+        {
+            TestCentricProgressBar progressBar = new TestCentricProgressBar();
+            progressBar.Maximum = 100;
+            progressBar.Value = progress;
+
+            Rectangle rect = new Rectangle(0, 0, 200, 50);
+            int width = progressBar.GetProgressWidth(rect);
+
+            Assert.That(width, Is.EqualTo(expectedWidth));
+        }
+
+        [Test]
+        public void GetProgressWidth_MaximumValueIsZero_ReturnsZero()
+        {
+            TestCentricProgressBar progressBar = new TestCentricProgressBar();
+            progressBar.Maximum = 0;
+            progressBar.Value = 0;
+
+            Rectangle rect = new Rectangle(0, 0, 200, 50);
+            int width = progressBar.GetProgressWidth(rect);
+
+            Assert.That(width, Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCase(0, 0)]
+        [TestCase(50, 50)]
+        [TestCase(100, 100)]
+        public void GetPercentCompleted_MaximumValueIsDefined_ReturnsExpectedValue(int progress, int expectedPercent)
+        {
+            TestCentricProgressBar progressBar = new TestCentricProgressBar();
+            progressBar.Maximum = 100;
+            progressBar.Value = progress;
+
+            int percent = progressBar.GetPercentCompleted();
+
+            Assert.That(percent, Is.EqualTo(expectedPercent));
+        }
+
+        [Test]
+        public void GetPercentCompleted_MaximumValueIsZero_ReturnsZero()
+        {
+            TestCentricProgressBar progressBar = new TestCentricProgressBar();
+            progressBar.Maximum = 0;
+            progressBar.Value = 0;
+
+            int percent = progressBar.GetPercentCompleted();
+
+            Assert.That(percent, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/TestCentric/tests/Controls/TestCentricProgressBarTests.cs
+++ b/src/TestCentric/tests/Controls/TestCentricProgressBarTests.cs
@@ -11,7 +11,6 @@ namespace TestCentric.Gui.Controls
     [TestFixture]
     public class TestCentricProgressBarTests
     {
-        [Test]
         [TestCase(0, 0)]
         [TestCase(50, 100)]
         [TestCase(100, 200)]
@@ -40,7 +39,6 @@ namespace TestCentric.Gui.Controls
             Assert.That(width, Is.EqualTo(0));
         }
 
-        [Test]
         [TestCase(0, 0)]
         [TestCase(50, 50)]
         [TestCase(100, 100)]


### PR DESCRIPTION
Fixes #1087 

This PR closes issue #1087 by improving the robustness of the ProgressBar class and thereby avoiding the DivideByZeroException. So overall it's considered as a simple and low risk solution to fix this issue without changing any user workflow.

The user output in this case is: 
Please note the Test count:0 in the screenshot and the empty ProgressBar
![Uploading TestOutput.jpg…]()


Alternativate solutions:
- Don't start 'Run selected tests' workflow, if no tests are selected (maybe with some message box)
- Disable toolbar button 'Run selected tests', if no tests are selected

The additional observation mentioned in this issue about the Settings -> Tree Display -> Display a checkbox is not handled by this PR, but I propose it should handled by a separate issue which defines the target state.