### PR TITLE
Improve "Show checkboxes in tree" functionality

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -55,9 +55,8 @@ namespace TestCentric.Gui.Presenters
             {
                 EnsureNonRunnableFilesAreVisible(ea.Test);
 
-                VisualState visualState;
-
-                if (TryLoadVisualState(out visualState))
+                bool visualStateLoaded = TryLoadVisualState(out VisualState visualState);
+                if (visualStateLoaded)
                 {
                     switch (visualState.DisplayStrategy)
                     {
@@ -77,6 +76,7 @@ namespace TestCentric.Gui.Presenters
                 else
                     Strategy = new NUnitTreeDisplayStrategy(_view, _model);
 
+                _view.ShowCheckBoxes.Checked = visualStateLoaded ? visualState.ShowCheckBoxes : _treeSettings.ShowCheckBoxes;
                 Strategy.OnTestLoaded(ea.Test, visualState);
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
@@ -129,6 +129,9 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
                         Strategy.Reload();
+                        break;
+                    case "TestCentric.Gui.TestTree.ShowCheckBoxes":
+                        _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
                         break;
                 }
             };

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -9,15 +9,26 @@ using NSubstitute;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
-    using Views;
-    using Model;
-    using Elements;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System;
-
     public class TreeViewPresenterTests : TreeViewPresenterTestBase
     {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void WhenSettingsAreChanged_ShowCheckBoxes_NewSettingIsApplied(bool showCheckBoxSetting)
+        {
+            _model.Settings.Gui.TestTree.ShowCheckBoxes = showCheckBoxSetting;
+
+            Assert.That(_view.ShowCheckBoxes.Checked, Is.EqualTo(showCheckBoxSetting));
+        }
+
+        [TestCase("Default")]
+        [TestCase("VisualStudio")]
+        public void WhenSettingsAreChanged_AlternateImageSet_NewSettingIsApplied(string imageSet)
+        {
+            _model.Settings.Gui.TestTree.AlternateImageSet = imageSet;
+
+            Assert.That(_view.AlternateImageSet, Is.EqualTo(imageSet));
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenContextNodeIsNotNull_RunCommandExecutesThatTest()
@@ -75,7 +86,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         //public void WhenContextMenuIsDisplayed_RunCheckedCommandVisibilityIsSet(
         //    [Values] bool showCheckBoxes)
         //{
-            
+
         //    var testNode = new TestNode(XmlHelper.CreateXmlNode("<test-case/>"));
         //    var treeNode = new TreeNode()
         //    {


### PR DESCRIPTION
This PR closes #1090 by applying the "Show checkboxes" settings in these use cases:

- If "Show checkboxes" is changed in the settings, it's applied to the test tree immediately.
- If a test is loaded, the checkboxes are shown according to the VisualState file (if present) or the default value from the setting is applied.
  (Moreover the state of the context menu entry 'Show checkboxes" is consistent to the tree)

These changes are intended to provide a more consistent user experience when working with "Show checkboxes" functionality.
But please check first, if you agree with this proposed solution from customer point of view.
 