### PR TITLE
Support changing the tree display format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2022
+image: Previous Visual Studio 2022
 
 build_script: 
   - cmd: dotnet --info

--- a/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
@@ -79,6 +79,12 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
         }
 
+        public override bool IsGroupingUpToDate()
+        {
+            string groupId = _settings.Gui.TestTree.FixtureList.GroupBy;
+            return _grouping?.ID == groupId;
+        }
+
         #endregion
 
         #region Protected Members

--- a/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
@@ -36,13 +36,19 @@ namespace TestCentric.Gui.Presenters
             get { return "Fixtures By " + DefaultGroupSetting; }
         }
 
-        protected override VisualState CreateVisualState() => new VisualState("FIXTURE_LIST", _grouping.ID).LoadFrom(_view.TreeView);
+        protected override VisualState CreateVisualState() => new VisualState("FIXTURE_LIST", _grouping?.ID).LoadFrom(_view.TreeView);
 
         public override void OnTestLoaded(TestNode testNode, VisualState visualState)
         {
             ClearTree();
 
-            switch (DefaultGroupSetting)
+            string groupBy = DefaultGroupSetting;
+            if (_grouping == null || _grouping.ID != groupBy)
+            {
+                _grouping = CreateTestGrouping(groupBy);
+            }
+
+            switch (groupBy)
             {
                 default:
                 case "ASSEMBLY":

--- a/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
@@ -79,12 +79,6 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
         }
 
-        public override bool IsGroupingUpToDate()
-        {
-            string groupId = _settings.Gui.TestTree.FixtureList.GroupBy;
-            return _grouping?.ID == groupId;
-        }
-
         #endregion
 
         #region Protected Members

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -31,6 +31,12 @@ namespace TestCentric.Gui.Presenters
         #region Public Methods
 
         /// <summary>
+        /// Checks if the GroupBy value from the settings
+        /// is applied as current grouping
+        /// </summary>
+        public virtual bool IsGroupingUpToDate() => false;
+
+        /// <summary>
         /// Post a test result to the tree, changing the treeNode
         /// color to reflect success or failure. Overridden here
         /// to allow for moving nodes from one group to another
@@ -84,7 +90,7 @@ namespace TestCentric.Gui.Presenters
             // for groupings that display each node once.
             var treeNode = treeNodes[0];
             var oldParent = treeNode.Parent;
-            var oldGroup = oldParent.Tag as TestGroup;
+            var oldGroup = oldParent?.Tag as TestGroup;
 
             // We only have to proceed for tests that are direct
             // descendants of a group node.
@@ -155,12 +161,6 @@ namespace TestCentric.Gui.Presenters
         protected void SetDefaultTestGrouping()
         {
             _grouping = CreateTestGrouping(DefaultGroupSetting);
-        }
-
-        protected void SetTestGrouping(string groupBy)
-        {
-            _grouping = CreateTestGrouping(groupBy);
-            DefaultGroupSetting = groupBy;
         }
 
         protected abstract string DefaultGroupSetting { get; set; }

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -29,13 +29,6 @@ namespace TestCentric.Gui.Presenters
         #endregion
 
         #region Public Methods
-
-        /// <summary>
-        /// Checks if the GroupBy value from the settings
-        /// is applied as current grouping
-        /// </summary>
-        public virtual bool IsGroupingUpToDate() => false;
-
         /// <summary>
         /// Post a test result to the tree, changing the treeNode
         /// color to reflect success or failure. Overridden here

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -10,11 +10,6 @@ namespace TestCentric.Gui.Presenters
     public interface ITreeDisplayStrategy
     {
         /// <summary>
-        /// The identifier of the strategy
-        /// </summary>
-        string StrategyID { get; }
-
-        /// <summary>
         /// Called when a test is loaded: build of all tree nodes and apply VisualState
         /// (for example: expand/collapse nodes)
         /// </summary>

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -80,6 +80,7 @@ namespace TestCentric.Gui.Presenters
             _view.ResultTabs.SelectedIndex = _settings.Gui.SelectedTab;
 
             UpdateViewCommands();
+            UpdateTreeDisplayMenuItem();
 
             foreach (string format in _model.ResultFormats)
                 if (format != "cases" && format != "user")
@@ -936,7 +937,9 @@ namespace TestCentric.Gui.Presenters
                 case "FIXTURE_LIST":
                     _view.GroupBy.Enabled = true;
                     // HACK: Should be handled by the element itself
-                    ((Elements.CheckedToolStripMenuGroup)_view.GroupBy).MenuItems[1].Enabled = false;
+                    Elements.CheckedToolStripMenuGroup menuGroup = _view.GroupBy as Elements.CheckedToolStripMenuGroup;
+                    if (menuGroup != null)
+                        menuGroup.MenuItems[1].Enabled = false;
                     _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                     break;
             }

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -937,8 +937,7 @@ namespace TestCentric.Gui.Presenters
                 case "FIXTURE_LIST":
                     _view.GroupBy.Enabled = true;
                     // HACK: Should be handled by the element itself
-                    Elements.CheckedToolStripMenuGroup menuGroup = _view.GroupBy as Elements.CheckedToolStripMenuGroup;
-                    if (menuGroup != null)
+                    if (_view.GroupBy is Elements.CheckedToolStripMenuGroup menuGroup)
                         menuGroup.MenuItems[1].Enabled = false;
                     _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                     break;

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -252,6 +252,16 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.MainForm.ShowStatusBar":
                         _view.StatusBarView.Visible = _settings.Gui.MainForm.ShowStatusBar;
                         break;
+                    case "TestCentric.Gui.TestTree.DisplayFormat":
+                        _view.DisplayFormat.SelectedItem = _settings.Gui.TestTree.DisplayFormat;
+                        UpdateTreeDisplayMenuItem();
+                        break;
+                    case "TestCentric.Gui.TestTree.TestList.GroupBy":
+                        _view.GroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
+                        break;
+                    case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
+                        _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
+                        break;
                 }
             };
 
