### PR TITLE
Provide filter logic of TestNodes; starting with filtering by outcome

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -38,7 +38,8 @@ namespace TestCentric.Gui.Presenters
             _foldedNodeNames.Clear();
 
             foreach (var topLevelNode in testNode.Children)
-                _view.Add(CreateNUnitTreeNode(null, topLevelNode));
+                if (topLevelNode.IsVisible)
+                    _view.Add(CreateNUnitTreeNode(null, topLevelNode));
 
             if (visualState != null)
                 visualState.ApplyTo(_view.TreeView);
@@ -81,9 +82,8 @@ namespace TestCentric.Gui.Presenters
             }
 
             foreach (TestNode child in testNode.Children)
-            {
-                CreateNUnitTreeNode(parentNode, child);
-            }
+                if (child.IsVisible)
+                    CreateNUnitTreeNode(parentNode, child);
 
             return treeNode;
         }

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -110,6 +110,11 @@ namespace TestCentric.Gui.Presenters
                 Strategy.OnTestRunFinished();
             };
 
+            _model.Events.TestFilterChanged += (ea) =>
+            {
+                Strategy?.Reload();
+            };
+
             _model.Events.TestFinished += OnTestFinished;
             _model.Events.SuiteFinished += OnTestFinished;
 

--- a/src/TestModel/model/ITestCentricTestFilter.cs
+++ b/src/TestModel/model/ITestCentricTestFilter.cs
@@ -1,0 +1,20 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Collections.Generic;
+
+namespace TestCentric.Gui.Model
+{
+    /// <summary>
+    /// Provides filter functionality: by outcome, by duration, by category...
+    /// </summary>
+    public interface ITestCentricTestFilter
+    {
+        /// <summary>
+        /// Filters the loaded TestNodes by outcome
+        /// </summary>
+        IEnumerable<string> OutcomeFilter { get; set; }
+    }
+}

--- a/src/TestModel/model/ITestEvents.cs
+++ b/src/TestModel/model/ITestEvents.cs
@@ -61,5 +61,6 @@ namespace TestCentric.Gui.Model
         event TestSelectionEventHandler SelectedTestsChanged;
 
         event TestEventHandler CategorySelectionChanged;
+        event TestEventHandler TestFilterChanged;
     }
 }

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -88,6 +88,11 @@ namespace TestCentric.Gui.Model
 
         TestFilter CategoryFilter { get; }
 
+        /// <summary>
+        /// Provides filter functionality: by outcome, by duration, by category...
+        /// </summary>
+        ITestCentricTestFilter TestCentricTestFilter { get; }
+
         #endregion
 
         #region Methods

--- a/src/TestModel/model/TestCentricTestFilter.cs
+++ b/src/TestModel/model/TestCentricTestFilter.cs
@@ -1,0 +1,84 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TestCentric.Gui.Model
+{
+    internal class TestCentricTestFilter : ITestCentricTestFilter
+    {
+        // By default: all outcome filters are enabled
+        List<string> _outcomeFilter = new List<string>()
+        {
+            "Passed",
+            "Failed",
+            "Ignored",
+            "Skipped",
+            "Inconclusive",
+            "Not Run",
+        };
+
+        internal TestCentricTestFilter(TestModel model, Action filterChangedEvent)
+        {
+            TestModel = model;
+            FireFilterChangedEvent = filterChangedEvent;
+        }
+
+        private ITestModel TestModel { get; }
+
+        private Action FireFilterChangedEvent;
+
+        public IEnumerable<string> OutcomeFilter
+        {
+            get => _outcomeFilter;
+
+            set
+            {
+                _outcomeFilter = value.ToList();
+                FilterNodes(TestModel.LoadedTests);
+                FireFilterChangedEvent();
+            }
+        }
+
+        private bool FilterNodes(TestNode testNode)
+        {
+            // 1. Check if any child is visible => parent must be visible too
+            bool childIsVisible = false;
+            foreach (TestNode child in testNode.Children)
+                if (FilterNodes(child))
+                    childIsVisible = true;
+
+            // 2. Check if node itself is visible
+            bool isVisible = IsOutcomeFilterMatching(testNode);
+            testNode.IsVisible = isVisible || childIsVisible;
+            return testNode.IsVisible;
+        }
+
+        private bool IsOutcomeFilterMatching(TestNode testNode)
+        {
+            string outcome = "Not Run";
+
+            var result = TestModel.GetResultForTest(testNode.Id);
+            if (result != null)
+            {
+                switch (result.Outcome.Status)
+                {
+                    case TestStatus.Failed:
+                    case TestStatus.Passed:
+                    case TestStatus.Inconclusive:
+                        outcome = result.Outcome.Status.ToString();
+                        break;
+                    case TestStatus.Skipped:
+                        outcome = result.Outcome.Label == "Ignored" ? "Ignored" : "Skippeed";
+                        break;
+                }
+            }
+
+            return OutcomeFilter.Contains(outcome);
+        }
+    }
+}

