### PR TITLE
Refactor TestSelection class to implement IEnumerable interface

### DIFF
--- a/.github/workflows/testcentric-gui-ci.yml
+++ b/.github/workflows/testcentric-gui-ci.yml
@@ -1,0 +1,79 @@
+﻿name: TestCentric.GuiRunner.CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    paths-ignore:
+      - "*.txt"
+      - "*.md"
+
+env:
+  DOTNET_NOLOGO: true # Disable the .NET logo
+  DOTNET_CLI_TELEMETRY_OPTOUT: true # Disable sending .NET CLI telemetry
+
+jobs:
+  ContinuousIntegration:
+    name: Continuous Integration
+    runs-on: windows-latest
+
+    env:
+        TESTCENTRIC_MYGET_API_KEY: ${{ secrets.TESTCENTRIC_MYGET_API_KEY }}
+        TESTCENTRIC_NUGET_API_KEY: ${{ secrets.TESTCENTRIC_NUGET_API_KEY }}
+        TESTCENTRIC_CHOCO_API_KEY: ${{ secrets.TESTCENTRIC_CHOCO_API_KEY }}
+        GITHUB_ACCESS_TOKEN: ${{ secrets.TESTCENTRIC_GITHUB_ACCESS_TOKEN }}
+
+    steps:
+      - name: ⤵️ Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🛠️ Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            2.1.x
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+
+      - name: 🔧 Install dotnet tools
+        run: dotnet tool restore
+
+      - name: 🍰 Run cake
+        env:
+            TESTCENTRIC_MYGET_API_KEY: ${{ secrets.TESTCENTRIC_MYGET_API_KEY }}
+            TESTCENTRIC_NUGET_API_KEY: ${{ secrets.TESTCENTRIC_NUGET_API_KEY }}
+            TESTCENTRIC_CHOCO_API_KEY: ${{ secrets.TESTCENTRIC_CHOCO_API_KEY }}
+            GITHUB_ACCESS_TOKEN: ${{ secrets.TESTCENTRIC_GITHUB_ACCESS_TOKEN }}
+
+        # If you need to get more verbose logging, add the following to the dotnet-cake above:  --verbosity=diagnostic
+        run: dotnet cake --target=ContinuousIntegration --configuration=Release
+
+      - name: 🪵 Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Upload Console Logs
+          # This path is defined in build-settings.cake
+          path: "build-results/*.binlog"
+          # if-no-files-found: error
+
+      - name: 🪵 Upload InternalTrace logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: InternalTraceLogs
+          # This path is defined in build-settings.cake
+          path: "*.log"
+          # if-no-files-found: error
+
+      - name: 💾 Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "Test Results"
+          path: test-results

