### PR TITLE
Hide ResultSummary view when closing/reloading tests; Fix cross thread access for closing XML/TestProperties view

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -130,6 +130,7 @@ namespace TestCentric.Gui.Presenters
             {
                 UpdateViewCommands();
 
+                _view.RunSummaryDisplay.Hide();
                 BeginLongRunningOperation("Unloading...");
             };
 
@@ -144,6 +145,7 @@ namespace TestCentric.Gui.Presenters
             {
                 UpdateViewCommands();
 
+                _view.RunSummaryDisplay.Hide();
                 BeginLongRunningOperation("Reloading...");
             };
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -16,6 +16,7 @@ namespace TestCentric.Gui.Presenters
     using System.Xml;
     using System.Drawing;
     using System.IO;
+    using TestCentric.Gui.Controls;
 
     /// <summary>
     /// TreeViewPresenter is the presenter for the TestTreeView
@@ -326,7 +327,7 @@ namespace TestCentric.Gui.Presenters
         {
             if (_propertiesDisplay != null)
             {
-                _propertiesDisplay.Close();
+                _propertiesDisplay.InvokeIfRequired(() => _propertiesDisplay.Close());
                 _propertiesDisplay = null;
             }
         }
@@ -380,14 +381,13 @@ namespace TestCentric.Gui.Presenters
 
         private void CloseXmlDisplay()
         {
-            _xmlDisplay?.Close();
+            _xmlDisplay?.InvokeIfRequired(() => _xmlDisplay?.Close());
         }
 
         private void CheckXmlDisplay()
         {
             if (_xmlDisplay != null && !_xmlDisplay.Pinned)
-                _xmlDisplay.Close();
-
+                CloseXmlDisplay();
         }
 
         private void InitializeContextMenu()

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloading.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloading.cs
@@ -1,0 +1,21 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NSubstitute;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Presenters.Main
+{
+    [TestFixture]
+    public class WhenTestsAreReloading : MainPresenterTestBase
+    {
+        [Test]
+        public void ReloadingTests_SummaryResultView_IsHidden()
+        {
+            FireTestsReloadingEvent();
+            _view.RunSummaryDisplay.Received().Hide();
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreUnloading.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreUnloading.cs
@@ -1,0 +1,21 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NSubstitute;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Presenters.Main
+{
+    [TestFixture]
+    public class WhenTestsAreUnloading : MainPresenterTestBase
+    {
+        [Test]
+        public void UnloadingTests_SummaryResultView_IsHidden()
+        {
+            FireTestsUnloadingEvent();
+            _view.RunSummaryDisplay.Received().Hide();
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #1092 and closes #1093.
I hope it's OK to combine both fixes in one PR as these changes are small.

**Issue 'ResultSummary view':**
The proposed changes take care that the ResultSummary view gets hidden, when tests are unloading and when tests are reloading. I was wondering whether event Unloading/Reloading or event Unloaded/Reloaded are better for this task, but came to the conclusion that for this use case it's not a essential difference. So I stick with the event Unloading/Reloading.

**Issue cross-thread access:**
The solution uses the existing extension method InvokeIfRequired to solve the cross-thread access.
I have given some thought to whether unit tests can be written here, but I failed to find any solution. I assume that some UI thread must be running during test execution to reproduce this issue in a test run, that seems challenging on first sight. If there is already a sample solution somewhere for this use case, then I can also apply it here.