@@ -473,7 +483,7 @@ namespace TestCentric.Gui.Presenters
 
             _view.DisplayFormat.SelectionChanged += () =>
             {
-                SetTreeDisplayFormat(_view.DisplayFormat.SelectedItem);
+                _settings.Gui.TestTree.DisplayFormat = _view.DisplayFormat.SelectedItem;
             };
 
             _view.GroupBy.SelectionChanged += () =>
@@ -907,8 +917,11 @@ namespace TestCentric.Gui.Presenters
             }
         }
 
-        private void SetTreeDisplayFormat(string displayFormat)
-        {
+        private void UpdateTreeDisplayMenuItem()
+        { 
+            // Get current display format from settings
+            string displayFormat = _settings.Gui.TestTree.DisplayFormat;
+
             _view.DisplayFormat.SelectedItem = displayFormat;
 
             switch (displayFormat)

--- a/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
@@ -91,6 +91,12 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
         }
 
+        public override bool IsGroupingUpToDate()
+        {
+            string groupId = _settings.Gui.TestTree.TestList.GroupBy;
+            return _grouping?.ID == groupId;
+        }
+
         protected override VisualState CreateVisualState() => new VisualState("TEST_LIST", _grouping?.ID).LoadFrom(_view.TreeView);
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
@@ -40,7 +40,13 @@ namespace TestCentric.Gui.Presenters
         {
             ClearTree();
 
-            switch (DefaultGroupSetting)
+            string groupBy = DefaultGroupSetting;
+            if (_grouping == null || _grouping.ID != groupBy)
+            {
+                _grouping = CreateTestGrouping(groupBy);
+            }
+
+            switch (groupBy)
             {
                 default:
                 case "ASSEMBLY":
@@ -85,7 +91,7 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
         }
 
-        protected override VisualState CreateVisualState() => new VisualState("TEST_LIST", _grouping.ID).LoadFrom(_view.TreeView);
+        protected override VisualState CreateVisualState() => new VisualState("TEST_LIST", _grouping?.ID).LoadFrom(_view.TreeView);
 
         #endregion
 

--- a/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
@@ -91,12 +91,6 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
         }
 
-        public override bool IsGroupingUpToDate()
-        {
-            string groupId = _settings.Gui.TestTree.TestList.GroupBy;
-            return _grouping?.ID == groupId;
-        }
-
         protected override VisualState CreateVisualState() => new VisualState("TEST_LIST", _grouping?.ID).LoadFrom(_view.TreeView);
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -97,6 +97,7 @@ namespace TestCentric.Gui.Presenters
                 // or user terminates cancels the run.
                 Strategy.SaveVisualState();
 
+                _model.ClearResults();
                 _view.ResetAllTreeNodeImages(); 
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
@@ -114,13 +115,21 @@ namespace TestCentric.Gui.Presenters
                         break;
                     case "TestCentric.Gui.TestTree.DisplayFormat":
                         {
-                            Strategy = CreateDisplayStrategy(_treeSettings.DisplayFormat, _view, _model);
-                            Strategy.Reload();
+                            // Check if strategy is already up-to-date (for example: while project loading)
+                            string displayFormat = _treeSettings.DisplayFormat;
+                            if (Strategy?.StrategyID != displayFormat)
+                            { 
+                                Strategy = CreateDisplayStrategy(displayFormat, _view, _model);
+                                Strategy.Reload();
+                            }
                             break;
                         }
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
-                        Strategy.Reload();
+                        // Checks if grouping is already up-to-date (for example: while project loading)
+                        GroupDisplayStrategy groupStrategy = Strategy as GroupDisplayStrategy;
+                        if (groupStrategy != null && !groupStrategy.IsGroupingUpToDate())
+                            Strategy.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
                         _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
@@ -154,6 +163,9 @@ namespace TestCentric.Gui.Presenters
                     var testNode = _view.ContextNode.Tag as TestNode;
                     if (testNode != null)
                         _model.RunTests(testNode);
+                    var groupNode = _view.ContextNode.Tag as TestGroup;
+                    if (groupNode != null)
+                        _model.RunTests(groupNode);
                 }
             };
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -116,21 +116,13 @@ namespace TestCentric.Gui.Presenters
                         break;
                     case "TestCentric.Gui.TestTree.DisplayFormat":
                         {
-                            // Check if strategy is already up-to-date (for example: while project loading)
-                            string displayFormat = _treeSettings.DisplayFormat;
-                            if (Strategy?.StrategyID != displayFormat)
-                            { 
-                                Strategy = CreateDisplayStrategy(displayFormat, _view, _model);
-                                Strategy.Reload();
-                            }
+                            Strategy = CreateDisplayStrategy(_treeSettings.DisplayFormat, _view, _model);
+                            Strategy.Reload();
                             break;
                         }
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
-                        // Checks if grouping is already up-to-date (for example: while project loading)
-                        GroupDisplayStrategy groupStrategy = Strategy as GroupDisplayStrategy;
-                        if (groupStrategy != null && !groupStrategy.IsGroupingUpToDate())
-                            Strategy.Reload();
+                        Strategy.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
                         _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
