### PR TITLE
Test result icon for test groups

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
@@ -43,31 +43,6 @@ namespace TestCentric.Gui.Presenters
                     group.ImageIndex = _displayStrategy.CalcImageIndexForGroup(group);
         }
 
-        public override void OnTestFinished(ResultNode result)
-        {
-            var imageIndex = DisplayStrategy.CalcImageIndex(result.Outcome);
-            if (imageIndex >= TestTreeView.SuccessIndex)
-            {
-                var treeNodes = _displayStrategy.GetTreeNodesForTest(result);
-                foreach (var treeNode in treeNodes)
-                {
-                    var parentNode = treeNode.Parent;
-                    TestGroup group = treeNode.Parent?.Tag as TestGroup;
-                    if (group == null)
-                    {
-                        continue;
-                    }
-
-                    // Category nodes are updated either as soon as a test result for all children is present or at the end of the test run (method OnTestRunFinished)
-                    if (TestResultExistsForAllChildren(group))
-                    {
-                        int groupImageIndex = _displayStrategy.CalcImageIndexForGroup(group);
-                        parentNode.SelectedImageIndex = parentNode.ImageIndex = group.ImageIndex = imageIndex;
-                    }
-                }
-            }
-        }
-
         public override TestGroup[] SelectGroups(TestNode testNode)
         {
             List<TestGroup> groups = new List<TestGroup>();
@@ -115,26 +90,6 @@ namespace TestCentric.Gui.Presenters
 
                 return x.Name.CompareTo(y.Name);
             });
-        }
-
-        private bool TestResultExistsForAllChildren(TestGroup group)
-        {
-            foreach (TestNode testItem in group)
-            {
-                ResultNode result = _displayStrategy.GetResultForTest(testItem);
-                if (result == null)
-                {
-                    return false;
-                }
-
-                var imageIndexInGroup = DisplayStrategy.CalcImageIndex(result.Outcome);
-                if (imageIndexInGroup < TestTreeView.SuccessIndex)
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
@@ -28,7 +28,7 @@ namespace TestCentric.Gui.Presenters
 
         #region Overrides
 
-        public override string ID => _includeAncestors ? "CATEGORY_EXTENDED" : "CATEGORY";
+        public override string ID => "CATEGORY";
 
         public override void Load(IEnumerable<TestNode> tests)
         {

--- a/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/CategoryGrouping.cs
@@ -60,7 +60,8 @@ namespace TestCentric.Gui.Presenters
                     Groups.Add(group);
                 }
 
-                groups.Add(group);
+                if (!groups.Contains(group))
+                    groups.Add(group);
             }
 
             if (groups.Count == 0)

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -88,6 +88,10 @@ namespace TestCentric.Gui.Presenters
             _view.ResetAllTreeNodeImages();
         }
 
+        public virtual void OnTestRunFinished()
+        {
+        }
+
         // Called when either the display strategy or the grouping
         // changes. May need to distinguish these cases.
         public void Reload()

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -83,6 +83,11 @@ namespace TestCentric.Gui.Presenters
                 _view.SetImageIndex(treeNode, imageIndex);
         }
 
+        public virtual void OnTestRunStarting()
+        {
+            _view.ResetAllTreeNodeImages();
+        }
+
         // Called when either the display strategy or the grouping
         // changes. May need to distinguish these cases.
         public void Reload()

--- a/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
@@ -52,16 +52,6 @@ namespace TestCentric.Gui.Presenters
             _displayStrategy.ApplyResultToGroup(result, false);
         }
 
-        public override void OnTestRunFinished()
-        {
-            // Can be moved to base class TestGrouping in next step
-            foreach (TestGroup group in Groups)
-            {
-                int imageIndex = _displayStrategy.CalcImageIndexForGroup(group);
-                group.TreeNode.ImageIndex = group.TreeNode.SelectedImageIndex = group.ImageIndex = imageIndex;
-            }
-        }
-
         public override TestGroup[] SelectGroups(TestNode testNode)
         {
             return new TestGroup[] { SelectGroup(testNode) };

--- a/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
@@ -49,7 +49,7 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         public override void OnTestFinished(ResultNode result)
         {
-            _displayStrategy.ApplyResultToGroup(result, false);
+            _displayStrategy.ApplyResultToGroup(result);
         }
 
         public override TestGroup[] SelectGroups(TestNode testNode)

--- a/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DurationGrouping.cs
@@ -49,7 +49,17 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         public override void OnTestFinished(ResultNode result)
         {
-            _displayStrategy.ApplyResultToGroup(result, true);
+            _displayStrategy.ApplyResultToGroup(result, false);
+        }
+
+        public override void OnTestRunFinished()
+        {
+            // Can be moved to base class TestGrouping in next step
+            foreach (TestGroup group in Groups)
+            {
+                int imageIndex = _displayStrategy.CalcImageIndexForGroup(group);
+                group.TreeNode.ImageIndex = group.TreeNode.SelectedImageIndex = group.ImageIndex = imageIndex;
+            }
         }
 
         public override TestGroup[] SelectGroups(TestNode testNode)

--- a/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/FixtureListDisplayStrategy.cs
@@ -66,7 +66,6 @@ namespace TestCentric.Gui.Presenters
                     break;
 
                 case "CATEGORY":
-                case "CATEGORY_EXTENDED":
                 case "OUTCOME":
                 case "DURATION":
                     _grouping.Load(GetTestFixtures(testNode));

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -211,27 +211,6 @@ namespace TestCentric.Gui.Presenters
             }
         }
 
-        private void UpdateTestResult(ResultNode result)
-        {
-            var imageIndex = CalcImageIndex(result.Outcome);
-            if (imageIndex >= TestTreeView.SuccessIndex)
-            {
-                var treeNodes = GetTreeNodesForTest(result);
-                foreach (var treeNode in treeNodes)
-                {
-                    var parentNode = treeNode.Parent;
-                    if (parentNode != null)
-                    {
-                        var group = parentNode.Tag as TestGroup;
-                        if (group != null && imageIndex > group.ImageIndex)
-                        {
-                            parentNode.SelectedImageIndex = parentNode.ImageIndex = group.ImageIndex = imageIndex;
-                        }
-                    }
-                }
-            }
-        }
-
         #endregion
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -83,7 +83,7 @@ namespace TestCentric.Gui.Presenters
             _view.Add(treeNode);
         }
 
