### PR TITLE
Fix TreeView flickering

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -84,18 +84,20 @@ namespace TestCentric.Gui.Presenters
             foreach (TreeNode treeNode in GetTreeNodesForTest(result))
             {
                 _view.SetImageIndex(treeNode, imageIndex);
-                UpdateTreeNodeName(treeNode);
             }
         }
 
         public virtual void OnTestRunStarting()
         {
             _view.ResetAllTreeNodeImages();
-            UpdateTreeNodeNames();
+            if (_settings.Gui.TestTree.ShowTestDuration)
+                _view.InvokeIfRequired(() => UpdateTreeNodeNames());
         }
 
         public virtual void OnTestRunFinished()
         {
+            if (_settings.Gui.TestTree.ShowTestDuration)
+                _view.InvokeIfRequired(() => UpdateTreeNodeNames());
         }
 
         // Called when either the display strategy or the grouping
@@ -205,11 +207,13 @@ namespace TestCentric.Gui.Presenters
 
         private void UpdateTreeNodeNames(TreeNodeCollection nodes)
         {
+            _view.TreeView.BeginUpdate();
             foreach (TreeNode treeNode in nodes)
             {
                 UpdateTreeNodeName(treeNode);
                 UpdateTreeNodeNames(treeNode.Nodes);
             }
+            _view.TreeView.EndUpdate();
         }
 
         private void UpdateTreeNodeName(TreeNode treeNode)

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -133,7 +133,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
-        public void OnTestFinished_ShowDurationIsInactive_TreeNodeName_IsUpdated()
+        public void OnTestRunFinished_ShowDurationIsInactive_TreeNodeName_IsUpdated()
         {
             // Arrange
             TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
@@ -142,8 +142,13 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.GetResultForTest(testNode.Id).Returns(result);
             _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
+            var nodes = new TreeNode().Nodes;
+            nodes.Add(treeNode);
+            _view.Nodes.Returns(nodes);
+            _view.TreeView.Returns(new TreeView());
+
             // Act
-            _strategy.OnTestFinished(result);
+            _strategy.OnTestRunFinished();
 
             // Assert
             Assert.That(treeNode.Text, Is.EqualTo("Test1"));
@@ -160,8 +165,13 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.GetResultForTest(testNode.Id).Returns(result);
             _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
+            var nodes = new TreeNode().Nodes;
+            nodes.Add(treeNode);
+            _view.Nodes.Returns(nodes);
+            _view.TreeView.Returns(new TreeView());
+
             // Act
-            _strategy.OnTestFinished(result);
+            _strategy.OnTestRunFinished();
 
             // Assert
             Assert.That(treeNode.Text, Does.Match(@"Test1 \[1[,.]500s\]"));


### PR DESCRIPTION
This PR closes #1165 which reports a flicking in the Treeview when executing tests.

As mentioned in the issue description this bug is caused by the 'Show duration' implementation. This implementation updates a tree node name by adding the test duration as a suffix right away whenever a test finished.

I propose to solve this issue by doing one step back: instead of updating the tree node names on TestFinished event, we'll update them on the TestRunFinished event. That means that the TreeView update is triggered only once - which will solve the flickering.

Obviously this is one step back for the user as he cannot observe the test duration anymore during a test run, but needs to wait until the test run finish. Especially for long running test runs (for which test duration is most helpful), that's not the best solution.
However I didn't find any simple solution, which takes care about all use cases. And unfortunately WindowsForms TreeView triggers a TreeView refresh whenever a TreeNode name is changed.
So overall I want to fix this flickering effect first, which is annoying and hits all users regardless if 'Show duration' is activated or not.

Additional note:
If test run was executed previously and afterwards show test duration is activated, the test duration will be shown immediately - this is kept unchanged.

Some further ideas:
- Introduce a Timer based approach to update the Tree node names. So, the Tree node names are updated during a test run only every 10s (for example)
- Attention this idea is a major design switch - nonetheless I'm mentioning it.
We can introduce additional columns next to the tree view. One of these columns will show the 'Test duration'. So instead of updating the tree node names, we need to update the column cells. I hope that updating cells won't cause a flickering effect as well. But overall, it must be evaluated first, if such columns are beneficial at all and for which other information they can be used (for example categories)?
And it's worth to mention that WindowsForms doesn't support a 'TreeView with additional columns' out-of-the-box. But there are several examples in the web which might be helpful.

