### PR TITLE
Update to latest TestCentric.Engine dev release

### DIFF
--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -15,7 +15,7 @@
   
 	<ItemGroup>
 		<PackageReference Include="Mono.Options" Version="6.12.0.148" />
-		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00006" />
+		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00008" />
 		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta6" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.0.2" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.1" />

--- a/src/TestModel/model/TestCentric.Gui.Model.csproj
+++ b/src/TestModel/model/TestCentric.Gui.Model.csproj
@@ -15,7 +15,7 @@
   
 	<ItemGroup>
 		<PackageReference Include="Mono.Options" Version="6.12.0.148" />
-		<PackageReference Include="TestCentric.Engine" Version="2.0.0-beta6" />
+		<PackageReference Include="TestCentric.Engine" Version="2.0.0-dev00006" />
 		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta6" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.0.2" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.1" />


### PR DESCRIPTION
This PR closes #1144 by updating the project reference of the TestCentric.Engine.
The details about the actual fix can be found in the PR [213 ](https://github.com/TestCentric/testcentric-engine/pull/213) to that project.

When using the latest version of the TestCentric.Engine, the Stop and Kill button works reliably. The behavior was checked using the hung-tests.dll for different .Net framework versions (4.62, Core 3.1, .Net 7.0...)

As this was my first time updating a project referecence, I was a little surprised at the version number of the dev releases. I initially thought that the highest number will be the latest dev release. But I notice that it's different here by checking the release dates. So I finally chose the version 2.0.0-dev00008. Is there any smart approach to detect the latest dev release differently?