-        public void ApplyResultToGroup(ResultNode result, bool updateImages)
+        public void ApplyResultToGroup(ResultNode result)
         {
             var treeNodes = GetTreeNodesForTest(result);
 
@@ -126,21 +126,11 @@ namespace TestCentric.Gui.Presenters
                 else // update old group
                 {
                     oldParent.Text = GroupDisplayName(oldGroup);
-                    if (updateImages)
-                        oldParent.ImageIndex = oldParent.SelectedImageIndex = oldGroup.ImageIndex =
-                            CalcImageIndexForGroup(oldGroup);
                 }
 
                 newParent.Nodes.Add(treeNode);
                 newParent.Text = GroupDisplayName(newGroup);
                 newParent.Expand();
-
-                if (updateImages)
-                {
-                    var imageIndex = DisplayStrategy.CalcImageIndex(result.Outcome);
-                    if (imageIndex >= TestTreeView.SuccessIndex && imageIndex > newGroup.ImageIndex)
-                        newParent.ImageIndex = newParent.SelectedImageIndex = newGroup.ImageIndex = imageIndex;
-                }
 
                 if (newGroup.Count == 1)
                 {
@@ -180,6 +170,7 @@ namespace TestCentric.Gui.Presenters
                 case "DURATION":
                     return new DurationGrouping(this);
                 case "CATEGORY":
+                    // Tree display format 'Test_List' should consider categories on test fixtures and test cases
                     return new CategoryGrouping(this, StrategyID == "TEST_LIST");
             }
 

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -38,8 +38,16 @@ namespace TestCentric.Gui.Presenters
         public override void OnTestFinished(ResultNode result)
         {
             base.OnTestFinished(result);
+            _view.InvokeIfRequired(() => _grouping?.OnTestFinished(result));
+        }
 
-            ApplyResultToGroup(result, false);
+        /// <summary>
+        /// Reset all tree node images when a test run starts (also the image index of group nodes which a managed by the grouping)
+        /// </summary>
+        public override void OnTestRunStarting()
+        {
+            base.OnTestRunStarting();
+            _grouping?.OnTestRunStarting();
         }
 
         // TODO: Move this to TestGroup? Would need access to results.

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -47,7 +47,12 @@ namespace TestCentric.Gui.Presenters
         public override void OnTestRunStarting()
         {
             base.OnTestRunStarting();
-            _grouping?.OnTestRunStarting();
+            _view.InvokeIfRequired(() => _grouping?.OnTestRunStarting());
+        }
+
+        public override void OnTestRunFinished()
+        {
+            _view.InvokeIfRequired(() => _grouping?.OnTestRunFinished());
         }
 
         // TODO: Move this to TestGroup? Would need access to results.
@@ -203,6 +208,27 @@ namespace TestCentric.Gui.Presenters
                 }
                 if (topNode != null)
                     topNode.EnsureVisible();
+            }
+        }
+
+        private void UpdateTestResult(ResultNode result)
+        {
+            var imageIndex = CalcImageIndex(result.Outcome);
+            if (imageIndex >= TestTreeView.SuccessIndex)
+            {
+                var treeNodes = GetTreeNodesForTest(result);
+                foreach (var treeNode in treeNodes)
+                {
+                    var parentNode = treeNode.Parent;
+                    if (parentNode != null)
+                    {
+                        var group = parentNode.Tag as TestGroup;
+                        if (group != null && imageIndex > group.ImageIndex)
+                        {
+                            parentNode.SelectedImageIndex = parentNode.ImageIndex = group.ImageIndex = imageIndex;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -180,9 +180,7 @@ namespace TestCentric.Gui.Presenters
                 case "DURATION":
                     return new DurationGrouping(this);
                 case "CATEGORY":
-                    return new CategoryGrouping(this, false);
-                case "CATEGORY_EXTENDED":
-                    return new CategoryGrouping(this, true);
+                    return new CategoryGrouping(this, StrategyID == "TEST_LIST");
             }
 
             return null;

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -36,6 +36,11 @@ namespace TestCentric.Gui.Presenters
         void OnTestFinished(ResultNode result);
 
         /// <summary>
+        /// Called when a test run is starting
+        /// </summary>
+        void OnTestRunStarting();
+
+        /// <summary>
         /// Collapse all tree nodes beneath the fixture nodes
         /// </summary>
         void CollapseToFixtures();

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -41,6 +41,11 @@ namespace TestCentric.Gui.Presenters
         void OnTestRunStarting();
 
         /// <summary>
+        /// Called when a test run is finished
+        /// </summary>
+        void OnTestRunFinished();
+
+        /// <summary>
         /// Collapse all tree nodes beneath the fixture nodes
         /// </summary>
         void CollapseToFixtures();

--- a/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
@@ -52,7 +52,7 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         public override void OnTestFinished(ResultNode result)
         {
-            _displayStrategy.ApplyResultToGroup(result, false);
+            _displayStrategy.ApplyResultToGroup(result);
         }
 
         public override TestGroup[] SelectGroups(TestNode testNode)

--- a/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
@@ -55,16 +55,6 @@ namespace TestCentric.Gui.Presenters
             _displayStrategy.ApplyResultToGroup(result, false);
         }
 
-        public override void OnTestRunFinished()
-        {
-            // Can be moved to base class TestGrouping in next step
-            foreach (TestGroup group in Groups)
-            {
-                int imageIndex = _displayStrategy.CalcImageIndexForGroup(group);
-                group.TreeNode.ImageIndex = group.TreeNode.SelectedImageIndex = group.ImageIndex = imageIndex;
-            }
-        }
-
         public override TestGroup[] SelectGroups(TestNode testNode)
         {
             return new TestGroup[] { SelectGroup(testNode) };

--- a/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/OutcomeGrouping.cs
@@ -55,6 +55,16 @@ namespace TestCentric.Gui.Presenters
             _displayStrategy.ApplyResultToGroup(result, false);
         }
 
+        public override void OnTestRunFinished()
+        {
+            // Can be moved to base class TestGrouping in next step
+            foreach (TestGroup group in Groups)
+            {
+                int imageIndex = _displayStrategy.CalcImageIndexForGroup(group);
+                group.TreeNode.ImageIndex = group.TreeNode.SelectedImageIndex = group.ImageIndex = imageIndex;
+            }
+        }
+
         public override TestGroup[] SelectGroups(TestNode testNode)
         {
             return new TestGroup[] { SelectGroup(testNode) };

--- a/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
@@ -60,6 +60,14 @@ namespace TestCentric.Gui.Presenters
             // Override to take any necessary action
         }
 
+        public void OnTestRunStarting()
+        {
+            foreach (TestGroup testGroup in Groups)
+            {
+                testGroup.ImageIndex = 0;
+            }
+        }
+
         /// <summary>
         /// Returns an array of groups in which a TestNode is categorized.
         /// </summary>

--- a/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
@@ -69,8 +69,16 @@ namespace TestCentric.Gui.Presenters
             }
         }
 
-        public virtual void OnTestRunFinished()
+        public void OnTestRunFinished()
         {
+            // Update tree node icon for all group nodes at the end of a test run
+            // The icon state can be finally determined for duration and outcome grouping only at this point in time
+            // For category grouping, the status can already be partially determined in OnTestFinished event; But finally only at the end of a test run
+            foreach (TestGroup group in Groups)
+            {
+                int imageIndex = _displayStrategy.CalcImageIndexForGroup(group);
+                group.TreeNode.ImageIndex = group.TreeNode.SelectedImageIndex = group.ImageIndex = imageIndex;
+            }
         }
 
         /// <summary>

--- a/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestGrouping.cs
@@ -65,7 +65,12 @@ namespace TestCentric.Gui.Presenters
             foreach (TestGroup testGroup in Groups)
             {
                 testGroup.ImageIndex = 0;
+                testGroup.TreeNode.ImageIndex = testGroup.TreeNode.SelectedImageIndex = 0;
             }
+        }
+
+        public virtual void OnTestRunFinished()
+        {
         }
 
         /// <summary>

