### PR TITLE
NUnit tree: add option to show/hide namespace nodes; add folding of namespace nodes

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -176,14 +176,19 @@ namespace TestCentric.Gui.Presenters
             return string.Format("{0} ({1})", group.Name, group.Count());
         }
 
+        protected virtual string GetTestNodeName(TestNode testNode)
+        {
+            return testNode.Name;
+        }
+
         private string GetTestNodeDisplayName(TestNode testNode)
         {
-            string treeNodeName = testNode.Name;
+            string treeNodeName = GetTestNodeName(testNode);
 
             // Check if test result is available for this node
             ResultNode result = _model.GetResultForTest(testNode.Id);
             if (_settings.Gui.TestTree.ShowTestDuration && result != null)
-                treeNodeName = testNode.Name + $" [{result.Duration:0.000}s]";
+                treeNodeName += $" [{result.Duration:0.000}s]";
 
             return treeNodeName;
         }

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -136,7 +136,7 @@ namespace TestCentric.Gui.Presenters
 
         public TreeNode MakeTreeNode(TestNode testNode, bool recursive)
         {
-            string treeNodeName = GetTestNodeDisplayName(testNode);
+            string treeNodeName = GetTreeNodeDisplayName(testNode);
             TreeNode treeNode = new TreeNode(treeNodeName);
             treeNode.Tag = testNode;
 
@@ -176,14 +176,14 @@ namespace TestCentric.Gui.Presenters
             return string.Format("{0} ({1})", group.Name, group.Count());
         }
 
-        protected virtual string GetTestNodeName(TestNode testNode)
+        protected virtual string GetTreeNodeName(TestNode testNode)
         {
             return testNode.Name;
         }
 
-        private string GetTestNodeDisplayName(TestNode testNode)
+        private string GetTreeNodeDisplayName(TestNode testNode)
         {
-            string treeNodeName = GetTestNodeName(testNode);
+            string treeNodeName = GetTreeNodeName(testNode);
 
             // Check if test result is available for this node
             ResultNode result = _model.GetResultForTest(testNode.Id);
@@ -217,7 +217,7 @@ namespace TestCentric.Gui.Presenters
             if (testNode == null)
                 return;
 
-            string treeNodeName = GetTestNodeDisplayName(testNode);
+            string treeNodeName = GetTreeNodeDisplayName(testNode);
             _view.InvokeIfRequired(() => treeNode.Text = treeNodeName);
         }
 

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -266,7 +266,7 @@ namespace TestCentric.Gui.Presenters
                         _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                         break;
                     case "TestCentric.Gui.TestTree.ShowNamespace":
-                        _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
+                        _view.ShowNamespace.SelectedIndex = _settings.Gui.TestTree.ShowNamespace ? 0 : 1;
                         break;
                 }
             };
@@ -492,9 +492,9 @@ namespace TestCentric.Gui.Presenters
                 _settings.Gui.TestTree.DisplayFormat = _view.DisplayFormat.SelectedItem;
             };
 
-            _view.ShowNamespace.CheckedChanged += () =>
+            _view.ShowNamespace.SelectionChanged += () =>
             {
-                _settings.Gui.TestTree.ShowNamespace = _view.ShowNamespace.Checked;
+                _settings.Gui.TestTree.ShowNamespace = _view.ShowNamespace.SelectedIndex == 0;
             };
 
             _view.GroupBy.SelectionChanged += () =>
@@ -954,7 +954,7 @@ namespace TestCentric.Gui.Presenters
                     break;
             }
 
-            _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
+            _view.ShowNamespace.SelectedIndex = _settings.Gui.TestTree.ShowNamespace ? 0 : 1;
             _view.ShowNamespace.Enabled = displayFormat == "NUNIT_TREE";
         }
 

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -265,6 +265,9 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
                         _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                         break;
+                    case "TestCentric.Gui.TestTree.ShowNamespace":
+                        _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
+                        break;
                 }
             };
 
@@ -487,6 +490,11 @@ namespace TestCentric.Gui.Presenters
             _view.DisplayFormat.SelectionChanged += () =>
             {
                 _settings.Gui.TestTree.DisplayFormat = _view.DisplayFormat.SelectedItem;
+            };
+
+            _view.ShowNamespace.CheckedChanged += () =>
+            {
+                _settings.Gui.TestTree.ShowNamespace = _view.ShowNamespace.Checked;
             };
 
             _view.GroupBy.SelectionChanged += () =>
@@ -945,6 +953,9 @@ namespace TestCentric.Gui.Presenters
                     _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                     break;
             }
