### PR TITLE
Refactor TreeViewPresenter - introduce interface ITreeDisplayStrategy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2022
+image: Previous Visual Studio 2022
 
 build_script: 
   - cmd: dotnet --info

--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -82,7 +82,7 @@ namespace TestCentric.Gui
             new TestPropertiesPresenter(view.TestPropertiesView, model);
             new ErrorsAndFailuresPresenter(view.ErrorsAndFailuresView, model);
             new TextOutputPresenter(view.TextOutputView, model);
-            new TreeViewPresenter(view.TreeView, model);
+            new TreeViewPresenter(view.TreeView, model, new TreeDisplayStrategyFactory());
             new TestCentricPresenter(view, model, options);
 
             try

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -25,7 +25,7 @@ namespace TestCentric.Gui.Presenters
     /// We currently support three different strategies:
     /// NunitTreeDisplay, TestListDisplay and FixtureListDisplay.
     /// </summary>
-    public abstract class DisplayStrategy
+    public abstract class DisplayStrategy : ITreeDisplayStrategy
     {
         // TODO: This class is temporarily using image index values
         // from TestSuiteTreeNode rather than TestTreeView.

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -1,0 +1,43 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using TestCentric.Gui.Model;
+
+namespace TestCentric.Gui.Presenters
+{
+    public interface ITreeDisplayStrategy
+    {
+        /// <summary>
+        /// Called when a test is loaded: build of all tree nodes and apply VisualState
+        /// (for example: expand/collapse nodes)
+        /// </summary>
+        void OnTestLoaded(TestNode testNode, VisualState visualState);
+
+        /// <summary>
+        /// Called when a test is unloaded: clear all tree nodes
+        /// </summary>
+        void OnTestUnloaded();
+
+        /// <summary>
+        /// Reload tree: clear all tree nodes first and rebuild all nodes afterwards
+        /// </summary>
+        void Reload();
+
+        /// <summary>
+        /// Save the visual state of the tree display strategy into a file
+        /// </summary>
+        void SaveVisualState();
+
+        /// <summary>
+        /// Called when one test is finished: update tree node according to test result
+        /// </summary>
+        void OnTestFinished(ResultNode result);
+
+        /// <summary>
+        /// Collapse all tree nodes beneath the fixture nodes
+        /// </summary>
+        void CollapseToFixtures();
+    }
+}

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategyFactory.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategyFactory.cs
@@ -1,0 +1,25 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using TestCentric.Gui.Model;
+using TestCentric.Gui.Views;
+
+namespace TestCentric.Gui.Presenters
+{
+    /// <summary>
+    /// This factory interface supports the creation of TreeDisplayStrategy classes
+    /// </summary>
+    public interface ITreeDisplayStrategyFactory
+    {
+        /// <summary>
+        /// Creates a concrete class implementing interface ITreeDisplayStrategy
+        /// Supported displayStrategy:
+        /// - "NUNIT_TREE" (also default case) 
+        /// - "FIXTURE_LIST"
+        /// - "TEST_LIST"
+        /// </summary>
+        ITreeDisplayStrategy Create(string displayStrategy, ITestTreeView treeView, ITestModel testModel);
+    }
+}

--- a/src/TestCentric/testcentric.gui/Presenters/TreeDisplayStrategyFactory.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeDisplayStrategyFactory.cs
@@ -1,0 +1,30 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using TestCentric.Gui.Model;
+using TestCentric.Gui.Views;
+
+namespace TestCentric.Gui.Presenters
+{
+    /// <summary>
+    /// This factory class is responsible for the creation of TreeDisplayStrategy classes
+    /// </summary>
+    public class TreeDisplayStrategyFactory : ITreeDisplayStrategyFactory
+    {
+        public ITreeDisplayStrategy Create(string displayStrategy, ITestTreeView treeView, ITestModel testModel)
+        {
+            switch (displayStrategy)
+            {
+                case "FIXTURE_LIST":
+                    return new FixtureListDisplayStrategy(treeView, testModel);
+                case "TEST_LIST":
+                    return new TestListDisplayStrategy(treeView, testModel);
+                case "NUNIT_TREE":
+                default:
+                    return new NUnitTreeDisplayStrategy(treeView, testModel);
+            }
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTestBase.cs
@@ -17,13 +17,14 @@ namespace TestCentric.Gui.Presenters.TestTree
     public class TreeViewPresenterTestBase : PresenterTestBase<ITestTreeView>
     {
         protected TreeViewPresenter _presenter;
+        protected ITreeDisplayStrategyFactory _treeDisplayStrategyFactory = Substitute.For<ITreeDisplayStrategyFactory>();
 
         [SetUp]
         public void CreatePresenter()
         {
             _view.TreeContextMenu.Returns(new ContextMenuStrip());
 
-            _presenter = new TreeViewPresenter(_view, _model);
+            _presenter = new TreeViewPresenter(_view, _model, _treeDisplayStrategyFactory);
 
             // Make it look like the view loaded
             _view.Load += Raise.Event<System.EventHandler>(_view, new System.EventArgs());

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -28,6 +28,10 @@ namespace TestCentric.Gui.Presenters.TestTree
         [TestCaseSource("resultData")]
         public void TreeShowsProperResult(ResultState resultState, int expectedIndex)
         {
+            // Use concrete class NUnitTreeDisplayStrategy for this test case to assert SetImageIndex call
+            _treeDisplayStrategyFactory.Create(null, _view, _model)
+                            .Returns((x) => new NUnitTreeDisplayStrategy(x.Arg<ITestTreeView>(), x.Arg<ITestModel>()));
+
             _model.IsProjectLoaded.Returns(true);
             _model.HasTests.Returns(true);
 

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using System.IO;
 using System.Windows.Forms;
 using NSubstitute;
 using NUnit.Framework;
@@ -13,18 +12,6 @@ namespace TestCentric.Gui.Presenters.TestTree
 {
     public class WhenTestRunBegins : TreeViewPresenterTestBase
     {
-        // Use dedicated test file name; Used for VisualState file too
-        const string TestFileName = "TreeViewPresenterTestRunBegin.dll";
-
-        [TearDown]
-        public void TearDown()
-        {
-            // Delete VisualState file to prevent any unintended side effects
-            string fileName = VisualState.GetVisualStateFileName(TestFileName);
-            if (File.Exists(fileName))
-                File.Delete(fileName);
-        }
-
         [Test]
         public void WhenTestRunStarts_TreeNodeImagesAreReset()
         {
@@ -32,7 +19,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             var tv = new TreeView();
             _view.TreeView.Returns(tv);
 
-            var project = new TestCentricProject(_model, TestFileName);
+            var project = new TestCentricProject(_model, "Dummy.dll");
             _model.TestCentricProject.Returns(project);
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -28,6 +28,9 @@ namespace TestCentric.Gui.Presenters.TestTree
         [TestCaseSource("resultData")]
         public void TreeShowsProperResult(ResultState resultState, int expectedIndex)
         {
+            // Use concrete class NUnitTreeDisplayStrategy for this test case to assert SetImageIndex call
+            _treeDisplayStrategyFactory.Create(null, _view, _model)
+                .Returns((x) => new NUnitTreeDisplayStrategy(x.Arg<ITestTreeView>(), x.Arg<ITestModel>()));
             _model.IsProjectLoaded.Returns(true);
             _model.HasTests.Returns(true);
 


### PR DESCRIPTION
This PR is about a refactoring task we discussed about in #1102: 
I introduced a new interface _ITreeDisplayStrategy_ along with a new interface _ITreeDisplayStrategyFactory_. The goal of this task is mainly to improve the testability of the TreeViewPresenter class.

The new interface _ITreeDisplayStrategy_ provides exactly that set of functions, which were currently used by the TreeViewPresenter class. Moreover I thought it's benefical to move also the creation of the concrete classes out of the TreeViewPresenter class , so I introduced the new factory class _TreeDisplayStrategyFactory_. I decided to pass in the factory class via the constructor - but I can change it to some other pattern if required.

Regarding tests:
Some existing tests require a concrete TreeDisplayStrategy instead of a Substitute (because the concrete Strategy fires an event), so I adapted those tests. The test class WhenTestRunBegins is a good example of the improvement - some lines of code could be deleted here.