--- a/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestListDisplayStrategy.cs
@@ -78,7 +78,6 @@ namespace TestCentric.Gui.Presenters
                     break;
 
                 case "CATEGORY":
-                case "CATEGORY_EXTENDED":
                 case "OUTCOME":
                 case "DURATION":
                     _grouping.Load(GetTestCases(testNode));

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -106,7 +106,7 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.RunFinished += (ea) =>
             {
-                Strategy?.OnTestRunFinished();
+                Strategy.OnTestRunFinished();
             };
 
             _model.Events.TestFinished += OnTestFinished;

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -104,6 +104,11 @@ namespace TestCentric.Gui.Presenters
                 CheckXmlDisplay();
             };
 
+            _model.Events.RunFinished += (ea) =>
+            {
+                Strategy?.OnTestRunFinished();
+            };
+
             _model.Events.TestFinished += OnTestFinished;
             _model.Events.SuiteFinished += OnTestFinished;
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -99,7 +99,7 @@ namespace TestCentric.Gui.Presenters
                 Strategy.SaveVisualState();
 
                 _model.ClearResults();
-                _view.ResetAllTreeNodeImages(); 
+                Strategy.OnTestRunStarting();
                 CheckPropertiesDisplay();
                 CheckXmlDisplay();
             };

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -91,7 +91,6 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem byAssemblyMenuItem;
         private ToolStripMenuItem byFixtureMenuItem;
         private ToolStripMenuItem byCategoryMenuItem;
-        private ToolStripMenuItem byExtendedCategoryMenuItem;
         private ToolStripMenuItem byOutcomeMenuItem;
         private ToolStripMenuItem byDurationMenuItem;
         private ToolStripButton stopRunButton;
@@ -175,7 +174,7 @@ namespace TestCentric.Gui.Views
                 nunitTreeMenuItem, fixtureListMenuItem, testListMenuItem);
             GroupBy = new CheckedToolStripMenuGroup(
                 "testGrouping",
-                byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byExtendedCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
+                byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
             RunSummaryButton = new CheckBoxElement(runSummaryButton);
 
@@ -222,7 +221,6 @@ namespace TestCentric.Gui.Views
             this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byExtendedCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byOutcomeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.runParametersButton = new System.Windows.Forms.ToolStripButton();
@@ -399,7 +397,6 @@ namespace TestCentric.Gui.Views
             this.byAssemblyMenuItem,
             this.byFixtureMenuItem,
             this.byCategoryMenuItem,
-            this.byExtendedCategoryMenuItem,
             this.byOutcomeMenuItem,
             this.byDurationMenuItem});
             this.displayFormatButton.Image = ((System.Drawing.Image)(resources.GetObject("displayFormatButton.Image")));
@@ -455,13 +452,6 @@ namespace TestCentric.Gui.Views
             this.byCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
             this.byCategoryMenuItem.Tag = "CATEGORY";
             this.byCategoryMenuItem.Text = "By Category";
-            // 
-            // byExtendedCategoryMenuItem
-            // 
-            this.byExtendedCategoryMenuItem.Name = "byExtendedCategoryMenuItem";
-            this.byExtendedCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byExtendedCategoryMenuItem.Tag = "CATEGORY_EXTENDED";
-            this.byExtendedCategoryMenuItem.Text = "By Category (Extended)";
             // 
             // byOutcomeMenuItem
             // 