+
+            _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
+            _view.ShowNamespace.Enabled = displayFormat == "NUNIT_TREE";
         }
 
         private void RunAllTests()

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -128,6 +128,7 @@ namespace TestCentric.Gui.Presenters
                         }
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
+                    case "TestCentric.Gui.TestTree.ShowNamespace":
                         Strategy?.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
@@ -283,6 +284,8 @@ namespace TestCentric.Gui.Presenters
             {
                 _treeSettings.FixtureList.GroupBy = visualState.GroupBy;
             }
+
+            _treeSettings.ShowNamespace = visualState.ShowNamespace;
         }
 
         private void EnsureNonRunnableFilesAreVisible(TestNode testNode)

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -76,7 +76,7 @@ namespace TestCentric.Gui.Views
         IViewElement DisplayFormatButton { get; }
         ISelection DisplayFormat { get; }
         ISelection GroupBy { get; }
-        IChecked ShowNamespace { get; }
+        ISelection ShowNamespace { get; }
         ICommand RunParametersButton { get; }
 
         IChecked RunSummaryButton { get; }

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -76,6 +76,7 @@ namespace TestCentric.Gui.Views
         IViewElement DisplayFormatButton { get; }
         ISelection DisplayFormat { get; }
         ISelection GroupBy { get; }
