### PR TITLE
Fix merge error: Use _treeDisplayStrategyFactory for creation of display strategies

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -116,7 +116,7 @@ namespace TestCentric.Gui.Presenters
                         break;
                     case "TestCentric.Gui.TestTree.DisplayFormat":
                         {
-                            Strategy = CreateDisplayStrategy(_treeSettings.DisplayFormat, _view, _model);
+                            Strategy = _treeDisplayStrategyFactory.Create(_treeSettings.DisplayFormat, _view, _model);
                             Strategy.Reload();
                             break;
                         }
@@ -271,25 +271,6 @@ namespace TestCentric.Gui.Presenters
             {
                 _treeSettings.FixtureList.GroupBy = visualState.GroupBy;
             }
-        }
-        private static DisplayStrategy CreateDisplayStrategy(string displayStrategy, ITestTreeView treeView, ITestModel testModel)
-        {
-            DisplayStrategy strategy = null;
-            switch (displayStrategy)
-            {
-                case "FIXTURE_LIST":
-                    strategy = new FixtureListDisplayStrategy(treeView, testModel);
-                    break;
-                case "TEST_LIST":
-                    strategy = new TestListDisplayStrategy(treeView, testModel);
-                    break;
-                case "NUNIT_TREE":
-                default:
-                    strategy = new NUnitTreeDisplayStrategy(treeView, testModel);
-                    break;
-            }
-
-            return strategy;
         }
 
         private void EnsureNonRunnableFilesAreVisible(TestNode testNode)


### PR DESCRIPTION
Unfortunately, I am only now realizing that my merge for PR #1102 was not 100% accurate or not 100% as it was intended. I'm a bit surprised and I'm not sure when I made the mistake: it was not optimal that I did conflicting changes in two separate branches/PRs in parallel, maybe I did not solve the merge conflicts as indented (I need some better tooling support) or when I did the rollback of that optimization I did not work carefully....?

But nonetheless, I add this treeDisplayStrategyFactory to the TreeViewPresenter with the intention that it is used in all places. But unfortunately there was one code location remaining, which creates the Tree Strategies on its own. This is fixed now.

One general question:
Do you prefer that I write an issue for this PR?