### PR TITLE
Fix crash when 'run selected tests' but no tests are selected

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -954,7 +954,8 @@ namespace TestCentric.Gui.Presenters
         private void RunSelectedTests()
         {
             var testSelection = _model.SelectedTests;
-            _model.RunTests(testSelection);
+            if (testSelection != null)
+                _model.RunTests(testSelection);
         }
 
         private void RunFailedTests()

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -231,6 +231,8 @@ namespace TestCentric.Gui.Presenters
                 }
             };
 
+            _model.Events.SelectedTestsChanged += (e) => UpdateViewCommands();
+
             _settings.Changed += (s, e) =>
             {
                 switch (e.SettingName)
@@ -754,9 +756,10 @@ namespace TestCentric.Gui.Presenters
             bool hasFailures = _model.HasResults && _model.ResultSummary.FailedCount > 0;
 
             _view.RunAllButton.Enabled =
-            _view.RunSelectedButton.Enabled =
             _view.DisplayFormatButton.Enabled =
             _view.RunParametersButton.Enabled = testLoaded && !testRunning;
+
+            _view.RunSelectedButton.Enabled = testLoaded && !testRunning && _model.SelectedTests != null && _model.SelectedTests.Any();
 
             _view.RerunButton.Enabled = testLoaded && !testRunning && hasResults;
 
@@ -954,8 +957,7 @@ namespace TestCentric.Gui.Presenters
         private void RunSelectedTests()
         {
             var testSelection = _model.SelectedTests;
-            if (testSelection != null)
-                _model.RunTests(testSelection);
+            _model.RunTests(testSelection);
         }
 
         private void RunFailedTests()

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -250,9 +250,17 @@ namespace TestCentric.Gui.Presenters.Main
         [Test]
         public void RunButton_RunsSelectedTests()
         {
-            // TODO: Specify Results and test with specific argument
+            var testSelection = new TestSelection();
+            _model.SelectedTests = testSelection;
             _view.RunSelectedButton.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunTests(Arg.Any<TestSelection>());
+            _model.Received().RunTests(testSelection);
+        }
+
+        [Test]
+        public void RunButton_NoTestSelected_DidnotRunTests()
+        {
+            _view.RunSelectedButton.Execute += Raise.Event<CommandHandler>();
+            _model.DidNotReceiveWithAnyArgs().RunTests(Arg.Any<TestSelection>());
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -257,13 +257,6 @@ namespace TestCentric.Gui.Presenters.Main
         }
 
         [Test]
-        public void RunButton_NoTestSelected_DidnotRunTests()
-        {
-            _view.RunSelectedButton.Execute += Raise.Event<CommandHandler>();
-            _model.DidNotReceiveWithAnyArgs().RunTests(Arg.Any<TestSelection>());
-        }
-
-        [Test]
         public void RerunButton_RerunsTests()
         {
             _view.RerunButton.Execute += Raise.Event<CommandHandler>();
@@ -316,6 +309,45 @@ namespace TestCentric.Gui.Presenters.Main
         {
             _view.ForceStopButton.Execute += Raise.Event<CommandHandler>();
             _model.Received().StopTestRun(true);
+        }
+
+        [Test]
+        public void RunSelectedTestCommand_NoTestsSelected_IsDisabled()
+        {
+            // Arrange
+            _model.HasTests.Returns(true);
+            _model.SelectedTests = null;
+
+            // Act + Assert
+            Assert.That(_view.RunSelectedButton.Enabled, Is.False);
+        }
+
+        [Test]
+        public void SelectedTestsChanged_NoTestSelected_CommandIsDisabled()
+        {
+            // Arrange
+            _model.HasTests.Returns(true);
+            _model.SelectedTests.Returns(new TestSelection());
+
+            // Act
+            _model.Events.SelectedTestsChanged += Raise.Event<TestSelectionEventHandler>(new TestSelectionEventArgs(null));
+
+            // Assert
+            Assert.That(_view.RunSelectedButton.Enabled, Is.False);
+        }
+
+        [Test]
+        public void SelectedTestsChanged_TestSelected_CommandIsEnabled()
+        {
+            // Arrange
+            _model.HasTests.Returns(true);
+            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' />") }));
+
+            // Act
+            _model.Events.SelectedTestsChanged += Raise.Event<TestSelectionEventHandler>(new TestSelectionEventArgs(null));
+
+            // Assert
+            Assert.That(_view.RunSelectedButton.Enabled, Is.True);
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -21,6 +21,7 @@ namespace TestCentric.Gui.Presenters.Main
             _model.HasResults.Returns(true);
             _model.ResultSummary.Returns(new ResultSummary() { FailureCount = 1 });
             _model.IsTestRunning.Returns(false);
+            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' />") }));
 
             var resultNode = new ResultNode("<test-run id='XXX' result='Failed' />");
             FireRunFinishedEvent(resultNode);

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -22,6 +22,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
+            _model.SelectedTests.Returns(new TestSelection(new[] { testNode }));
 
             var project = new TestCentricProject(_model, "dummy.dll");
             _model.TestCentricProject.Returns(project);

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -22,6 +22,7 @@ namespace TestCentric.Gui.Presenters.Main
 
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
+            _model.SelectedTests.Returns(new TestSelection(new[] { testNode }));
 
             FireTestReloadedEvent(testNode);
         }

--- a/src/TestModel/model/ITestEvents.cs
+++ b/src/TestModel/model/ITestEvents.cs
@@ -13,6 +13,7 @@ namespace TestCentric.Gui.Model
     public delegate void TestNodeEventHandler(TestNodeEventArgs args);
     public delegate void TestResultEventHandler(TestResultEventArgs args);
     public delegate void TestItemEventHandler(TestItemEventArgs args);
+    public delegate void TestSelectionEventHandler(TestSelectionEventArgs args);
     public delegate void TestOutputEventHandler(TestOutputEventArgs args);
     public delegate void UnhandledExceptionEventHandler(UnhandledExceptionEventArgs args);
     public delegate void TestFilesLoadingEventHandler(TestFilesLoadingEventArgs args);
@@ -57,6 +58,7 @@ namespace TestCentric.Gui.Model
         // Event used to broadcast a change in the selected
         // item, so that all presenters may be notified.
         event TestItemEventHandler SelectedItemChanged;
+        event TestSelectionEventHandler SelectedTestsChanged;
 
         event TestEventHandler CategorySelectionChanged;
     }

--- a/src/TestModel/model/TestEventArgs.cs
+++ b/src/TestModel/model/TestEventArgs.cs
@@ -61,6 +61,16 @@ namespace TestCentric.Gui.Model
         public ITestItem TestItem { get; private set; }
     }
 