--- a/src/TestModel/model/TestEventDispatcher.cs
+++ b/src/TestModel/model/TestEventDispatcher.cs
@@ -124,6 +124,11 @@ namespace TestCentric.Gui.Model
             CategorySelectionChanged?.Invoke(new TestEventArgs());
         }
 
+        public void FireTestFilterChanged()
+        {
+            TestFilterChanged?.Invoke(new TestEventArgs());
+        }
+
         #endregion
 
         #region ITestEvents Implementation
@@ -164,6 +169,7 @@ namespace TestCentric.Gui.Model
         public event TestSelectionEventHandler SelectedTestsChanged;
 
         public event TestEventHandler CategorySelectionChanged;
+        public event TestEventHandler TestFilterChanged;
 
         #endregion
 

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -56,6 +56,7 @@ namespace TestCentric.Gui.Model
             RecentFiles = new RecentFiles(_settingsService);
 
             Services = new TestServices(testEngine);
+            TestCentricTestFilter = new TestCentricTestFilter(this, () => _events.FireTestFilterChanged());
 
             AvailableAgents = new List<string>(
                 Services.TestAgentService.GetAvailableAgents().Select((a) => a.AgentName));
@@ -206,6 +207,8 @@ namespace TestCentric.Gui.Model
         public bool ExcludeSelectedCategories { get; private set; }
 
         public TestFilter CategoryFilter { get; private set; } = TestFilter.Empty;
+
+        public ITestCentricTestFilter TestCentricTestFilter { get; private set; }
 
         #endregion
 

--- a/src/TestModel/model/TestNode.cs
+++ b/src/TestModel/model/TestNode.cs
@@ -33,6 +33,7 @@ namespace TestCentric.Gui.Model
 
         public TestNode(XmlNode xmlNode)
         {
+            IsVisible = true;
             Xml = xmlNode;
 
             // It's a quirk of the test engine that the test-run element does;
@@ -76,6 +77,10 @@ namespace TestCentric.Gui.Model
         public bool IsAssembly => Type == "Assembly";
         public bool IsProject => Type == "Project";
 
+        /// <summary>
+        /// Controls if the TestNode should be visible or hidden in the TestTree
+        /// </summary>
+        public bool IsVisible { get; set; }
         public int TestCount => IsSuite ? GetAttribute("testcasecount", 0) : 1;
         public RunState RunState => GetRunState();
 


### PR DESCRIPTION
This PR is the first incremental step for issue #1148.
It provides the basic filter functionality of test nodes by supporting filtering by outcome. There's only one single use case supported yet: test results are already present from a test run and afterwards an outcome filter is applied programmatically. Then the test tree will display only the filtered nodes.

Further use cases will be supported in the next incremental steps:
- UI to configure a filter
- Apply active filter already during test run
- Apply commands on filtered nodes only (for example 'Run selected')

So, it's not the intention that this filter functionality is already perfect. But I believe it's a good foundation for the next steps.
These changes do not yet have any effect on the user as the filters cannot be activated, so this PR could be merged without causing any side effects.

If things go as planned, the new filter class can be extended to support also duration and category filtering - and maybe name filtering sometime in the future. And also the other way around: I hope that we won't have to adapt any other code locations if we extend the filters. This applies especially for the test tree: displaying a filtered tree and the filter functionality is well separated.

I tested the filter functionality by misusing one of the existing toolbar buttons. So for example setting the filter programmatically to:
`_model.TestCentricTestFilter.OutcomeFilter = new List<string>() { "Not Run", "Failed" };`