+        IChecked ShowNamespace { get; }
         ICommand RunParametersButton { get; }
 
         IChecked RunSummaryButton { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -88,6 +88,7 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
+        private ToolStripMenuItem nunitTreeHideNamespaceMenuItem;
         private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem byAssemblyMenuItem;
         private ToolStripMenuItem byFixtureMenuItem;
@@ -176,7 +177,7 @@ namespace TestCentric.Gui.Views
             GroupBy = new CheckedToolStripMenuGroup(
                 "testGrouping",
                 byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
-            ShowNamespace = new CheckedMenuElement(nunitTreeShowNamespaceMenuItem);
+            ShowNamespace = new CheckedToolStripMenuGroup("showNamespace", nunitTreeShowNamespaceMenuItem, nunitTreeHideNamespaceMenuItem);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
             RunSummaryButton = new CheckBoxElement(runSummaryButton);
 
@@ -220,6 +221,7 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeHideNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -415,7 +417,15 @@ namespace TestCentric.Gui.Views
             this.nunitTreeShowNamespaceMenuItem.Name = "NUNIT_TREE_SHOW_NAMESPACE";
             this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
-            this.nunitTreeShowNamespaceMenuItem.Text = "Namespace";
+            this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
+
+            // 
+            // nunitTreeHideNamespaceMenuItem
+            // 
+            this.nunitTreeHideNamespaceMenuItem.Name = "NUNIT_TREE_HIDE_NAMESPACE";
+            this.nunitTreeHideNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeHideNamespaceMenuItem.Tag = "NUNIT_TREE_HIDE_NAMESPACE";
+            this.nunitTreeHideNamespaceMenuItem.Text = "Hide Namespace";
 
             // 
             // nunitTreeMenuItem
@@ -424,7 +434,7 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
             this.nunitTreeMenuItem.Text = "NUnit Tree";
-            nunitTreeMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+            nunitTreeMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { nunitTreeShowNamespaceMenuItem, nunitTreeHideNamespaceMenuItem });
 
             // 
             // fixtureListMenuItem
@@ -1138,7 +1148,7 @@ namespace TestCentric.Gui.Views
         public IViewElement DisplayFormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
         public ISelection GroupBy { get; private set; }
-        public IChecked ShowNamespace { get; private set; }
+        public ISelection ShowNamespace { get; private set; }
         public ICommand RunParametersButton { get; private set; }
 
         public IChecked RunSummaryButton { get; private set; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -87,6 +87,7 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem nunitTreeMenuItem;
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
+        private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
         private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem byAssemblyMenuItem;
         private ToolStripMenuItem byFixtureMenuItem;
@@ -175,6 +176,7 @@ namespace TestCentric.Gui.Views
             GroupBy = new CheckedToolStripMenuGroup(
                 "testGrouping",
                 byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
+            ShowNamespace = new CheckedMenuElement(nunitTreeShowNamespaceMenuItem);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
             RunSummaryButton = new CheckBoxElement(runSummaryButton);
 
@@ -217,6 +219,7 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -405,6 +408,15 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton.Size = new System.Drawing.Size(29, 21);
             this.displayFormatButton.Text = "Display";
             this.displayFormatButton.ToolTipText = "Tree Display Format";
+
+            // 
+            // nunitTreeShowNamespaceMenuItem
+            // 
+            this.nunitTreeShowNamespaceMenuItem.Name = "NUNIT_TREE_SHOW_NAMESPACE";
+            this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
+            this.nunitTreeShowNamespaceMenuItem.Text = "Namespace";
+
             // 
             // nunitTreeMenuItem
             // 
@@ -412,6 +424,8 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
             this.nunitTreeMenuItem.Text = "NUnit Tree";
+            nunitTreeMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+
             // 
             // fixtureListMenuItem
             // 
@@ -1124,6 +1138,7 @@ namespace TestCentric.Gui.Views
         public IViewElement DisplayFormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
         public ISelection GroupBy { get; private set; }
+        public IChecked ShowNamespace { get; private set; }
         public ICommand RunParametersButton { get; private set; }
 
         public IChecked RunSummaryButton { get; private set; }

--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -30,6 +30,12 @@ namespace TestCentric.Gui
             DisplayStrategy = strategyID;
         }
 
+        public VisualState(string strategyID, bool showNamespace)
+        {
+            DisplayStrategy = strategyID;
+            ShowNamespace = showNamespace;
+        }
+
         public VisualState(string strategyID, string groupID)
         {
             if (strategyID == "NUNIT_TREE")
@@ -52,6 +58,8 @@ namespace TestCentric.Gui
 
         //[XmlAttribute, DefaultValue(false)]
         public bool ShowCheckBoxes;
+
+        public bool ShowNamespace;
 
         // TODO: Categories not yet supported
         //public List<string> SelectedCategories;
@@ -250,6 +258,7 @@ namespace TestCentric.Gui
             // GroupBy is null for NUnitTree strategy, otherwise required
             if (GroupBy == null && strategy != "NUNIT_TREE") GroupBy = "ASSEMBLY";
             ShowCheckBoxes = reader.GetAttribute("ShowCheckBoxes") == "True";
+            ShowNamespace = reader.GetAttribute("ShowNamespace") == "True";
 
             while (reader.Read())
             {
@@ -364,7 +373,9 @@ namespace TestCentric.Gui
                 writer.WriteAttributeString("GroupBy", GroupBy);
             if (ShowCheckBoxes)
                 writer.WriteAttributeString("ShowCheckBoxes", "True");
-            
+            if (ShowNamespace)
+                writer.WriteAttributeString("ShowNamespace", "True");
+
             WriteVisualTreeNodes(Nodes);
 
             void WriteVisualTreeNodes(List<VisualTreeNode> nodes)

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -349,5 +349,19 @@ namespace TestCentric.Gui.Presenters.Main
             // Assert
             Assert.That(_view.RunSelectedButton.Enabled, Is.True);
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowNamespaceChanged_ChangesModelSetting(bool isChecked)
+        {
+            // Arrange
+            _view.ShowNamespace.Checked.Returns(isChecked);
+
+            // Act
+            _view.ShowNamespace.CheckedChanged += Raise.Event<CommandHandler>();
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(isChecked));
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -350,18 +350,18 @@ namespace TestCentric.Gui.Presenters.Main
             Assert.That(_view.RunSelectedButton.Enabled, Is.True);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void ShowNamespaceChanged_ChangesModelSetting(bool isChecked)
+        [TestCase(0, true)]
+        [TestCase(1, false)]
+        public void ShowNamespaceChanged_ChangesModelSetting(int selectedMenuItem, bool expectedShowNamespace)
         {
             // Arrange
-            _view.ShowNamespace.Checked.Returns(isChecked);
+            _view.ShowNamespace.SelectedIndex.Returns(selectedMenuItem);
 
             // Act
-            _view.ShowNamespace.CheckedChanged += Raise.Event<CommandHandler>();
+            _view.ShowNamespace.SelectionChanged += Raise.Event<CommandHandler>();
 
             // Assert
-            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(isChecked));
+            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(expectedShowNamespace));
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -45,15 +45,15 @@ namespace TestCentric.Gui.Presenters.Main
             _view.GroupBy.SelectedItem = groupBy;
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void ShowNamespace_SettingChanged_MenuItemIsUpdated(bool showNamespace)
+        [TestCase(true, 0)]
+        [TestCase(false, 1)]
+        public void ShowNamespace_SettingChanged_MenuItemIsUpdated(bool showNamespace, int expectedMenuIndex)
         {
             // 1. Act
             _settings.Gui.TestTree.ShowNamespace = showNamespace;
 
             // 2. Assert
-            _view.ShowNamespace.Checked = showNamespace;
+            _view.ShowNamespace.SelectedIndex = expectedMenuIndex;
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -44,5 +44,16 @@ namespace TestCentric.Gui.Presenters.Main
             // 2. Assert
             _view.GroupBy.SelectedItem = groupBy;
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowNamespace_SettingChanged_MenuItemIsUpdated(bool showNamespace)
+        {
+            // 1. Act
+            _settings.Gui.TestTree.ShowNamespace = showNamespace;
+
+            // 2. Assert
+            _view.ShowNamespace.Checked = showNamespace;
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -238,7 +238,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _strategy.OnTestLoaded(new TestNode(xml), null);
 
             // Assert
-            Assert.That((treeNode.Tag as TestNode).Id, Is.EqualTo("1-1033"));
+            Assert.That((treeNode.Tag as TestNode).Id, Is.EqualTo("1-1031"));
             Assert.That(treeNode.Text, Is.EqualTo("Library.Test.Folder"));
             Assert.That(treeNode.Nodes.Count, Is.EqualTo(0));
         }
@@ -295,7 +295,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _strategy.OnTestLoaded(new TestNode(xml), null);
 
             // Assert
-            Assert.That((treeNode.Tag as TestNode).Id, Is.EqualTo("1-1033"));
+            Assert.That((treeNode.Tag as TestNode).Id, Is.EqualTo("1-1031"));
             Assert.That(treeNode.Text, Is.EqualTo("Library.Test.Folder"));
             Assert.That(treeNode.Nodes.Count, Is.EqualTo(0));
         }

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -27,6 +27,21 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.ShowCheckBoxes.Checked, Is.EqualTo(showCheckBoxSetting));
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void WhenSettingsAreChanged_ShowNamespace_StrategyIsReloaed(bool showNamespace)
+        {
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+            _model.Settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
+
+            // Act
+            _model.Settings.Gui.TestTree.ShowNamespace = showNamespace;
+
+            // Assert
+            strategy.Received(2).Reload();
+        }
+
         [TestCase("Default")]
         [TestCase("VisualStudio")]
         public void WhenSettingsAreChanged_AlternateImageSet_NewSettingIsApplied(string imageSet)

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -86,6 +86,44 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_view.ShowCheckBoxes.Checked, Is.EqualTo(showCheckBox));
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestLoaded_NoVisualState_ShowNamespace_IsAppliedFromSettings(bool showNamespace)
+        {
+            // Arrange: adapt settings
+            _model.Settings.Gui.TestTree.ShowNamespace = showNamespace;
+
+            // Act: load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(showNamespace));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestLoaded_WithVisualState_ShowNamespace_IsAppliedFromVisualState(bool showNamespace)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.ShowNamespace = showNamespace;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_settings.Gui.TestTree.ShowNamespace, Is.EqualTo(showNamespace));
+        }
+
         [TestCase("NUNIT_TREE", typeof(NUnitTreeDisplayStrategy))]
         [TestCase("FIXTURE_LIST", typeof(FixtureListDisplayStrategy))]
         [TestCase("TEST_LIST", typeof(TestListDisplayStrategy))]

--- a/src/TestCentric/tests/VisualStateSerializationTests.cs
+++ b/src/TestCentric/tests/VisualStateSerializationTests.cs
@@ -68,6 +68,7 @@ namespace TestCentric.Gui
                 Assert.That(docElement.Name, Is.EqualTo("VisualState"));
                 Assert.That(docElement.GetAttribute("DisplayStrategy"), Is.EqualTo(vs.DisplayStrategy));
                 Assert.That(docElement.GetAttribute("ShowCheckBoxes"), Is.EqualTo(vs.ShowCheckBoxes ? "True" : ""));
+                Assert.That(docElement.GetAttribute("ShowNamespace"), Is.EqualTo(vs.ShowNamespace ? "True" : ""));
                 Assert.That(firstChild.Name, Is.EqualTo("Nodes"));
                 Assert.That(topNodes.Count, Is.EqualTo(vs.Nodes.Count));
                 for (int i = 0; i < topNodes.Count; i++)
@@ -146,6 +147,14 @@ namespace TestCentric.Gui
                         "NUNIT_TREE",
                         checkBoxes: true))
                     .SetName("NUnitTree_EmptyWithOneAttribute)");
