### PR TITLE
Check/Uncheck tree node - consider test groups

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -17,6 +17,7 @@ namespace TestCentric.Gui.Presenters
     using System.Drawing;
     using System.IO;
     using TestCentric.Gui.Controls;
+    using System.Linq;
 
     /// <summary>
     /// TreeViewPresenter is the presenter for the TestTreeView
@@ -227,11 +228,19 @@ namespace TestCentric.Gui.Presenters
             _view.AfterCheck += (treeNode) =>
             {
                 var checkedNodes = _view.CheckedNodes;
-                var selection = new TestSelection();
 
+                IList<TestNode> selectedTests = new List<TestNode>();
                 foreach (var node in checkedNodes)
-                    selection.Add(node.Tag as TestNode);
-                
+                {
+                    if (node.Tag is TestNode testNode)
+                        selectedTests.Add(testNode);
+
+                    if (node.Tag is TestGroup testGroup)
+                        foreach (TestNode testNodeInGroup in testGroup)
+                            selectedTests.Add(testNodeInGroup);
+                }
+
+                var selection = new TestSelection(selectedTests.Distinct());
                 _model.SelectedTests = selection;
             };
 


### PR DESCRIPTION
This PR is a proposal for fixing issue #1111 .
Let's discuss and improve this proposal. If we come to a final conclusion, I'll add several tests for this use case.

The basic idea of this solution is that all children of a TestGroup are added to TestSelection. We cannot add the TestGroup itself, because it is unknown to NUnit framework. The children might be Testcases or TestFixtures nodes.

Please note also the LINQ statement selectedTests.Distinct() to ensure that all items are added only once.


From user point of view it's possible to select multiple group nodes now and execute this set of tests:
<img src="https://github.com/user-attachments/assets/c8023fc7-e20e-4e6f-98be-95034c922cd1" width="300">

Another observation (independent from this issue and PR): if the user checks a group node or test fixture all tests of that group or of that test fixture are executed. It makes no difference if the user selects additionally any test case inside this group/test fixture:
<img src="https://github.com/user-attachments/assets/b267e603-da89-473a-a02f-c1cccb8e8976" width="300">
I think that behavior is totally fine.