### PR TITLE
Fix crash when opening XmlDisplay for a TestGroup node

### DIFF
--- a/src/TestCentric/testcentric.gui/Dialogs/XmlDisplay.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/XmlDisplay.cs
@@ -17,7 +17,7 @@ namespace TestCentric.Gui.Dialogs
         private ITestModel _model;
 
         private TreeNode _treeNode;
-        private TestNode _testNode;
+        private ITestItem _testItem;
         
         public XmlDisplay(ITestModel model)
         {
@@ -47,13 +47,17 @@ namespace TestCentric.Gui.Dialogs
                 throw new ArgumentNullException(nameof(treeNode));
 
             _treeNode = treeNode;
-            _testNode = treeNode.Tag as TestNode;
+            _testItem = treeNode.Tag as ITestItem;
+
+            if (_testItem == null)
+                throw new ArgumentException("Unknown object associated to treenode");
 
             SuspendLayout();
-            TestName = (treeNode.Tag as ITestItem)?.Name;
+            TestName = _testItem.Name;
 
             // Display empty XML content for TestGroup nodes (for example category nodes)
-            XmlNode fullXml = (_testNode != null) ? GetFullXml(_testNode) : null;
+            TestNode testNode = _testItem as TestNode;
+            XmlNode fullXml = (testNode != null) ? GetFullXml(testNode) : null;
             xmlTextBox.Rtf = new Xml2RtfConverter(2).Convert(fullXml);
 
             ResumeLayout();
@@ -63,7 +67,8 @@ namespace TestCentric.Gui.Dialogs
 
         public void OnTestFinished(ResultNode result)
         {
-            if (result.Id == _testNode.Id)
+            TestNode testNode = _testItem as TestNode;
+            if (testNode != null && result.Id == testNode.Id)
                 Invoke(new Action(() => Display(_treeNode)));
         }
 

--- a/src/TestCentric/testcentric.gui/Dialogs/XmlDisplay.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/XmlDisplay.cs
@@ -50,8 +50,10 @@ namespace TestCentric.Gui.Dialogs
             _testNode = treeNode.Tag as TestNode;
 
             SuspendLayout();
-            TestName = _testNode.Name;
-            var fullXml = GetFullXml(_testNode);
+            TestName = (treeNode.Tag as ITestItem)?.Name;
+
+            // Display empty XML content for TestGroup nodes (for example category nodes)
+            XmlNode fullXml = (_testNode != null) ? GetFullXml(_testNode) : null;
             xmlTextBox.Rtf = new Xml2RtfConverter(2).Convert(fullXml);
 
             ResumeLayout();

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -122,7 +122,7 @@ namespace TestCentric.Gui.Presenters
                         }
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
-                        Strategy.Reload();
+                        Strategy?.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
                         _view.ShowCheckBoxes.Checked = _treeSettings.ShowCheckBoxes;
@@ -450,9 +450,6 @@ namespace TestCentric.Gui.Presenters
 
             var layout = _model.Settings.Gui.GuiLayout;
             _view.TestPropertiesCommand.Visible = layout == "Mini";
-
-            // For example test category nodes or test result nodes (passed/failed)
-            _view.ViewAsXmlCommand.Enabled = !(_view?.ContextNode?.Tag is TestGroup);
         }
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -450,6 +450,9 @@ namespace TestCentric.Gui.Presenters
 
             var layout = _model.Settings.Gui.GuiLayout;
             _view.TestPropertiesCommand.Visible = layout == "Mini";
