### PR TITLE
Close property window when switching from Mini GUI to full GUI view mode

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -133,6 +133,10 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
                         _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
                         break;
+                    case "TestCentric.Gui.GuiLayout":
+                        if (_model.Settings.Gui.GuiLayout == "Full")
+                            ClosePropertiesDisplay();
+                        break;
                 }
             };
 

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -353,6 +353,7 @@ namespace TestCentric.Gui.Views
             this.rerunButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.rerunButton.Name = "rerunButton";
             this.rerunButton.Size = new System.Drawing.Size(23, 21);
+            this.rerunButton.ToolTipText = "Repeat last test run";
             // 
             // runFailedButton
             // 


### PR DESCRIPTION
This PR closes #1098 by closing the Properties dialog when switching from Mini GUI to Full GUI mode.

This fix doesn't solve any critical existing problems, but is instead intended to simplify the use cases and to avoid any unexpected handling in the future. Of course, we can discuss whether the dialog is also helpful in Full GUI mode. But since it cannot actually be opened using the Full GUI mode, I would not support it in this way either.

This PR includes also a second improvement:
All toolbar buttons provide a tooltip - all buttons except one! This missing tooltip was added now.