--- a/build.cake
+++ b/build.cake
@@ -75,10 +75,10 @@ var nugetPackage = new NuGetPackage(
 				"Images/Tree/Visual Studio/Success.png", "Images/Tree/Visual Studio/Failure.png", "Images/Tree/Visual Studio/Ignored.png", "Images/Tree/Visual Studio/Inconclusive.png", "Images/Tree/Visual Studio/Skipped.png") )
 		.WithDependencies(
 			KnownExtensions.Net462PluggableAgent.NuGetPackage.LatestDevBuild,
-			KnownExtensions.Net60PluggableAgent.NuGetPackage.LatestRelease,
-			KnownExtensions.Net70PluggableAgent.NuGetPackage.LatestRelease,
-			KnownExtensions.Net80PluggableAgent.NuGetPackage.LatestRelease
-		),
+			KnownExtensions.Net60PluggableAgent.NuGetPackage.LatestDevBuild,
+			KnownExtensions.Net70PluggableAgent.NuGetPackage.LatestDevBuild,
+			KnownExtensions.Net80PluggableAgent.NuGetPackage.LatestDevBuild
+        ),
 	testRunner: new GuiSelfTester(BuildSettings.NuGetTestDirectory + "TestCentric.GuiRunner." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {
 		HasFiles("CHANGES.txt", "LICENSE.txt", "NOTICES.txt", "testcentric.png"),
@@ -114,10 +114,10 @@ var chocolateyPackage = new ChocolateyPackage(
 				"Images/Tree/Visual Studio/Success.png", "Images/Tree/Visual Studio/Failure.png", "Images/Tree/Visual Studio/Ignored.png", "Images/Tree/Visual Studio/Inconclusive.png", "Images/Tree/Visual Studio/Skipped.png") )
 		.WithDependencies(
 			KnownExtensions.Net462PluggableAgent.ChocoPackage.LatestDevBuild,
-			KnownExtensions.Net60PluggableAgent.ChocoPackage.LatestRelease,
-			KnownExtensions.Net70PluggableAgent.ChocoPackage.LatestRelease,
-			KnownExtensions.Net80PluggableAgent.ChocoPackage.LatestRelease
-		),
+			KnownExtensions.Net60PluggableAgent.ChocoPackage.LatestDevBuild,
+			KnownExtensions.Net70PluggableAgent.ChocoPackage.LatestDevBuild,
+			KnownExtensions.Net80PluggableAgent.ChocoPackage.LatestDevBuild
+        ),
 	testRunner: new GuiSelfTester(BuildSettings.ChocolateyTestDirectory + "testcentric-gui." + BuildSettings.PackageVersion + "/tools/testcentric.exe"),
 	checks: new PackageCheck[] {
 		HasDirectory("tools").WithFiles("CHANGES.txt", "LICENSE.txt", "NOTICES.txt", "VERIFICATION.txt", "testcentric.choco.addins").AndFiles(GUI_FILES).AndFiles(ENGINE_FILES).AndFile("testcentric.choco.addins"),

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -13,6 +13,7 @@ namespace TestCentric.Gui.Presenters
     using Views;
 	using Elements;
     using System.IO;
+    using System.Linq;
 
     /// <summary>
     /// DisplayStrategy is the abstract base for the various
@@ -167,7 +168,7 @@ namespace TestCentric.Gui.Presenters
 
         public string GroupDisplayName(TestGroup group)
         {
-            return string.Format("{0} ({1})", group.Name, group.Count);
+            return string.Format("{0} ({1})", group.Name, group.Count());
         }
 
         public static int CalcImageIndex(ResultState outcome)

--- a/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/GroupDisplayStrategy.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Presenters
 {
+    using System.Linq;
     using Model;
     using Views;
 
@@ -121,7 +122,7 @@ namespace TestCentric.Gui.Presenters
                 treeNode.Remove();
 
                 // If it was last test in group, remove group
-                if (oldGroup.Count == 0)
+                if (oldGroup.Count() == 0)
                     oldParent.Remove();
                 else // update old group
                 {
@@ -132,12 +133,12 @@ namespace TestCentric.Gui.Presenters
                 newParent.Text = GroupDisplayName(newGroup);
                 newParent.Expand();
 
-                if (newGroup.Count == 1)
+                if (newGroup.Count() == 1)
                 {
                     _view.Clear();
                     TreeNode topNode = null;
                     foreach (var group in _grouping.Groups)
-                        if (group.Count > 0)
+                        if (group.Count() > 0)
                         {
                             Add(group.TreeNode);
                             if (topNode == null)
@@ -188,7 +189,7 @@ namespace TestCentric.Gui.Presenters
                     var treeNode = MakeTreeNode(group, true);
                     group.TreeNode = treeNode;
                     treeNode.Expand();
-                    if (group.Count > 0)
+                    if (group.Count() > 0)
                     {
                         _view.Add(treeNode);
                         if (topNode == null)

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -230,7 +230,7 @@ namespace TestCentric.Gui.Presenters
                 var selection = new TestSelection();
 
                 foreach (var node in checkedNodes)
-                    selection.Add(node.Tag as TestNode);
+                    selection.Add(node.Tag as ITestItem);
                 
                 _model.SelectedTests = selection;
             };

--- a/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/FixtureListDisplayStrategyTests.cs
@@ -6,6 +6,7 @@
 namespace TestCentric.Gui.Presenters
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Windows.Forms;
     using NSubstitute;
     using NUnit.Framework;
@@ -200,7 +201,7 @@ namespace TestCentric.Gui.Presenters
             // Assert testGroup
             TestGroup testGroup = treeNode.Tag as TestGroup;
             Assert.That(testGroup, Is.Not.Null);
-            Assert.That(testGroup.Count, Is.EqualTo(expectedInGroup));
+            Assert.That(testGroup.Count(), Is.EqualTo(expectedInGroup));
         }
 
         private string CreateTestFixtureXml(string testId, string category)

--- a/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/TestListDisplayStrategyTests.cs
@@ -6,6 +6,7 @@
 namespace TestCentric.Gui.Presenters
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Windows.Forms;
     using System.Xml;
     using NSubstitute;
@@ -287,7 +288,7 @@ namespace TestCentric.Gui.Presenters
             // Assert testGroup
             TestGroup testGroup = treeNode.Tag as TestGroup;
             Assert.That(testGroup, Is.Not.Null);
-            Assert.That(testGroup.Count, Is.EqualTo(expectedInGroup));
+            Assert.That(testGroup.Count(), Is.EqualTo(expectedInGroup));
         }
 
         private string CreateTestcaseXml(string testId, string category)

--- a/src/TestCentric/tests/Presenters/TestTree/TestSelection_WithCheckboxes.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TestSelection_WithCheckboxes.cs
@@ -4,6 +4,7 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using NSubstitute;
 using NUnit.Framework;
@@ -60,7 +61,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.CheckedNodes.Returns(new List<TreeNode>( new[] { TEST_CASE_TREE_NODE }));
 
             _view.AfterCheck += Raise.Event<TreeNodeActionHandler>(TEST_CASE_TREE_NODE);
-            _model.Received().SelectedTests = Arg.Is<TestSelection>(s => s.Count == 1 && s.Contains(TEST_CASE_NODE));
+            _model.Received().SelectedTests = Arg.Is<TestSelection>(s => s.Count() == 1 && s.Contains(TEST_CASE_NODE));
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/TestTree/TestSelection_WithoutCheckboxes.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TestSelection_WithoutCheckboxes.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
+    using System.Linq;
     using Elements;
     using TestCentric.Gui.Model;
     using Views;
@@ -52,7 +53,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void WhenSelectedNodeChanges_SelectedTestsAreSet(TreeNode treeNode, TestNode testNode)
         {
             _view.SelectedNodeChanged += Raise.Event<TreeNodeActionHandler>(treeNode);
-            _model.Received().SelectedTests = Arg.Is<TestSelection>(s => s.Count == 1 && s[0] == testNode);
+            _model.Received().SelectedTests = Arg.Is<TestSelection>(s => s.Count() == 1 && s.First() == testNode);
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -9,6 +9,9 @@ using NSubstitute;
 using TestCentric.Gui.Model;
 using System;
 using System.Runtime.InteropServices;
+using TestCentric.Gui.Views;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
@@ -90,6 +93,104 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             // 3. Assert
             Assert.That(_view.DebugContextCommand.Enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [Test]
+        public void TreeCheckBoxClicked_NoNodeSelected_SelectedTestsInModel_AreEmpty()
+        {
+            // 1. Arrange
+            IList<TreeNode> checkedNodes = new List<TreeNode>();
+            _view.CheckedNodes.Returns(checkedNodes);
+
+            // 2. Act
+            _view.AfterCheck += Raise.Event<TreeNodeActionHandler>((TreeNode)null);
+
+            // 3. Assert
+            TestSelection testSelection = _model.SelectedTests;
+            Assert.That(testSelection, Is.Empty);
+        }
+
+        [Test]
+        public void TreeCheckBoxClicked_TreeNodesAreSelected_AllTests_AreSelected()
+        {
+            // 1. Arrange
+            var treeNode1 = new TreeNode() { Tag = new TestNode("<test-case id='1' />") };
+            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='2' />") };
+
+            IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1, treeNode2 };
+            _view.CheckedNodes.Returns(checkedNodes);
+
+            // 2. Act
+            _view.AfterCheck += Raise.Event<TreeNodeActionHandler>((TreeNode)null);
+
+            // 3. Assert
+            TestSelection testSelection = _model.SelectedTests;
+            Assert.That(testSelection.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TreeCheckBoxClicked_GroupIsSelected_AllTestsOfGroup_AreSelected()
+        {
+            // 1. Arrange
+            var subTestNode1 = new TestNode("<test-case id='2' />");
+            var subTestNode2 = new TestNode("<test-case id='3' />");
+            var testGroup = new TestGroup("Category_1") {  subTestNode1, subTestNode2 };
+
+            var treeNode1 = new TreeNode() { Tag = testGroup };
+
+            IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1 };
+            _view.CheckedNodes.Returns(checkedNodes);
+
+            // 2. Act
+            _view.AfterCheck += Raise.Event<TreeNodeActionHandler>((TreeNode)null);
+
+            // 3. Assert
+            TestSelection testSelection = _model.SelectedTests;
+            Assert.That(testSelection.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TreeCheckBoxClicked_TreeNodeAndGroupIsSelected_AllTests_AreSelected()
+        {
+            // 1. Arrange
+            var subTestNode1 = new TestNode("<test-case id='1' />");
+            var subTestNode2 = new TestNode("<test-case id='2' />");
+            var testGroup = new TestGroup("Category_1") { subTestNode1, subTestNode2 };
+
+            var treeNode1 = new TreeNode() { Tag = testGroup };
+            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='3' />") };
+
+            IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1, treeNode2 };
+            _view.CheckedNodes.Returns(checkedNodes);
+
+            // 2. Act
+            _view.AfterCheck += Raise.Event<TreeNodeActionHandler>((TreeNode)null);
+
+            // 3. Assert
+            TestSelection testSelection = _model.SelectedTests;
+            Assert.That(testSelection.Count(), Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TreeCheckBoxClicked_TreeNodeInsideGroupIsSelected_AllTests_AreSelected()
+        {
+            // 1. Arrange
+            var subTestNode1 = new TestNode("<test-case id='1' />");
+            var subTestNode2 = new TestNode("<test-case id='2' />");
+            var testGroup = new TestGroup("Category_1") { subTestNode1, subTestNode2 };
+
+            var treeNode1 = new TreeNode() { Tag = testGroup };
+            var treeNode2 = new TreeNode() { Tag = subTestNode1 };
+
+            IList<TreeNode> checkNodes = new List<TreeNode>() { treeNode1, treeNode2 };
+            _view.CheckedNodes.Returns(checkNodes);
+
+            // 2. Act
+            _view.AfterCheck += Raise.Event<TreeNodeActionHandler>((TreeNode)null);
+
+            // 3. Assert
+            TestSelection testSelection = _model.SelectedTests;
+            Assert.That(testSelection.Count(), Is.EqualTo(2));
         }
 
         // TODO: Version 1 Test - Make it work if needed.

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Options" Version="6.12.0.148" />
 		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00023" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00014" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00017" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.0" />
 	</ItemGroup>

--- a/src/TestModel/model/TestFilter.cs
+++ b/src/TestModel/model/TestFilter.cs
@@ -4,6 +4,7 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -46,10 +47,10 @@ namespace TestCentric.Gui.Model
             return new TestFilter($"<filter><id>{test.Id}</id></filter>");
         }
 
-        public static TestFilter MakeIdFilter(IList<TestNode> testNodes)
+        public static TestFilter MakeIdFilter(IEnumerable<TestNode> testNodes)
         {
-            if (testNodes.Count == 1)
-                return MakeIdFilter(testNodes[0]);
+            if (testNodes.Count() == 1)
+                return MakeIdFilter(testNodes.First());
 
             StringBuilder sb = new StringBuilder("<filter><or>");
 

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -219,7 +219,7 @@ namespace TestCentric.Gui.Model
 
             public bool DebuggingRequested { get; }
 
-            public bool IsEmpty => SelectedTests.Count == 0;
+            public bool IsEmpty => SelectedTests.Count() == 0;
 
             public TestRunSpecification(TestSelection selectedTests, TestFilter filter, bool debuggingRequested)
             {

--- a/src/TestModel/model/TestNode.cs
+++ b/src/TestModel/model/TestNode.cs
@@ -167,18 +167,8 @@ namespace TestCentric.Gui.Model
 
         public TestSelection Select(TestNodePredicate predicate)
         {
-            return Select(predicate, null);
-        }
-
-        public TestSelection Select(TestNodePredicate predicate, Comparison<TestNode> comparer)
-        {
             var selection = new TestSelection();
-
             Accumulate(selection, this, predicate);
-
-            if (comparer != null)
-                selection.Sort(comparer);
-
             return selection;
         }
 

--- a/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
+++ b/src/TestModel/tests/TestCentric.Gui.Model.Tests.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
 		<PackageReference Include="NUnitLite" Version="4.1.0" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00014" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00017" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.0" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/TestModel/tests/TestSelectionTests.cs
+++ b/src/TestModel/tests/TestSelectionTests.cs
@@ -22,16 +22,6 @@ namespace TestCentric.Gui.Model
         }
 
         [Test]
-        public void SortByNameTest()
-        {
-            _selection.Sort((x, y) => x.Name.CompareTo(y.Name));
-
-            Assert.That(_selection[0].Name, Is.EqualTo("Dick"));
-            Assert.That(_selection[1].Name, Is.EqualTo("Harry"));
-            Assert.That(_selection[2].Name, Is.EqualTo("Tom"));
-        }
-
-        [Test]
         public void RemoveTestNode()
         {
             _selection.RemoveId("2");

--- a/testcentric-gui.sln
+++ b/testcentric-gui.sln
@@ -78,6 +78,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "aspnetcore-test", "src\test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "windows-forms-test", "src\tests\windows-forms-test\windows-forms-test.csproj", "{51B2B3DC-7EC7-46B4-B51F-53C164F44A4B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{A841D26B-422E-40EF-AE78-019B6BEB5B73}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{8F99EF67-A6E4-4F47-85B6-3B3E683B6A14}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\testcentric-gui-ci.yml = .github\workflows\testcentric-gui-ci.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -156,6 +163,8 @@ Global
 		{A0A0C740-487E-420C-9515-29E0016D05E6} = {0F939442-8450-41CF-8BB7-FAA00866F4E4}
 		{D5D58A65-C6FC-4B93-B6D3-86201D8F8219} = {0F939442-8450-41CF-8BB7-FAA00866F4E4}
 		{51B2B3DC-7EC7-46B4-B51F-53C164F44A4B} = {0F939442-8450-41CF-8BB7-FAA00866F4E4}
+		{A841D26B-422E-40EF-AE78-019B6BEB5B73} = {A65042E1-D8BC-48DD-8DE1-F0991F07EA77}
+		{8F99EF67-A6E4-4F47-85B6-3B3E683B6A14} = {A841D26B-422E-40EF-AE78-019B6BEB5B73}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CDFF439B-8888-4133-8734-86F4F899BC40}


### PR DESCRIPTION
This PR resolves issue #1111 

The root cause of that crash was that the code didn't handle checking/unchecking TestGroups nodes so far.

This solution improves the TestSelection class so that either TestNodes or TestGroups maybe added. For that purpose the internal implementation was changed: the TestSelection class exposes only the interface IEnumerable\<TestNode\> and uses a private Hashset for the list of nodes internally. So the choice about using a Hashset or List is only an internal implementation detail of that class.

As a consequence several code locations must be adapted. These adaptations were not conceptual changes, but mostly using Linq to access the IEnumerable\<TestNode\>.
