### PR TITLE
Show/hide test duration in test nodes

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -49,5 +49,11 @@ namespace TestCentric.Gui.Presenters
         /// Collapse all tree nodes beneath the fixture nodes
         /// </summary>
         void CollapseToFixtures();
+
+        /// <summary>
+        /// Update all tree node names
+        /// If setting 'ShowDuration' is active and test results are available, show test duration in tree node.
+        /// </summary>
+        void UpdateTreeNodeNames();
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -42,6 +42,7 @@ namespace TestCentric.Gui.Presenters
             _treeSettings = _model.Settings.Gui.TestTree;
 
             _view.ShowCheckBoxes.Checked = _view.CheckBoxes = _treeSettings.ShowCheckBoxes;
+            _view.ShowTestDuration.Checked = _treeSettings.ShowTestDuration;
             _view.AlternateImageSet = _treeSettings.AlternateImageSet;
 
             WireUpEvents();
@@ -152,6 +153,12 @@ namespace TestCentric.Gui.Presenters
             _view.ShowCheckBoxes.CheckedChanged += () =>
             {
                 _view.CheckBoxes = _view.ShowCheckBoxes.Checked;
+            };
+
+            _view.ShowTestDuration.CheckedChanged += () =>
+            {
+                _treeSettings.ShowTestDuration = _view.ShowTestDuration.Checked;
+                Strategy?.UpdateTreeNodeNames();
             };
 
             _view.RunContextCommand.Execute += () =>

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -28,6 +28,7 @@ namespace TestCentric.Gui.Views
         ICommand DebugContextCommand { get; }
         IToolStripMenu ActiveConfiguration { get; }
         IChecked ShowCheckBoxes { get; }
+        IChecked ShowTestDuration { get; }
         ICommand ExpandAllCommand { get; }
         ICommand CollapseAllCommand { get; }
         ICommand CollapseToFixturesCommand { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -40,6 +40,7 @@ namespace TestCentric.Gui.Views
             this.activeConfigMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.showCheckboxesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showTestDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.expandAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseToFixturesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -71,6 +72,7 @@ namespace TestCentric.Gui.Views
             this.activeConfigMenuItem,
             this.contextMenuSeparator2,
             this.showCheckboxesMenuItem,
+            this.showTestDurationMenuItem,
             this.expandAllMenuItem,
             this.collapseAllMenuItem,
             this.collapseToFixturesMenuItem});
@@ -124,6 +126,13 @@ namespace TestCentric.Gui.Views
             this.showCheckboxesMenuItem.Size = new System.Drawing.Size(190, 22);
             this.showCheckboxesMenuItem.Text = "Show Checkboxes";
             // 
+            // showTestDurationMenuItem
+            // 
+            this.showTestDurationMenuItem.CheckOnClick = true;
+            this.showTestDurationMenuItem.Name = "showTestDurationMenuItem";
+            this.showTestDurationMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.showTestDurationMenuItem.Text = "Show Test Duration";
+            // 
             // expandAllMenuItem
             // 
             this.expandAllMenuItem.Name = "expandAllMenuItem";
@@ -174,6 +183,7 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.ToolStripMenuItem collapseToFixturesMenuItem;
         private System.Windows.Forms.ImageList treeImages;
         private System.Windows.Forms.ToolStripMenuItem showCheckboxesMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showTestDurationMenuItem;
         private System.Windows.Forms.ToolStripMenuItem debugMenuItem;
         private System.Windows.Forms.ToolStripMenuItem activeConfigMenuItem;
         private System.Windows.Forms.ToolStripSeparator contextMenuSeparator2;

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -42,6 +42,7 @@ namespace TestCentric.Gui.Views
             DebugContextCommand = new CommandMenuElement(this.debugMenuItem);
             ActiveConfiguration = new PopupMenuElement(this.activeConfigMenuItem);
             ShowCheckBoxes = new CheckedMenuElement(showCheckboxesMenuItem);
+            ShowTestDuration = new CheckedMenuElement(showTestDurationMenuItem);
             ExpandAllCommand = new CommandMenuElement(expandAllMenuItem);
             CollapseAllCommand = new CommandMenuElement(collapseAllMenuItem);
             CollapseToFixturesCommand = new CommandMenuElement(collapseToFixturesMenuItem);
@@ -115,6 +116,7 @@ namespace TestCentric.Gui.Views
         public ICommand DebugContextCommand { get; private set; }
         public IToolStripMenu ActiveConfiguration { get; private set; }
         public IChecked ShowCheckBoxes { get; private set; }
+        public IChecked ShowTestDuration { get; private set; }
         public ICommand ExpandAllCommand { get; private set; }
         public ICommand CollapseAllCommand { get; private set; }
         public ICommand CollapseToFixturesCommand { get; private set; }

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -68,7 +68,120 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             return new NUnitTreeDisplayStrategy(_view, _model);
         }