@@ -161,11 +153,9 @@ namespace TestCentric.Gui.Presenters
             {
                 if (_view.ContextNode != null)
                 {
-                    var testNode = _view.ContextNode.Tag as TestNode;
-                    if (testNode != null)
+                    if (_view.ContextNode.Tag is TestNode testNode)
                         _model.RunTests(testNode);
-                    var groupNode = _view.ContextNode.Tag as TestGroup;
-                    if (groupNode != null)
+                    else if (_view.ContextNode.Tag is TestGroup groupNode)
                         _model.RunTests(groupNode);
                 }
             };

--- a/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -45,5 +45,52 @@ namespace TestCentric.Gui.Presenters.Main
         {
             ViewElement(propName).Received().Visible = visible;
         }
+
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void CheckMenu_DisplayFormat_SelectedItem_IsInitialzedFromSettings(string displayFormat)
+        {
+            // 1. Arrange
+            _settings.Gui.TestTree.DisplayFormat = displayFormat;
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+
+            // 3. Assert
+            _view.DisplayFormat.Received().SelectedItem = displayFormat;
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void CheckMenu_GroupBy_SelectedItem_FixtureList_IsInitialzedFromSettings(string groupBy)
+        {
+            // 1. Arrange
+            _settings.Gui.TestTree.DisplayFormat = "FIXTURE_LIST";
+            _settings.Gui.TestTree.FixtureList.GroupBy = groupBy;
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+
+            // 3. Assert
+            _view.GroupBy.Received().SelectedItem = groupBy;
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void CheckMenu_GroupBy_SelectedItem_TestList_IsInitialzedFromSettings(string groupBy)
+        {
+            // 1. Arrange
+            _settings.Gui.TestTree.DisplayFormat = "TEST_LIST";
+            _settings.Gui.TestTree.TestList.GroupBy = groupBy;
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+
+            // 3. Assert
+            _view.GroupBy.Received().SelectedItem = groupBy;
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -1,0 +1,48 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Presenters.Main
+{
+    internal class WhenSettingsChanged : MainPresenterTestBase
+    {
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void DisplayFormat_SettingChanged_MenuItemIsUpdated(string displayFormat)
+        {
+            // 1. Act
+            _settings.Gui.TestTree.DisplayFormat = displayFormat;
+
+            // 2. Assert
+            _view.DisplayFormat.SelectedItem = displayFormat;
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void FixtureListGroupBy_SettingChanged_MenuItemIsUpdated(string groupBy)
+        {
+            // 1. Act
+            _settings.Gui.TestTree.FixtureList.GroupBy = groupBy;
+
+            // 2. Assert
+            _view.GroupBy.SelectedItem = groupBy;
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void TestListGroupBy_SettingChanged_MenuItemIsUpdated(string groupBy)
+        {
+            // 1. Act
+            _settings.Gui.TestTree.TestList.GroupBy = groupBy;
+
+            // 2. Assert
+            _view.GroupBy.SelectedItem = groupBy;
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -45,6 +45,78 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.Received().ResetAllTreeNodeImages();
         }
 
+        [Test]
+        public void WhenTestRunStarts_TestModel_ClearResults()
+        {
+            // Arrange
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            var project = new TestCentricProject(_model, TestFileName);
+            _model.TestCentricProject.Returns(project);
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireRunStartingEvent(1234);
+
+            // Assert
+            _model.Received().ClearResults();
+        }
+
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void WhenTestRunStarts_CurrentDisplayFormat_IsSaved_InVisualFile(string displayFormat)
+        {
+            // Arrange
+            _settings.Gui.TestTree.DisplayFormat = displayFormat;
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            var project = new TestCentricProject(_model, TestFileName);
+            _model.TestCentricProject.Returns(project);
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireRunStartingEvent(1234);
+
+            // Assert
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            VisualState visualState = VisualState.LoadFrom(fileName);
+            Assert.That(visualState.DisplayStrategy, Is.EqualTo(displayFormat));
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void WhenTestRunStarts_CurrentGroupBy_IsSaved_InVisualFile(string groupBy)
+        {
+            // Arrange
+            _settings.Gui.TestTree.DisplayFormat = "FIXTURE_LIST";
+            _settings.Gui.TestTree.FixtureList.GroupBy = groupBy;
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            var project = new TestCentricProject(_model, TestFileName);
+            _model.TestCentricProject.Returns(project);
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireRunStartingEvent(1234);
+
+            // Assert
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            VisualState visualState = VisualState.LoadFrom(fileName);
+            Assert.That(visualState.GroupBy, Is.EqualTo(groupBy));
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenTestRunStarts_ResultsAreCleared()

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -79,6 +79,126 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.ShowCheckBoxes.Checked, Is.EqualTo(showCheckBox));
         }
 
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void TestLoaded_WithVisualState_TreeStrategy_IsCreatedFromVisualState(string displayFormat)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.DisplayStrategy = displayFormat;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_presenter.Strategy.StrategyID, Is.EqualTo(displayFormat));
+        }
+
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void TestLoaded_NoVisualState_TreeStrategy_IsCreatedFromSettings(string displayFormat)
+        {
+            // Arrange: adapt settings
+            _model.Settings.Gui.TestTree.DisplayFormat = displayFormat;
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_presenter.Strategy.StrategyID, Is.EqualTo(displayFormat));
+        }
+
+        [TestCase("NUNIT_TREE")]
+        [TestCase("FIXTURE_LIST")]
+        [TestCase("TEST_LIST")]
+        public void TestLoaded_WithVisualState_DisplayFormatSetting_IsUpdatedFromVisualState(string displayFormat)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.DisplayStrategy = displayFormat;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.DisplayFormat, Is.EqualTo(displayFormat));
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void TestLoaded_WithVisualState_FixtureListGroupBySetting_IsUpdatedFromVisualState(string groupBy)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.DisplayStrategy = "FIXTURE_LIST";
+            visualState.GroupBy = groupBy;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            _model.Settings.Gui.TestTree.TestList.GroupBy = "DURATION";
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.FixtureList.GroupBy, Is.EqualTo(groupBy));
+            Assert.That(_model.Settings.Gui.TestTree.TestList.GroupBy, Is.EqualTo("DURATION"));     // Assert that testList groupBy was not changed accidently
+        }
+
+        [TestCase("ASSEMBLY")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        public void TestLoaded_WithVisualState_TestListGroupBySetting_IsUpdatedFromVisualState(string groupBy)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.DisplayStrategy = "TEST_LIST";
+            visualState.GroupBy = groupBy;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            _model.Settings.Gui.TestTree.FixtureList.GroupBy = "DURATION";
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.TestList.GroupBy, Is.EqualTo(groupBy));
+            Assert.That(_model.Settings.Gui.TestTree.FixtureList.GroupBy, Is.EqualTo("DURATION"));     // Assert that fixtureList groupBy was not changed accidently
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //[Platform(Exclude = "Linux", Reason = "Display issues")]

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -9,6 +9,7 @@ using NSubstitute;
 namespace TestCentric.Gui.Presenters.TestTree
 {
     using Model;
+    using System;
     using System.IO;
     using System.Windows.Forms;
 
@@ -85,10 +86,10 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.ShowCheckBoxes.Checked, Is.EqualTo(showCheckBox));
         }
 