--- a/src/TestCentric/tests/Presenters/CategoryGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/CategoryGroupingTests.cs
@@ -1,0 +1,165 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters
+{
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+    using NSubstitute;
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+    using NUnit.Framework.Internal;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Views;
+
+    [TestFixture]
+    internal class CategoryGroupingTests
+    {
+        [Test]
+        public void Constructor_Groups_IsEmptyList()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, true);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCase(true, "CATEGORY")]
+        [TestCase(false, "CATEGORY")]
+        public void ID_Is_Category(bool includeAncestors, string expectedID)
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, includeAncestors);
+
+            // 3. Assert
+            Assert.That(grouping.ID, Is.EqualTo(expectedID));
+        }
+
+        [Test]
+        public void Load_EmptyTestNodeList_NonCategory_IsCreated()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            IEnumerable<TestNode> tests = new List<TestNode>();
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, false);
+            grouping.Load(tests);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Load_TestNodeWithoutCategory_IsAddedToNonCategory()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            
+            var testNode = new TestNode($"<test-case id='1' />");
+            var tests = new List<TestNode> { testNode };
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, false);
+            grouping.Load(tests);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(1));
+            Assert.That(grouping.Groups[0], Contains.Item(testNode));
+        }
+
+        [Test]
+        public void Load_TestNodeWithCategory_CategoryNodeIsCreated()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var testNode = new TestNode($"<test-case id='1'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var tests = new List<TestNode> { testNode };
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, false);
+            grouping.Load(tests);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(2));
+            var categoryGroup = grouping.Groups[1];
+            Assert.That(categoryGroup.Name, Is.EqualTo("Feature_1"));
+            Assert.That(categoryGroup, Contains.Item(testNode));
+        }
+
+        [Test]
+        public void Load_TestNodes_AllCategoryNodesAreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var testNode1 = new TestNode($"<test-case id='1'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var testNode2 = new TestNode($"<test-case id='2'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var testNode3 = new TestNode($"<test-case id='3'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
+            var testNode4 = new TestNode($"<test-case id='4'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
+            var testNode5 = new TestNode($"<test-case id='5'> </test-case>");
+            var tests = new List<TestNode> { testNode1, testNode2, testNode3, testNode4, testNode5 };
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, false);
+            grouping.Load(tests);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(3));
+
+            var categoryGroup = grouping.Groups[1];
+            Assert.That(categoryGroup.Name, Is.EqualTo("Feature_1"));
+            Assert.That(categoryGroup, Contains.Item(testNode1));
+            Assert.That(categoryGroup, Contains.Item(testNode2));
+
+            categoryGroup = grouping.Groups[2];
+            Assert.That(categoryGroup.Name, Is.EqualTo("Feature_2"));
+            Assert.That(categoryGroup, Contains.Item(testNode3));
+            Assert.That(categoryGroup, Contains.Item(testNode4));
+
+            categoryGroup = grouping.Groups[0];
+            Assert.That(categoryGroup.Name, Is.EqualTo("None"));
+            Assert.That(categoryGroup, Contains.Item(testNode5));
+        }
+
+        [Test]
+        public void OnTestFinished_Calls_ApplyResultToGroup()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            ResultNode result = new ResultNode("<test-case id='1'/>");
+
+            // 2. Act
+            CategoryGrouping grouping = new CategoryGrouping(strategy, false);
+            grouping.OnTestFinished(result);
+
+            // 3. Assert
+            strategy.Received().ApplyResultToGroup(result);
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/DurationGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/DurationGroupingTests.cs
@@ -1,0 +1,187 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters
+{
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Linq;
+    using Model;
+    using Views;
+
+    [TestFixture]
+    public class DurationGroupingTests
+    {
+        [Test]
+        public void Constructor_Groups_IsEmptyList()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ID_Is_Duration()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+
+            // 3. Assert
+            Assert.That(grouping.ID, Is.EqualTo("DURATION"));
+        }
+
+        [Test]
+        public void Load_DurationGroups_AreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            IEnumerable<TestNode> tests = new List<TestNode>();
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+            grouping.Load(tests);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(4));
+        }
+
+        [Test]
+        [TestCase("2.0", "Slow > 1 sec")]
+        [TestCase("0.9", "Medium > 100 ms")]
+        [TestCase("0.01", "Fast < 100 ms")]
+        public void Load_ResultExistsForTestNode_TestNodeIsInsideGroup(string duration, string expectedGroupName)
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var resultNode = new ResultNode($"<test-case id='1' duration='{duration}'/>");
+
+            var testNode = new TestNode($"<test-case id='1' />");
+            var tests = new List<TestNode> { testNode };
+
+            model.GetResultForTest("1").Returns(resultNode);
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+            grouping.Load(tests);
+
+            // 3. Assert
+            var expectedGroup = grouping.Groups.FirstOrDefault(g => g.Name == expectedGroupName);
+            Assert.That(expectedGroup, Contains.Item(testNode));
+        }
+
+        [Test]
+        public void Load_NoResultExistsForTestNode_TestNodeIsInsideNotRunGroup()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var testNode = new TestNode($"<test-case id='1' />");
+            var tests = new List<TestNode> { testNode };
+
+            model.GetResultForTest("1").Returns((ResultNode)null);
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+            grouping.Load(tests);
+
+            // 3. Assert
+            var expectedGroup = grouping.Groups.FirstOrDefault(g => g.Name == "Not Run");
+            Assert.That(expectedGroup, Contains.Item(testNode));
+        }
+
+        [Test]
+        public void OnTestFinished_Calls_ApplyResultToGroup()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            ResultNode result = new ResultNode("<test-case id='1'/>");
+
+            // 2. Act
+            DurationGrouping grouping = new DurationGrouping(strategy);
+            grouping.OnTestFinished(result);
+
+            // 3. Assert
+            strategy.Received().ApplyResultToGroup(result);
+        }
+
+        [Test]
+        [TestCase("Passed", "Passed", "Passed", TestTreeView.SuccessIndex)]
+        [TestCase("Passed", "Passed", "Failed", TestTreeView.FailureIndex)]
+        [TestCase("Passed", "Failed", "Passed", TestTreeView.FailureIndex)]
+        [TestCase("Failed", "Warning", "Passed", TestTreeView.FailureIndex)]
+        [TestCase("Failed", "Failed", "Failed", TestTreeView.FailureIndex)]
+        [TestCase("Warning", "Passed", "Passed", TestTreeView.WarningIndex)]
+        [TestCase("Passed", "Passed", "Warning", TestTreeView.WarningIndex)]
+        [TestCase("Passed", "Passed", "Inconclusive", TestTreeView.SuccessIndex)]
+        [TestCase("Inconclusive", "Inconclusive", "Inconclusive", -1)]
+        [TestCase("Skipped", "Skipped", "Skipped", -1)]
+        [TestCase("Failed", "Skipped", "Skipped", TestTreeView.FailureIndex)]
+        [TestCase("Skipped", "Passed", "Skipped", TestTreeView.SuccessIndex)]
+        public void OnTestRunFinished(string testResult1, string testResult2, string testResult3, int expectedImageIndex)
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            IEnumerable<TestNode> tests = new List<TestNode>();
+            ResultNode result = new ResultNode("<test-case id='1'/>");
+
+            // Create grouping and initialize all groups
+            DurationGrouping grouping = new DurationGrouping(strategy);
+            grouping.Load(tests);
+
+            foreach (TestGroup testGroup in grouping.Groups)
+            {
+                testGroup.TreeNode = new TreeNode();
+            }
+
+            // 2. Act
+            // Only testing the first group
+            TestGroup group = grouping.Groups.First();
+            CreateTestAndResultInGroup(group, model, "1", testResult1);
+            CreateTestAndResultInGroup(group, model, "2", testResult2);
+            CreateTestAndResultInGroup(group, model, "3", testResult3);
+
+            grouping.OnTestRunFinished();
+
+            // 3. Assert
+            Assert.That(group.ImageIndex, Is.EqualTo(expectedImageIndex));
+        }
+
+        private void CreateTestAndResultInGroup(TestGroup group, ITestModel model, string testId, string testResult)
+        {
+            group.Add(new TestNode($"<test-case id='{testId}' />"));
+            model.GetResultForTest(testId).Returns(CreateResultNode(testId, testResult));
+        }
+
+        private ResultNode CreateResultNode(string id, string result)
+        {
+            return new ResultNode($"<test-case id='{id}' result='{result}'/>");
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
@@ -1,0 +1,186 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters
+{
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+    using NSubstitute;
+    using NUnit.Framework;
+    using NUnit.Framework.Internal;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Views;
+    using FakeUserSettings = Fakes.UserSettings;
+
+    [TestFixture]
+    internal class FixtureListDisplayStrategyTests
+    {
+        [Test]
+        [TestCase("", "", "", 1, 3, 0, 0, 0)]
+        [TestCase("Category_1", "", "", 2, 2, 1, 0, 0)]
+        [TestCase("Category_1", "Category_1", "", 2, 1, 2, 0, 0)]
+        [TestCase("Category_1", "", "Category_1", 2, 1, 2, 0, 0)]
+        [TestCase("Category_1", "Category_1", "Category_1", 1, 0, 3, 0, 0)]
+        [TestCase("Category_1", "", "Category_2", 3, 1, 1, 1, 0)]
+        [TestCase("Category_1", "Category_2", "", 3, 1, 1, 1, 0)]
+        [TestCase("Category_1", "Category_2", "Category_2", 2, 0, 1, 2, 0)]
+        [TestCase("Category_1", "Category_2", "Category_3", 3, 0, 1, 1, 1)]
+        public void OnTestLoaded_CategoryGrouping_AllGroupNodesAreCreated(string categoryFixture1, string categoryFixture2, string categoryFixture3, int expectedNodes, int expectedInNonCategory, int expectedInCategory1, int expectedInCategory2, int expectedInCategory3)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.FixtureList.GroupBy = "CATEGORY";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    CreateTestFixtureXml("3-1000", categoryFixture1) +
+                    CreateTestFixtureXml("3-1001", categoryFixture2) +
+                    CreateTestFixtureXml("3-1002", categoryFixture3) +
+                "</test-suite>");
+
+            // 2. Act           
+            FixtureListDisplayStrategy strategy = new FixtureListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", expectedInNonCategory);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", expectedInCategory1);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", expectedInCategory2);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_3", expectedInCategory3);
+        }
+
+        [Test]
+        [TestCase("2.0", "2.0", "2.0", 1, 3, 0, 0, 0)]
+        [TestCase("0.5", "2.0", "2.0", 2, 2, 1, 0, 0)]
+        [TestCase("0.5", "0.5", "2.0", 2, 1, 2, 0, 0)]
+        [TestCase("0.1", "0.5", "2.0", 3, 1, 1, 1, 0)]
+        [TestCase("", "0.5", "", 2, 0, 1, 0, 2)]
+        [TestCase("", "0.1", "4", 3, 1, 0, 1, 1)]
+        [TestCase("", "", "", 1, 0, 0, 0, 3)]
+        public void OnTestLoaded_DurationGrouping_AllGroupNodesAreCreated(string duration1, string duration2, string duration3, int expectedNodes, int expectedInSlow, int expectedInMedium, int expectedInFast, int expectedNotRun)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.FixtureList.GroupBy = "DURATION";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    CreateTestFixtureXml("3-1000", "") +
+                    CreateTestFixtureXml("3-1001", "") +
+                    CreateTestFixtureXml("3-1002", "") +
+            "</test-suite>");
+
+            model.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(duration1) ? null : new ResultNode($"<test-case id='3-1000' duration='{duration1}' />"));
+            model.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(duration2) ? null : new ResultNode($"<test-case id='3-1001' duration='{duration2}' />"));
+            model.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(duration3) ? null : new ResultNode($"<test-case id='3-1002' duration='{duration3}' />"));
+
+            // 2. Act           
+            FixtureListDisplayStrategy strategy = new FixtureListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+            AssertTreeNodeAndTestGroup(treeNodes, "Slow > 1 sec", expectedInSlow);
+            AssertTreeNodeAndTestGroup(treeNodes, "Medium > 100 ms", expectedInMedium);
+            AssertTreeNodeAndTestGroup(treeNodes, "Fast < 100 ms", expectedInFast);
+            AssertTreeNodeAndTestGroup(treeNodes, "Not Run", expectedNotRun);
+        }
+
+        private static object[] TestCaseSourceOutcomeGrouping =
+            {
+                new object[] { "Passed", "Passed", "Passed", 1, new Dictionary<string, int>() { {"Passed", 3} } },
+                new object[] { "Passed", "Failed", "Passed", 2, new Dictionary<string, int>() { {"Passed", 2}, { "Failed", 1 } } },
+                new object[] { "Passed", "Failed", "Skipped", 3, new Dictionary<string, int>() { {"Passed", 1}, { "Failed", 1 }, { "Skipped", 1 } } },
+                new object[] { "Inconclusive", "", "", 2, new Dictionary<string, int>() { { "Inconclusive", 1}, { "Not Run", 2 }, { "Passed", 0 } } },
+                new object[] { "", "", "", 1, new Dictionary<string, int>() { { "Passed", 0}, { "Failed", 0 }, { "Not Run", 3 } } },
+            };
+
+        [Test]
+        [TestCaseSource(nameof(TestCaseSourceOutcomeGrouping))]
+        public void OnTestLoaded_OutcomeGrouping_AllGroupNodesAreCreated(string resultState1, string resultState2, string resultState3, int expectedNodes, Dictionary<string, int> expectedInGroup)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.FixtureList.GroupBy = "OUTCOME";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    CreateTestFixtureXml("3-1000", "") +
+                    CreateTestFixtureXml("3-1001", "") +
+                    CreateTestFixtureXml("3-1002", "") +
+            "</test-suite>");
+
+            model.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='3-1000' result='{resultState1}' />"));
+            model.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' result='{resultState2}' />"));
+            model.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' result='{resultState3}' />"));
+
+            // 2. Act           
+            FixtureListDisplayStrategy strategy = new FixtureListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+
+            foreach (var exp in expectedInGroup)
+            {
+                AssertTreeNodeAndTestGroup(treeNodes, exp.Key, exp.Value);
+            }
+        }
+
+        private static void AssertTreeNodeAndTestGroup(List<TreeNode> treeNodes, string testGroupName, int expectedInGroup)
+        {
+            TreeNode treeNode = treeNodes.Find(x => (x.Tag as TestGroup)?.Name == testGroupName);
+            if (expectedInGroup == 0)
+            {
+                Assert.That(treeNode, Is.Null, $"TreeNode {testGroupName} exists in tree");
+                return;
+            }
+
+            Assert.That(treeNode, Is.Not.Null, $"Failed to find node {testGroupName} in tree");
+
+            // Assert treeNodes
+            Assert.That(treeNode.Nodes.Count, Is.EqualTo(expectedInGroup));
+            Assert.That(treeNode.Text, Does.StartWith(testGroupName));
+
+            // Assert testGroup
+            TestGroup testGroup = treeNode.Tag as TestGroup;
+            Assert.That(testGroup, Is.Not.Null);
+            Assert.That(testGroup.Count, Is.EqualTo(expectedInGroup));
+        }
+
+        private string CreateTestFixtureXml(string testId, string category)
+        {
+            string str = $"<test-suite type='TestFixture' id='{testId}'> ";
+            if (!string.IsNullOrEmpty(category))
+                str += $"<properties> <property name='Category' value='{category}' /> </properties> ";
+
+            str += "</test-suite>";
+
+            return str;
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
@@ -60,6 +60,37 @@ namespace TestCentric.Gui.Presenters
         }
 
         [Test]