+    public class TestSelectionEventArgs : TestEventArgs
+    {
+        public TestSelectionEventArgs(TestSelection testSelection)
+        {
+            TestSelection = testSelection;
+        }
+
+        public TestSelection TestSelection { get; private set; }
+    }
+
     public class TestOutputEventArgs : TestEventArgs
     {
         public TestOutputEventArgs(string testName, string stream, string text)

--- a/src/TestModel/model/TestEventDispatcher.cs
+++ b/src/TestModel/model/TestEventDispatcher.cs
@@ -114,6 +114,11 @@ namespace TestCentric.Gui.Model
             SelectedItemChanged?.Invoke(new TestItemEventArgs(testItem));
         }
 
+        public void FireSelectedTestsChanged(TestSelection testSelection)
+        {
+            SelectedTestsChanged?.Invoke(new TestSelectionEventArgs(testSelection));
+        }
+
         public void FireCategorySelectionChanged()
         {
             CategorySelectionChanged?.Invoke(new TestEventArgs());
@@ -156,6 +161,7 @@ namespace TestCentric.Gui.Model
 
         // Test Selection Event
         public event TestItemEventHandler SelectedItemChanged;
+        public event TestSelectionEventHandler SelectedTestsChanged;
 
         public event TestEventHandler CategorySelectionChanged;
 

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -194,7 +194,12 @@ namespace TestCentric.Gui.Model
         /// <summary>
         ///  Gets or sets the list of selected tests.
         /// </summary>
-        public TestSelection SelectedTests { get; set; }
+        public TestSelection SelectedTests 
+        { 
+            get {  return _selectedTests; }
+            set { _selectedTests = value; _events?.FireSelectedTestsChanged(_selectedTests); }
+        }
+        private TestSelection _selectedTests;
 
         public List<string> SelectedCategories { get; private set; }
 


### PR DESCRIPTION
This PR fixes issue #1138.

Unfortunately I didn't manage to detect the actual root cause of this crash. As described in the issue repeating the same steps which were previously causing the crash suddently work. That doesn't feel good, but I'd rather fix the problem now than keep looking for a long time.

So the property `SelectedTests` might be set to null in some scenarios, which will cause the crash when executing 'Run selected tests'. Therefore I propose to fix it simply by handling this case now.