-        [TestCase("NUNIT_TREE")]
-        [TestCase("FIXTURE_LIST")]
-        [TestCase("TEST_LIST")]
-        public void TestLoaded_WithVisualState_TreeStrategy_IsCreatedFromVisualState(string displayFormat)
+        [TestCase("NUNIT_TREE", typeof(NUnitTreeDisplayStrategy))]
+        [TestCase("FIXTURE_LIST", typeof(FixtureListDisplayStrategy))]
+        [TestCase("TEST_LIST", typeof(TestListDisplayStrategy))]
+        public void TestLoaded_WithVisualState_TreeStrategy_IsCreatedFromVisualState(string displayFormat, Type expectedStrategy)
         {
             // Arrange: Create and save VisualState file
             VisualState visualState = new VisualState();
@@ -105,13 +106,13 @@ namespace TestCentric.Gui.Presenters.TestTree
             FireTestLoadedEvent(testNode);
 
             // Assert
-            Assert.That(_presenter.Strategy.StrategyID, Is.EqualTo(displayFormat));
+            Assert.That(_presenter.Strategy, Is.TypeOf(expectedStrategy));
         }
 
-        [TestCase("NUNIT_TREE")]
-        [TestCase("FIXTURE_LIST")]
-        [TestCase("TEST_LIST")]
-        public void TestLoaded_NoVisualState_TreeStrategy_IsCreatedFromSettings(string displayFormat)
+        [TestCase("NUNIT_TREE", typeof(NUnitTreeDisplayStrategy))]
+        [TestCase("FIXTURE_LIST", typeof(FixtureListDisplayStrategy))]
+        [TestCase("TEST_LIST", typeof(TestListDisplayStrategy))]
+        public void TestLoaded_NoVisualState_TreeStrategy_IsCreatedFromSettings(string displayFormat, Type expectedStrategy)
         {
             // Arrange: adapt settings
             _model.Settings.Gui.TestTree.DisplayFormat = displayFormat;
@@ -125,7 +126,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             FireTestLoadedEvent(testNode);
 
             // Assert
-            Assert.That(_presenter.Strategy.StrategyID, Is.EqualTo(displayFormat));
+            Assert.That(_presenter.Strategy, Is.TypeOf(expectedStrategy));
         }
 
         [TestCase("NUNIT_TREE")]

