### PR TITLE
Disable context menu entry 'Run' and 'Debug' during a test run

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -436,6 +436,10 @@ namespace TestCentric.Gui.Presenters
 
             var layout = _model.Settings.Gui.GuiLayout;
             _view.TestPropertiesCommand.Visible = layout == "Mini";
+
+            // If a test is already running, no new test run should be started.
+            _view.RunContextCommand.Enabled = !_model.IsTestRunning;
+            _view.DebugContextCommand.Enabled = !_model.IsTestRunning;
         }
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -438,8 +438,8 @@ namespace TestCentric.Gui.Presenters
             _view.TestPropertiesCommand.Visible = layout == "Mini";
 
             // If a test is already running, no new test run should be started.
-            _view.RunContextCommand.Enabled = !_model.IsTestRunning;
-            _view.DebugContextCommand.Enabled = !_model.IsTestRunning;
+            _view.RunContextCommand.Enabled = _model.HasTests && !_model.IsTestRunning;
+            _view.DebugContextCommand.Enabled = _model.HasTests && !_model.IsTestRunning;
         }
 
         #endregion

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -58,11 +58,14 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.TestPropertiesCommand.Visible, Is.False);
         }
 
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        public void WhenContextMenuIsDisplayed_RunCommand_EnabledState_IsUpdated(bool isTestRunning, bool expectedEnabled)
+        [TestCase(true, true, false)]
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(false, true, false)]
+        public void WhenContextMenuIsDisplayed_RunCommand_EnabledState_IsUpdated(bool hasTests, bool isTestRunning, bool expectedEnabled)
         {
             // 1. Arrange
+            _model.HasTests.Returns(hasTests);
             _model.IsTestRunning.Returns(isTestRunning);
 
             // 2. Act
@@ -72,11 +75,14 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.RunContextCommand.Enabled, Is.EqualTo(expectedEnabled));
         }
 
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        public void WhenContextMenuIsDisplayed_DebugCommand_EnabledState_IsUpdated(bool isTestRunning, bool expectedEnabled)
+        [TestCase(true, true, false)]
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(false, true, false)]
+        public void WhenContextMenuIsDisplayed_DebugCommand_EnabledState_IsUpdated(bool hasTests, bool isTestRunning, bool expectedEnabled)
         {
             // 1. Arrange
+            _model.HasTests.Returns(hasTests);
             _model.IsTestRunning.Returns(isTestRunning);
 
             // 2. Act

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -58,6 +58,34 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.TestPropertiesCommand.Visible, Is.False);
         }
 
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void WhenContextMenuIsDisplayed_RunCommand_EnabledState_IsUpdated(bool isTestRunning, bool expectedEnabled)
+        {
+            // 1. Arrange
+            _model.IsTestRunning.Returns(isTestRunning);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.RunContextCommand.Enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void WhenContextMenuIsDisplayed_DebugCommand_EnabledState_IsUpdated(bool isTestRunning, bool expectedEnabled)
+        {
+            // 1. Arrange
+            _model.IsTestRunning.Returns(isTestRunning);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.DebugContextCommand.Enabled, Is.EqualTo(expectedEnabled));
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenContextNodeIsNotNull_RunCommandExecutesThatTest()


### PR DESCRIPTION
This PR solves #1130 by disabling both context menu entries 'Run' and 'Debug' during a test run.
Here's a screenshot:

<img src="https://github.com/user-attachments/assets/b9aa4033-16ff-4b23-b0e8-adf98cb3f2bc" width="700">

I wandered back and forth between 2 possible solutions: either setting the Enabled state whenever the context menu is opened, or set to disable in event RunStarted and enable again in event RunFinished.

From my point of view the first option is a bit simpler - because only one code location is taking care about the Enabled state. So I choose this approach.