+
+        [Test]
+        public void OnTestRunStarting_ResetAllTreeNodeImages_IsInvoked()
+        {
+            // Act
+            _strategy.OnTestRunStarting();
+
+            // Assert
+            _view.Received().ResetAllTreeNodeImages();
+        }
+
+        [Test]
+        public void OnTestRunStarting_UpdateTreeNodeNames_IsInvoked()
+        {
+            // Assert
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
+            _view.Nodes.Add(treeNode);
+
+            // Act
+            _strategy.OnTestRunStarting();
+
+            // Assert
+            Assert.That(treeNode.Text, Does.Match("Test1"));
+        }
+
+        [TestCase("Skipped", 0)]
+        [TestCase("Inconclusive", 1)]
+        [TestCase("Passed", 2)]
+        [TestCase("Warning", 3)]
+        [TestCase("Failed", 4)]
+        public void OnTestFinished_TreeNodeImage_IsUpdated(string testResult, int expectedImageIndex)
+        {
+            // Arrange
+            TestNode testNode = new TestNode("<test-case id='1' />");
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+            ResultNode result = new ResultNode($"<test-case id='1' result='{testResult}'/>");
+
+            // Act
+            _strategy.OnTestFinished(result);
+
+            // Assert
+            _view.Received().SetImageIndex(treeNode, expectedImageIndex);
+        }
+
+        [Test]
+        public void OnTestFinished_ShowDurationIsInactive_TreeNodeName_IsUpdated()
+        {
+            // Arrange
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+            ResultNode result = new ResultNode($"<test-case id='1' result='Passed'/>");
+            _model.GetResultForTest(testNode.Id).Returns(result);
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
+
+            // Act
+            _strategy.OnTestFinished(result);
+
+            // Assert
+            Assert.That(treeNode.Text, Is.EqualTo("Test1"));
+        }
+
+        [Test]
+        public void OnTestFinished_ShowDurationIsActive_TreeNodeName_IsUpdated()
+        {
+            // Arrange
+            _settings.Gui.TestTree.ShowTestDuration = true;
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+            ResultNode result = new ResultNode($"<test-case id='1' result='Passed' duration='1.5'/>");
+            _model.GetResultForTest(testNode.Id).Returns(result);
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
+
+            // Act
+            _strategy.OnTestFinished(result);
+
+            // Assert
+            Assert.That(treeNode.Text, Does.Match(@"Test1 \[1[,.]500s\]"));
+        }
+
+        [Test]
+        public void MakeTreeNode_ShowDurationIsActive_TreeNodeName_ContainsDuration()
+        {
+            // Arrange
+            _settings.Gui.TestTree.ShowTestDuration = true;
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            ResultNode result = new ResultNode($"<test-case id='1' result='Passed' duration='1.5'/>");
+            _model.GetResultForTest(testNode.Id).Returns(result);
+
+            // Act
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+
+            // Assert
+            Assert.That(treeNode.Text, Does.Match(@"Test1 \[1[,.]500s\]"));
+        }
+
+        [Test]
+        public void MakeTreeNode_ShowDurationIsInactive_TreeNodeName_ContainsTestName()
+        {
+            // Arrange
+            _settings.Gui.TestTree.ShowTestDuration = false;
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            ResultNode result = new ResultNode($"<test-case id='1' result='Passed' duration='1.5'/>");
+            _model.GetResultForTest(testNode.Id).Returns(result);
+
+            // Act
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+
+            // Assert
+            Assert.That(treeNode.Text, Does.Match(@"Test1"));
+        }
     }
+
 
     //public class NUnitTestListStrategyTests : DisplayStrategyTests
     //{

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using TestCentric.Gui.Views;
 using System.Collections.Generic;
 using System.Linq;
+using TestCentric.Gui.Elements;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
@@ -33,6 +34,20 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Settings.Gui.TestTree.AlternateImageSet = imageSet;
 
             Assert.That(_view.AlternateImageSet, Is.EqualTo(imageSet));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void WhenContextMenu_ShowTestDuration_IsClicked_SettingsIsUpdated(bool showTestDuration)
+        {
+            // 1. Arrange
+            _view.ShowTestDuration.Checked = showTestDuration;
+
+            // 2. Act
+            _view.ShowTestDuration.CheckedChanged += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            Assert.That(_model.Settings.Gui.TestTree.ShowTestDuration, Is.EqualTo(showTestDuration));
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
@@ -24,6 +24,13 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.ShowCheckBoxes.Received().Checked = showCheckBoxes;
         }
 
+        [Test]
+        public void ShowTestDurationIsSet()
+        {
+            bool showTestDuration = _settings.Gui.TestTree.ShowTestDuration;
+            _view.ShowTestDuration.Received().Checked = showTestDuration;
+        }
+
         //[Test]
         //public void StrategyIsSet()
         //{

--- a/src/TestModel/model/Settings/TestTreeSettings.cs
+++ b/src/TestModel/model/Settings/TestTreeSettings.cs
@@ -38,6 +38,12 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(ShowCheckBoxes), value); }
         }
 
+        public bool ShowTestDuration
+        {
+            get { return GetSetting(nameof(ShowTestDuration), false); }
+            set { SaveSetting(nameof(ShowTestDuration), value); }
+        }
+
         public string DisplayFormat
         {
             get { return GetSetting(nameof(DisplayFormat), "NUNIT_TREE"); }


### PR DESCRIPTION
This PR close issue #1137 by displaying the test duration in the tree nodes.
The test duration is shown in square brackets behind the tree node name.
<img src="https://github.com/user-attachments/assets/a2109387-47d2-45b4-9b77-4be54a2137b1" width="350">

The user can turn on/off this feature using the tree context menu:
<img src="https://github.com/user-attachments/assets/4a939301-46ef-4c42-ab12-5a5543a61ace" width="400">

The current state (turned on/off) is saved in the settings, so that the last active state is restored when restarting TestCentric. The state is **not** stored in the VisualState file.

From technical point of view the TreeNodes are created by the `DisplayStrategy `class, therefore I placed the code there (the core of the implementation is done here). It handles these use cases:
- OnTestFinished: update tree node name of the finished test
- OnTestRunStarting: reset all tree node names - that's identical to our behavior regarding the tree node images. So that no outdated results from a previous run are shown.
- Turn on/off features: update all tree node names
- Switch display strategy/grouping: If feature is turned on, the new strategy/grouping will display test durations right from the start.

If no test results are available or the feature is turned off, the tree node names remain as before.