+
+                yield return new TestCaseData(
+                    VisualStateTestData.CreateVisualState(
+                        "NUNIT_TREE",
+                        null,
+                        checkBoxes: true,
+                        showNamespace: true))
+                    .SetName("NUnitTree_EmptyWithTwoAttributes)");
 
                 yield return new TestCaseData(
                     VisualStateTestData.CreateVisualState(

--- a/src/TestCentric/tests/VisualStateTestData.cs
+++ b/src/TestCentric/tests/VisualStateTestData.cs
@@ -133,6 +133,8 @@ namespace TestCentric.Gui
                 case "NUNIT_TREE":
                     return  CreateVisualState(
                         DisplayStrategy,
+                        null,
+                        true,
                         true,
                         VTN("Assembly1", EXP + TOP,
                             VTN("NUnit", EXP,
@@ -351,6 +353,11 @@ namespace TestCentric.Gui
         }
 
         public static VisualState CreateVisualState(string strategy, string grouping, bool checkBoxes = false, params VisualTreeNode[] visualTreeNodes)
+        {
+            return CreateVisualState(strategy, grouping, checkBoxes, false, visualTreeNodes);
+        }
+
+        public static VisualState CreateVisualState(string strategy, string grouping, bool checkBoxes = false, bool showNamespace = false, params VisualTreeNode[] visualTreeNodes)
         {
             VisualState visualState;
 

--- a/src/TestCentric/tests/VisualStateTests.cs
+++ b/src/TestCentric/tests/VisualStateTests.cs
@@ -139,6 +139,7 @@ namespace TestCentric.Gui
             Assert.Multiple(() =>
             {
                 Assert.That(restoredState.ShowCheckBoxes, Is.EqualTo(visualState.ShowCheckBoxes));
+                Assert.That(restoredState.ShowNamespace, Is.EqualTo(visualState.ShowNamespace));
                 // TODO: Categories not yet supported
                 //Assert.AreEqual(ExpectedVisualState.SelectedCategories, restoredState.SelectedCategories);
                 //Assert.AreEqual(ExpectedVisualState.ExcludeCategories, restoredState.ExcludeCategories);

--- a/src/TestModel/model/Settings/TestTreeSettings.cs
+++ b/src/TestModel/model/Settings/TestTreeSettings.cs
@@ -50,6 +50,12 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(DisplayFormat), value); }
         }
 
+        public bool ShowNamespace
+        {
+            get { return GetSetting(nameof(ShowNamespace), true); }
+            set { SaveSetting(nameof(ShowNamespace), value); }
+        }
+
         public class FixtureListSettings : SettingsGroup
         {
             public FixtureListSettings(ISettings settings, string prefix) : base(settings, prefix + "FixtureList") { }


### PR DESCRIPTION
This PR solves issue #1151 and #1152 which both are dealing with the NUnit tree:
- list fixtures without namespaces
- fold namespace nodes

From user point of view there's a new submenu item which controls if the namespace nodes are shown or hidden in general.
<img src="https://github.com/user-attachments/assets/357f2ec7-c0ea-4c63-8ea6-2f3f5a2ffc0b" width="350">

This menu item is only enabled for the NUnit tree, but disabled if FixtureList or TestList mode is active.

Here's a screenshot: Namespaces are shown on left side, on right side they are hidden
<img src="https://github.com/user-attachments/assets/8fd1181e-f880-4f6b-9d4e-3c62e2a4119c" width="550">

In addition the namespaces are getting folded (if applicable). Here's an example:
<img src="https://github.com/user-attachments/assets/7c4bdf5e-ba14-46e4-9cec-e08a23a9853c" width="550">


From a technical point of view, several aspects had to be taken into account. 
The core of this issue is implemented in the class NUnitTreeDisplayStrategy: it's taking care about omitting namespaces and folding of namespaces. I decided not to change the base method `MakeTreeNode` which is used by all Strategies, but to add the implementation in the NUnitTreeDisplayStrategy class itself. So it's kept independent, avoiding any unintended side effects. However the recursive call to create the nodes for the children are done here, now.
One important line of code is how to detect a namespace reliable - thanks to your hint about SetUpFixtures, I consider this case as well.

When folding the namespaces, I decided to assign the 'deepest' of the folded TestNodes to the resulting TreeNode. All other folded TestNodes will not have a corresponding TreeNode. Some special handling was required for the TreeNode name of folded namespaces. Thanks to the new feature 'Show test duration', the tree node name must be adapted whenever 'Show test duration' is switched on/off and therefore it's not kept untouched after tree node creation. I had the impression that it's difficult to determine the folded name afterwards, so I decided to keep a list of all folded names in the NUnitTreeDisplayStrategy. That list can be used, whenever a tree node name is requested.

VisualState/Settings:
I implemented the ShowNamespace option identically to the Strategy or Grouping option: that means that it's stored in the settings and in the VisualState file. The VisualState file ensures that the same visual tree representation is restored whenever a test project is loaded. And the setting option ensures that the last selected option is applied when opening a project without VisualState file.

And I extended some tests for these new use cases.