+        public void OnTestLoaded_CategoryGrouping_MultipleCategoriesAtOneFixture_AllGroupNodesAreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.FixtureList.GroupBy = "CATEGORY";
+
+            TestNode testNode = new TestNode(
+                        $"<test-suite type='TestFixture' id='3-1000'> " +
+                            $"<properties> <property name='Category' value='Category_1' /> </properties> " +
+                            $"<properties> <property name='Category' value='Category_2' /> </properties> " +
+                        "</test-suite>");
+
+            // 2. Act           
+            FixtureListDisplayStrategy strategy = new FixtureListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(2));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", 0);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", 1);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", 1);
+        }
+
+        [Test]
         [TestCase("2.0", "2.0", "2.0", 1, 3, 0, 0, 0)]
         [TestCase("0.5", "2.0", "2.0", 2, 2, 1, 0, 0)]
         [TestCase("0.5", "0.5", "2.0", 2, 1, 2, 0, 0)]

--- a/src/TestCentric/tests/Presenters/OutcomeGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/OutcomeGroupingTests.cs
@@ -1,0 +1,116 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters
+{
+    using System.Collections.Generic;
+    using NSubstitute;
+    using NUnit.Framework;
+    using System.Linq;
+    using Model;
+    using Views;
+
+    [TestFixture]
+    public class OutcomeGroupingTests
+    {
+        [Test]
+        public void Constructor_DefaultGroups_AreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            OutcomeGrouping grouping = new OutcomeGrouping(strategy);
+
+            // 3. Assert
+            Assert.That(grouping.Groups.Count, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void ID_Is_Outcome()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            // 2. Act
+            OutcomeGrouping grouping = new OutcomeGrouping(strategy);
+
+            // 3. Assert
+            Assert.That(grouping.ID, Is.EqualTo("OUTCOME"));
+        }
+
+        [Test]
+        [TestCase("Passed", "", "Passed")]
+        [TestCase("Failed", "", "Failed")]
+        [TestCase("Skipped", "", "Skipped")]
+        [TestCase("Skipped", "Ignored", "Ignored")]
+        [TestCase("Inconclusive", "", "Inconclusive")]
+        public void Load_ResultExistsForTestNode_TestNodeIsInsideGroup(string resultState, string outcomeLabel, string expectedGroupName)
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var resultNode = new ResultNode($"<test-case id='1' result='{resultState}' label='{outcomeLabel}'/>");
+
+            var testNode = new TestNode($"<test-case id='1' />");
+            var tests = new List<TestNode> { testNode };
+
+            model.GetResultForTest("1").Returns(resultNode);
+
+            // 2. Act
+            OutcomeGrouping grouping = new OutcomeGrouping(strategy);
+            grouping.Load(tests);
+
+            // 3. Assert
+            var expectedGroup = grouping.Groups.FirstOrDefault(g => g.Name == expectedGroupName);
+            Assert.That(expectedGroup, Contains.Item(testNode));
+        }
+
+        [Test]
+        public void Load_NoResultExistsForTestNode_TestNodeIsInsideNotRunGroup()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+
+            var testNode = new TestNode($"<test-case id='1' />");
+            var tests = new List<TestNode> { testNode };
+
+            model.GetResultForTest("1").Returns((ResultNode)null);
+
+            // 2. Act
+            OutcomeGrouping grouping = new OutcomeGrouping(strategy);
+            grouping.Load(tests);
+
+            // 3. Assert
+            var expectedGroup = grouping.Groups.FirstOrDefault(g => g.Name == "Not Run");
+            Assert.That(expectedGroup, Contains.Item(testNode));
+        }
+
+        [Test]
+        public void OnTestFinished_Calls_ApplyResultToGroup()
+        {
+            // 1. Arrange
+            ITestTreeView treeView = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
+            ResultNode result = new ResultNode("<test-case id='1'/>");
+
+            // 2. Act
+            OutcomeGrouping grouping = new OutcomeGrouping(strategy);
+            grouping.OnTestFinished(result);
+
+            // 3. Assert
+            strategy.Received().ApplyResultToGroup(result);
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
@@ -1,0 +1,232 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Presenters
+{
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+    using System.Xml;
+    using NSubstitute;
+    using NUnit.Framework;
+    using NUnit.Framework.Internal;
+    using TestCentric.Gui.Model;
+    using TestCentric.Gui.Views;
+    using FakeUserSettings = Fakes.UserSettings;
+
+    [TestFixture]
+    internal class TestListDisplayStrategyTests
+    {
+        [Test]
+        [TestCase("", "", "", 1, 3, 0, 0, 0)]
+        [TestCase("Category_1", "", "", 2, 2, 1, 0, 0)]
+        [TestCase("Category_1", "Category_1", "", 2, 1, 2, 0, 0)]
+        [TestCase("Category_1", "", "Category_1", 2, 1, 2, 0, 0)]
+        [TestCase("Category_1", "Category_1", "Category_1", 1, 0, 3, 0, 0)]
+        [TestCase("Category_1", "", "Category_2", 3, 1, 1, 1, 0)]
+        [TestCase("Category_1", "Category_2", "", 3, 1, 1, 1, 0)]
+        [TestCase("Category_1", "Category_2", "Category_2", 2, 0, 1, 2, 0)]
+        [TestCase("Category_1", "Category_2", "Category_3", 3, 0, 1, 1, 1)]
+        public void OnTestLoaded_CategoryGrouping_AllGroupNodesAreCreated(string categoryTestcase1, string categoryTestcase2, string categoryTestcase3, int expectedNodes, int expectedInNonCategory, int expectedInCategory1, int expectedInCategory2, int expectedInCategory3)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "CATEGORY";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    "<test-suite type='TestFixture'>" +
+                        CreateTestcaseXml("3-1000", categoryTestcase1) +
+                        CreateTestcaseXml("3-1001", categoryTestcase2) +
+                        CreateTestcaseXml("3-1002", categoryTestcase3) +
+                    "</test-suite>" +
+                "</test-suite>");
+
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", expectedInNonCategory);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", expectedInCategory1);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", expectedInCategory2);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_3", expectedInCategory3);
+        }
+
+        [Test]
+        [TestCase("Category_1", "", "", "", 1, 0, 3, 0, 0)]
+        // [TestCase("Category_1", "Category_1", "", "", 1, 0, 3, 0, 0)]
+        // [TestCase("Category_1", "Category_1", "Category_1", "Category_1", 1, 0, 3, 0, 0)]
+        [TestCase("Category_1", "Category_2", "Category_2", "Category_2", 2, 0, 3, 3, 0)]
+        public void OnTestLoaded_CategoryGrouping_CategoryAtTestFixture_AllGroupNodesAreCreated(string categoryTestFixture, string categoryTestcase1, string categoryTestcase2, string categoryTestcase3, int expectedNodes, int expectedInNonCategory, int expectedInCategory1, int expectedInCategory2, int expectedInCategory3)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "CATEGORY";
+
+            string xmlText = "<test-suite type='TestSuite'> " + $"<properties> <property name='Category' value='{categoryTestFixture}' /> </properties> " +
+                                "<test-suite type='TestFixture'>" +
+                                    CreateTestcaseXml("3-1000", categoryTestcase1) +
+                                    CreateTestcaseXml("3-1001", categoryTestcase2) +
+                                    CreateTestcaseXml("3-1002", categoryTestcase3) +
+                                "</test-suite>" +
+                            "</test-suite>";
+            TestNode testNode = new TestNode(XmlHelper.CreateXmlNode(xmlText));
+            
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", expectedInNonCategory);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", expectedInCategory1);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", expectedInCategory2);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_3", expectedInCategory3);
+        }
+
+        [Test]
+        [TestCase("2.0", "2.0", "2.0", 1, 3, 0, 0, 0)]
+        [TestCase("0.5", "2.0", "2.0", 2, 2, 1, 0, 0)]
+        [TestCase("0.5", "0.5", "2.0", 2, 1, 2, 0, 0)]
+        [TestCase("0.1", "0.5", "2.0", 3, 1, 1, 1, 0)]
+        [TestCase("", "0.5", "", 2, 0, 1, 0, 2)]
+        [TestCase("", "0.1", "4", 3, 1, 0, 1, 1)]
+        [TestCase("", "", "", 1, 0, 0, 0, 3)]
+        public void OnTestLoaded_DurationGrouping_AllGroupNodesAreCreated(string duration1, string duration2, string duration3, int expectedNodes, int expectedInSlow, int expectedInMedium, int expectedInFast, int expectedNotRun)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "DURATION";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    "<test-suite type='TestFixture'>" +
+                        CreateTestcaseXml("3-1000", "") +
+                        CreateTestcaseXml("3-1001", "") +
+                        CreateTestcaseXml("3-1002", "") +
+                    "</test-suite>" +
+                "</test-suite>");
+
+            model.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(duration1) ? null : new ResultNode($"<test-case id='3-1000' duration='{duration1}' />"));
+            model.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(duration2) ? null : new ResultNode($"<test-case id='3-1001' duration='{duration2}' />"));
+            model.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(duration3) ? null : new ResultNode($"<test-case id='3-1002' duration='{duration3}' />"));
+
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+            AssertTreeNodeAndTestGroup(treeNodes, "Slow > 1 sec", expectedInSlow);
+            AssertTreeNodeAndTestGroup(treeNodes, "Medium > 100 ms", expectedInMedium);
+            AssertTreeNodeAndTestGroup(treeNodes, "Fast < 100 ms", expectedInFast);
+            AssertTreeNodeAndTestGroup(treeNodes, "Not Run", expectedNotRun);
+        }
+
+        private static object[] TestCaseSourceOutcomeGrouping =
+    {
+                new object[] { "Passed", "Passed", "Passed", 1, new Dictionary<string, int>() { {"Passed", 3} } },
+                new object[] { "Passed", "Failed", "Passed", 2, new Dictionary<string, int>() { {"Passed", 2}, { "Failed", 1 } } },
+                new object[] { "Passed", "Failed", "Skipped", 3, new Dictionary<string, int>() { {"Passed", 1}, { "Failed", 1 }, { "Skipped", 1 } } },
+                new object[] { "Inconclusive", "", "", 2, new Dictionary<string, int>() { { "Inconclusive", 1}, { "Not Run", 2 }, { "Passed", 0 } } },
+                new object[] { "", "", "", 1, new Dictionary<string, int>() { { "Passed", 0}, { "Failed", 0 }, { "Not Run", 3 } } },
+            };
+
+        [Test]
+        [TestCaseSource(nameof(TestCaseSourceOutcomeGrouping))]
+        public void OnTestLoaded_OutcomeGrouping_AllGroupNodesAreCreated(string resultState1, string resultState2, string resultState3, int expectedNodes, Dictionary<string, int> expectedInGroup)
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "OUTCOME";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestSuite'> " +
+                    "<test-suite type='TestFixture'>" +
+                        CreateTestcaseXml("3-1000", "") +
+                        CreateTestcaseXml("3-1001", "") +
+                        CreateTestcaseXml("3-1002", "") +
+                    "</test-suite>" +
+                "</test-suite>");
+
+            model.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='3-1000' result='{resultState1}' />"));
+            model.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' result='{resultState2}' />"));
+            model.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' result='{resultState3}' />"));
+
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(expectedNodes));
+
+            foreach (var exp in expectedInGroup)
+            {
+                AssertTreeNodeAndTestGroup(treeNodes, exp.Key, exp.Value);
+            }
+        }
+
+        private static void AssertTreeNodeAndTestGroup(List<TreeNode> treeNodes, string testGroupName, int expectedInGroup)
+        {
+            TreeNode treeNode = treeNodes.Find(x => (x.Tag as TestGroup)?.Name == testGroupName);
+            if (expectedInGroup == 0)
+            {
+                Assert.That(treeNode, Is.Null, $"TreeNode {testGroupName} exists in tree");
+                return;
+            }
+
+            Assert.That(treeNode, Is.Not.Null, $"Failed to find node {testGroupName} in tree");
+
+            // Assert treeNodes
+            Assert.That(treeNode.Nodes.Count, Is.EqualTo(expectedInGroup));
+            Assert.That(treeNode.Text, Does.StartWith(testGroupName));
+
+            // Assert testGroup
+            TestGroup testGroup = treeNode.Tag as TestGroup;
+            Assert.That(testGroup, Is.Not.Null);
+            Assert.That(testGroup.Count, Is.EqualTo(expectedInGroup));
+        }
+
+        private string CreateTestcaseXml(string testId, string category)
+        {
+            string str = $"<test-case id='{testId}'> ";
+            if (!string.IsNullOrEmpty(category))
+                str += $"<properties> <property name='Category' value='{category}' /> </properties> ";
+
+            str += "</test-case>";
+
+            return str;
+        }
+    }
+}