+
+            // For example test category nodes or test result nodes (passed/failed)
+            _view.ViewAsXmlCommand.Enabled = !(_view?.ContextNode?.Tag is TestGroup);
         }
 
         #endregion

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -33,55 +33,6 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
-        public void WhenContextMenuIsDisplayed_SelectedNodeIsGroup_ViewAsXmlContextMenu_IsDisabled()
-        {
-            // 1. Arrange
-            TreeNode treeNode = new TreeNode("TreeNode");
-            TestGroup testGroup = new TestGroup("MyGroup");
-            treeNode.Tag = testGroup;
-
-            _view.ContextNode.Returns(treeNode);
-
-            // 2. Act
-            _view.ContextMenuOpening += Raise.Event<EventHandler>();
-
-            // 3. Assert
-            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.False);
-        }
-
-        [Test]
-        public void WhenContextMenuIsDisplayed_SelectedNodeIsTestNode_ViewAsXmlContextMenu_IsEnabled()
-        {
-            // 1. Arrange
-            TreeNode treeNode = new TreeNode("TreeNode");
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
-            treeNode.Tag = testNode;
-
-            _view.ContextNode.Returns(treeNode);
-
-            // 2. Act
-            _view.ContextMenuOpening += Raise.Event<EventHandler>();
-
-            // 3. Assert
-            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.True);
-        }
-
-        [Test]
-        public void WhenContextMenuIsDisplayed_NoSelectedNode_ViewAsXmlContextMenu_IsEnabled()
-        {
-            // 1. Arrange
-            TreeNode treeNode = new TreeNode("TreeNode");
-            treeNode.Tag = null;
-            _view.ContextNode.Returns(treeNode);
-
-            // 2. Act
-            _view.ContextMenuOpening += Raise.Event<EventHandler>();
-
-            // 3. Assert
-            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.True);
-        }
-
-        [Test]
         public void WhenContextMenuIsDisplayed_GuiMiniLayout_TestPropertiesContextMenu_IsVisible()
         {
             // 1. Arrange

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -6,6 +6,9 @@
 using System.Windows.Forms;
 using NUnit.Framework;
 using NSubstitute;
+using TestCentric.Gui.Model;
+using System;
+using System.Runtime.InteropServices;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
@@ -27,6 +30,81 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Settings.Gui.TestTree.AlternateImageSet = imageSet;
 
             Assert.That(_view.AlternateImageSet, Is.EqualTo(imageSet));
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_SelectedNodeIsGroup_ViewAsXmlContextMenu_IsDisabled()
+        {
+            // 1. Arrange
+            TreeNode treeNode = new TreeNode("TreeNode");
+            TestGroup testGroup = new TestGroup("MyGroup");
+            treeNode.Tag = testGroup;
+
+            _view.ContextNode.Returns(treeNode);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.False);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_SelectedNodeIsTestNode_ViewAsXmlContextMenu_IsEnabled()
+        {
+            // 1. Arrange
+            TreeNode treeNode = new TreeNode("TreeNode");
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            treeNode.Tag = testNode;
+
+            _view.ContextNode.Returns(treeNode);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.True);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_NoSelectedNode_ViewAsXmlContextMenu_IsEnabled()
+        {
+            // 1. Arrange
+            TreeNode treeNode = new TreeNode("TreeNode");
+            treeNode.Tag = null;
+            _view.ContextNode.Returns(treeNode);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.ViewAsXmlCommand.Enabled, Is.True);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_GuiMiniLayout_TestPropertiesContextMenu_IsVisible()
+        {
+            // 1. Arrange
+            _model.Settings.Gui.GuiLayout = "Mini";
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.TestPropertiesCommand.Visible, Is.True);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_GuiFullLayout_TestPropertiesContextMenu_IsNotVisible()
+        {
+            // 1. Arrange
+            _model.Settings.Gui.GuiLayout = "Full";
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.TestPropertiesCommand.Visible, Is.False);
         }
 
         // TODO: Version 1 Test - Make it work if needed.


### PR DESCRIPTION
This PR closes #1105 by disabling the context menu item 'View as XML..' for all kind of GroupNodes.

Here's a screenshot:
<img src="https://github.com/user-attachments/assets/e9e2bda8-c4a5-4fcc-808b-254ee9dd1f81" width="300">

In addition, the use case must also be taken into account if the dialog is 'pinned' and the user selects some GroupNode, now.
The proposed solution keeps the dialog open, but deletes the entire content and only displays the name of the tree node in it's caption. Here's a screenshot:

<img src="https://github.com/user-attachments/assets/2561e2e6-8147-4129-81be-870316e3246c" width="500">

Actually, the context menu no longer needs to be disabled, because the Dialog can handle GroupNodes somehow now. But from my point of view it's OK to keep it disabled, as no real XML content is displayed.