--- a/src/TestModel/model/Settings/TestTreeSettings.cs
+++ b/src/TestModel/model/Settings/TestTreeSettings.cs
@@ -38,6 +38,12 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(ShowCheckBoxes), value); }
         }
 
+        public string DisplayFormat
+        {
+            get { return GetSetting(nameof(DisplayFormat), "NUNIT_TREE"); }
+            set { SaveSetting(nameof(DisplayFormat), value); }
+        }
+
         public class FixtureListSettings : SettingsGroup
         {
             public FixtureListSettings(ISettings settings, string prefix) : base(settings, prefix + "FixtureList") { }


### PR DESCRIPTION
This PR is related to issue #1101. However it's not completed yet, but it's intended to check that I'm on the right track. So it's more a preview about the upcoming changes - for example all tests are missing. But this commit already contains more changes than I did before, so some confirmation is helpful.

For a list of use cases / test cases for this issue see my comment in #1101.

The essential part from a technical point of view is that I introduced a new setting 'DisplayFormat'. So whenever this setting changes, the TreeViewPresenter can update the tree and the TestCentricPresenter can update the selected menu items. I copied this approach from the GroupBy functionality - which also use a setting as the central store and notification.
I hope this is aligned with the general design.

While implementing/testing these changes, these considerations came into my mind:

- Should we align the wording: sometimes it's called 'DisplayFormat' and sometimes 'DisplayStrategy'? I would be a good point in time to harmonize this wording - I would prefer 'DisplayStrategy' as all those classes are also named XYZStrategy. But we could keep it unchanged of course also.
- I wonder if I should try to introduce an interface IStrategy for testability reasons. Currently the class TreeViewPresenter is working with the concrete classes DisplayStrategy/NUnitTreeDisplayStrategy/... which makes testing a little bit harder.

Thanks for your feedback :-)