--- a/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
@@ -64,9 +64,10 @@ namespace TestCentric.Gui.Presenters
 
         [Test]
         [TestCase("Category_1", "", "", "", 1, 0, 3, 0, 0)]
-        // [TestCase("Category_1", "Category_1", "", "", 1, 0, 3, 0, 0)]
-        // [TestCase("Category_1", "Category_1", "Category_1", "Category_1", 1, 0, 3, 0, 0)]
+        [TestCase("Category_1", "Category_1", "", "", 1, 0, 3, 0, 0)]
+        [TestCase("Category_1", "Category_1", "Category_1", "Category_1", 1, 0, 3, 0, 0)]
         [TestCase("Category_1", "Category_2", "Category_2", "Category_2", 2, 0, 3, 3, 0)]
+        [TestCase("Category_1", "Category_3", "Category_2", "Category_1", 3, 0, 3, 1, 1)]
         public void OnTestLoaded_CategoryGrouping_CategoryAtTestFixture_AllGroupNodesAreCreated(string categoryTestFixture, string categoryTestcase1, string categoryTestcase2, string categoryTestcase3, int expectedNodes, int expectedInNonCategory, int expectedInCategory1, int expectedInCategory2, int expectedInCategory3)
         {
             // 1. Arrange
@@ -99,6 +100,77 @@ namespace TestCentric.Gui.Presenters
             AssertTreeNodeAndTestGroup(treeNodes, "Category_1", expectedInCategory1);
             AssertTreeNodeAndTestGroup(treeNodes, "Category_2", expectedInCategory2);
             AssertTreeNodeAndTestGroup(treeNodes, "Category_3", expectedInCategory3);
+        }
+
+        [Test]
+        public void OnTestLoaded_CategoryGrouping_MultipleCategoriesAtOneFixture_AllGroupNodesAreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "CATEGORY";
+
+            TestNode testNode = new TestNode(
+                        "<test-suite type='TestFixture' id='3-1000'> " +
+                            "<properties> " +
+                                "<property name='Category' value='Category_1' /> " +
+                                "<property name='Category' value='Category_2' /> " +
+                            "</properties> " +
+                            CreateTestcaseXml("3-1000", "") +
+                            CreateTestcaseXml("3-1001", "") +
+                            CreateTestcaseXml("3-1002", "") +
+                        "</test-suite>");
+
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(2));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", 0);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", 3);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", 3);
+        }
+
+        [Test]
+        public void OnTestLoaded_CategoryGrouping_MultipleCategoriesAtOneTestcase_AllGroupNodesAreCreated()
+        {
+            // 1. Arrange
+            ITestTreeView view = Substitute.For<ITestTreeView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+
+            List<TreeNode> treeNodes = new List<TreeNode>();
+            view.Add(Arg.Do<TreeNode>(x => treeNodes.Add(x)));
+
+            model.Settings.Returns(settings);
+            settings.Gui.TestTree.TestList.GroupBy = "CATEGORY";
+
+            TestNode testNode = new TestNode(
+                "<test-suite type='TestFixture'> " +
+                    "<test-case  id='3-1000'> " +
+                        "<properties> " +
+                            "<property name='Category' value='Category_1' /> " +
+                            "<property name='Category' value='Category_2' /> " +
+                        "</properties> " +
+                    "</test-case>" +
+                "</test-suite>");
+
+            // 2. Act           
+            TestListDisplayStrategy strategy = new TestListDisplayStrategy(view, model);
+            strategy.OnTestLoaded(testNode, null);
+
+            // 3. Assert
+            Assert.That(treeNodes.Count, Is.EqualTo(2));
+            AssertTreeNodeAndTestGroup(treeNodes, "None", 0);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_1", 1);
+            AssertTreeNodeAndTestGroup(treeNodes, "Category_2", 1);
         }
 
         [Test]

