### PR TITLE
Reset all tree node images to the initial state before starting a new test run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2022
 
 build_script: 
   - cmd: dotnet --info
-  - ps: .\build.ps1 --Target=AppVeyor --Configuration=Release
+  - ps: .\build.ps1 --Target=ContinuousIntegration --Configuration=Release
   
 # disable built-in tests.
 test: false

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 const string REF_ENGINE_VERSION = "2.0.0-dev00023";
 
 // Load the recipe
-#load nuget:?package=TestCentric.Cake.Recipe&version=1.2.1-dev00010
+#load nuget:?package=TestCentric.Cake.Recipe&version=1.3.1
 // Comment out above line and uncomment below for local tests of recipe changes
 //#load ../TestCentric.Cake.Recipe/recipe/*.cake
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -112,6 +112,7 @@ namespace TestCentric.Gui.Presenters
                 // or user terminates cancels the run.
                 Strategy.SaveVisualState();
 
+                _view.ResetAllTreeNodeImages(); 
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
             };

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -57,6 +57,11 @@ namespace TestCentric.Gui.Views
         void SetImageIndex(TreeNode treeNode, int imageIndex);
 
         /// <summary>
+        /// Reset the image of all tree nodes to the initial state
+        /// </summary>
+        void ResetAllTreeNodeImages();
+
+        /// <summary>
         /// Invoke a delegate if necessary, otherwise just call it
         /// </summary>
         void InvokeIfRequired(MethodInvoker _delegate);

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -175,6 +175,20 @@ namespace TestCentric.Gui.Views
         public void SetImageIndex(TreeNode treeNode, int imageIndex) =>
             InvokeIfRequired(() => treeNode.ImageIndex = treeNode.SelectedImageIndex = imageIndex);
 
+        public void ResetAllTreeNodeImages()
+        {
+            InvokeIfRequired(() => ResetAllTreeNodeImages(treeView.Nodes));
+        }
+
+        private void ResetAllTreeNodeImages(TreeNodeCollection treeNodes)
+        {
+            foreach (TreeNode treeNode in treeNodes)
+            {
+                treeNode.ImageIndex = treeNode.SelectedImageIndex = InitIndex;
+                ResetAllTreeNodeImages(treeNode.Nodes);
+            }
+        }
+
         public void InvokeIfRequired(MethodInvoker _delegate)
         {
             if (treeView.InvokeRequired)

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -3,22 +3,47 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Framework;
+using System.IO;
+using System.Windows.Forms;
 using NSubstitute;
+using NUnit.Framework;
+using TestCentric.Gui.Model;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
-    public class WhenTestRunBegins
+    public class WhenTestRunBegins : TreeViewPresenterTestBase
     {
-        // TODO: Version 1 Test - Make it work if needed.
-        ////[Test] // TODO: simulate actual loading
-        //public void WhenTestRunStarts_RunCommandIsDisabled()
-        //{
-        //    ClearAllReceivedCalls();
-        //    FireRunStartingEvent(1234);
+        // Use dedicated test file name; Used for VisualState file too
+        const string TestFileName = "TreeViewPresenterTestRunBegin.dll";
 
-        //    _view.RunCommand.Received().Enabled = false;
-        //}
+        [TearDown]
+        public void TearDown()
+        {
+            // Delete VisualState file to prevent any unintended side effects
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+        }
+
+        [Test]
+        public void WhenTestRunStarts_TreeNodeImagesAreReset()
+        {
+            // Arrange
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            var project = new TestCentricProject(_model, TestFileName);
+            _model.TestCentricProject.Returns(project);
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireRunStartingEvent(1234);
+
+            // Assert
+            _view.Received().ResetAllTreeNodeImages();
+        }
 
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]


### PR DESCRIPTION
This PR closes #1094.

All tree node images are reset to the default state before starting a new test run. The behavior is now identical to the previous TestCentric 1.6.4 version.