--- a/src/TestCentric/tests/VisualStateTestData.cs
+++ b/src/TestCentric/tests/VisualStateTestData.cs
@@ -51,7 +51,6 @@ namespace TestCentric.Gui
                                     TN("FixtureB", TN("Test6"))));
 
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return CreateTreeView(
                                 true,
                                 TN("None",
@@ -89,7 +88,6 @@ namespace TestCentric.Gui
                                 TN("FixtureB", TN("Test6")));
 
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return CreateTreeView(
                                 true,
                                 TN("None", TN("Test1"), TN("Test2"), TN("Test3"), TN("Test4"), TN("Test5"), TN("Test6")));
@@ -120,7 +118,7 @@ namespace TestCentric.Gui
                 tv.TopNode = tv.Search("Assembly1");
             else if (Grouping == "FIXTURE")
                 tv.TopNode = tv.Search("MyFixture");
-            else if (Grouping == "CATEGORY" || Grouping == "CATEGORY_EXTENDED")
+            else if (Grouping == "CATEGORY")
                 tv.TopNode = tv.Search("None");
             else if (Grouping == "OUTCOME" || Grouping == "DURATION")
                 tv.TopNode = tv.Search("Not Run");
@@ -163,7 +161,6 @@ namespace TestCentric.Gui
                                     VTN("FixtureA", EXP + CHK)));
 
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return CreateVisualState(
                                 DisplayStrategy,
                                 true,
@@ -214,7 +211,6 @@ namespace TestCentric.Gui
                                 VTN("FixtureA", EXP + CHK));
 
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return CreateVisualState(
                                 DisplayStrategy,
                                 true,
@@ -254,7 +250,6 @@ namespace TestCentric.Gui
                         case "ASSEMBLY":
                         case "FIXTURE":
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return GetExpectedVisualState();
                         case "OUTCOME":
                             return  CreateVisualState(
@@ -286,7 +281,6 @@ namespace TestCentric.Gui
                         case "ASSEMBLY":
                         case "FIXTURE":
                         case "CATEGORY":
-                        case "CATEGORY_EXTENDED":
                             return GetExpectedVisualState();
                         case "OUTCOME":
                             return CreateVisualState(

--- a/src/TestCentric/tests/VisualStateTests.cs
+++ b/src/TestCentric/tests/VisualStateTests.cs
@@ -202,7 +202,6 @@ namespace TestCentric.Gui
                                 Assert.That(treeView.Search("Assembly2").IsExpanded, "Assembly2 not expanded");
                                 break;
                             case "CATEGORY":
-                            case "CATEGORY_EXTENDED":
                                 Assert.That(treeView.Search("None").IsExpanded, "Category 'None' not expanded");
                                 break;
                             case "OUTCOME":
@@ -234,7 +233,6 @@ namespace TestCentric.Gui
                                 }
                                 break;
                             case "CATEGORY":
-                            case "CATEGORY_EXTENDED":
                                 Assert.That(treeView.Search("None").IsExpanded, "Category 'None' not expanded");
                                 break;
                             case "OUTCOME":
@@ -262,13 +260,11 @@ namespace TestCentric.Gui
             new VisualStateTestData("NUNIT_TREE"),
             new VisualStateTestData("FIXTURE_LIST", "ASSEMBLY"),
             new VisualStateTestData("FIXTURE_LIST", "CATEGORY"),
-            new VisualStateTestData("FIXTURE_LIST", "CATEGORY_EXTENDED"),
             new VisualStateTestData("FIXTURE_LIST", "OUTCOME"),
             new VisualStateTestData("FIXTURE_LIST", "DURATION"),
             new VisualStateTestData("TEST_LIST", "ASSEMBLY"),
             new VisualStateTestData("TEST_LIST", "FIXTURE"),
             new VisualStateTestData("TEST_LIST", "CATEGORY"),
-            new VisualStateTestData("TEST_LIST", "CATEGORY_EXTENDED"),
             new VisualStateTestData("TEST_LIST", "OUTCOME"),
             new VisualStateTestData("TEST_LIST", "DURATION")
         };


### PR DESCRIPTION
I propose a solution in this PR for issue #1118. The current state is still not the final one, because all the tests are missing yet (and I expect that these scenarios are good testable). But let's discuss the proposed solution first.

I split the solution into three separate commits, hoping that it's easier to keep an overview.
1. commit: Reactivate existing solution to update tree icons for category groups
2. commit: Support update of tree icons for outcome and duraction groups
3. commit: Enhance update of tree icons for category nodes

I'll add some details in the next comments.