### PR TITLE
Disable TextFilter when no project is loaded

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -76,6 +76,7 @@ namespace TestCentric.Gui.Presenters
         {
             ClearTree();
             _view.OutcomeFilter.Enabled = false;
+            _view.TextFilter.Enabled = false;
         }
 
         public virtual void OnTestFinished(ResultNode result)

--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -75,8 +75,7 @@ namespace TestCentric.Gui.Presenters
         public void OnTestUnloaded()
         {
             ClearTree();
-            _view.OutcomeFilter.Enabled = false;
-            _view.TextFilter.Enabled = false;
+            _view.EnableTestFilter(false);
         }
 
         public virtual void OnTestFinished(ResultNode result)

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -49,8 +49,7 @@ namespace TestCentric.Gui.Presenters
             else
                 SetDefaultInitialExpansion();
 
-            _view.OutcomeFilter.Enabled = true;
-            _view.TextFilter.Enabled = true;
+            _view.EnableTestFilter(true);
         }
 
         protected override VisualState CreateVisualState() => new VisualState("NUNIT_TREE", _settings.Gui.TestTree.ShowNamespace).LoadFrom(_view.TreeView);

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -50,6 +50,7 @@ namespace TestCentric.Gui.Presenters
                 SetDefaultInitialExpansion();
 
             _view.OutcomeFilter.Enabled = true;
+            _view.TextFilter.Enabled = true;
         }
 
         protected override VisualState CreateVisualState() => new VisualState("NUNIT_TREE", _settings.Gui.TestTree.ShowNamespace).LoadFrom(_view.TreeView);

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -259,6 +259,7 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.DisplayFormat":
                         _view.DisplayFormat.SelectedItem = _settings.Gui.TestTree.DisplayFormat;
                         UpdateTreeDisplayMenuItem();
+                        UpdateViewCommands();
                         break;
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                         _view.GroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -57,6 +57,8 @@ namespace TestCentric.Gui.Views
 
         void SetTestFilterVisibility(bool visible);
 
+        void EnableTestFilter(bool enable);
+
         // Tree-related Methods
         void Clear();
         void Add(TreeNode treeNode);

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -211,6 +211,12 @@ namespace TestCentric.Gui.Views
             filterTextToolStrip.Visible = isVisible;
         }
 
+        public void EnableTestFilter(bool enable)
+        {
+            filterToolStrip.Enabled = enable;
+            filterTextToolStrip.Enabled = enable;
+        }
+
         public void LoadAlternateImages(string imageSet)
         {
             string[] imageNames = { "Skipped", "Inconclusive", "Success", "Ignored", "Failure" };

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using NSubstitute;
 using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters.Main
@@ -18,7 +19,7 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.DisplayFormat = displayFormat;
 
             // 2. Assert
-            _view.DisplayFormat.SelectedItem = displayFormat;
+            Assert.That(_view.DisplayFormat.SelectedItem, Is.EqualTo(displayFormat));
         }
 
         [TestCase("ASSEMBLY")]
@@ -30,7 +31,7 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.FixtureList.GroupBy = groupBy;
 
             // 2. Assert
-            _view.GroupBy.SelectedItem = groupBy;
+            Assert.That(_view.GroupBy.SelectedItem, Is.EqualTo(groupBy));
         }
 
         [TestCase("ASSEMBLY")]
@@ -42,7 +43,7 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.TestList.GroupBy = groupBy;
 
             // 2. Assert
-            _view.GroupBy.SelectedItem = groupBy;
+            Assert.That(_view.GroupBy.SelectedItem, Is.EqualTo(groupBy));
         }
 
         [TestCase(true, 0)]
@@ -53,7 +54,23 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.ShowNamespace = showNamespace;
 
             // 2. Assert
-            _view.ShowNamespace.SelectedIndex = expectedMenuIndex;
+            Assert.That(_view.ShowNamespace.SelectedIndex, Is.EqualTo(expectedMenuIndex));
+        }
+
+        [TestCase("NUNIT_TREE", true)]
+        [TestCase("FIXTURE_LIST", false)]
+        [TestCase("TEST_LIST", false)]
+        public void DisplayFormat_SettingChanged_ShowHideFilterButton_IsUpdated(string displayFormat, bool expectedState)
+        {
+            // 1. Arrange
+            _model.HasTests.Returns(true);
+
+            // 2. Act
+            _settings.Gui.TestTree.DisplayFormat = displayFormat;
+
+            // 3. Assert
+            Assert.That(_view.ShowHideFilterButton.Visible, Is.EqualTo(expectedState));
+            Assert.That(_view.ShowHideFilterButton.Enabled, Is.EqualTo(expectedState));
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -360,7 +360,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
-        public void OnTestLoaded_OutcomeFilter_IsEnabled()
+        public void OnTestLoaded_TestFilters_AreEnabled()
         {
             // Arrange
             string xml =
@@ -371,42 +371,17 @@ namespace TestCentric.Gui.Presenters.TestTree
             _strategy.OnTestLoaded(new TestNode(xml), null);
 
             // Assert
-            _view.OutcomeFilter.Received().Enabled = true;
+            _view.Received().EnableTestFilter(true);
         }
 
         [Test]
-        public void OnTestUnloaded_OutcomeFilter_IsDisabled()
+        public void OnTestUnloaded_TestFilters_AreDisabled()
         {
             // Arrange + Act
             _strategy.OnTestUnloaded();
 
             // Assert
-            _view.OutcomeFilter.Received().Enabled = false;
-        }
-
-        [Test]
-        public void OnTestLoaded_TextFilter_IsEnabled()
-        {
-            // Arrange
-            string xml =
-                "<test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
-                "</test-suite>";
-
-            // Act
-            _strategy.OnTestLoaded(new TestNode(xml), null);
-
-            // Assert
-            _view.TextFilter.Received().Enabled = true;
-        }
-
-        [Test]
-        public void OnTestUnloaded_TextFilter_IsDisabled()
-        {
-            // Arrange + Act
-            _strategy.OnTestUnloaded();
-
-            // Assert
-            _view.TextFilter.Received().Enabled = false;
+            _view.Received().EnableTestFilter(false);
         }
     }
 

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -383,6 +383,31 @@ namespace TestCentric.Gui.Presenters.TestTree
             // Assert
             _view.OutcomeFilter.Received().Enabled = false;
         }
+
+        [Test]
+        public void OnTestLoaded_TextFilter_IsEnabled()
+        {
+            // Arrange
+            string xml =
+                "<test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                "</test-suite>";
+
+            // Act
+            _strategy.OnTestLoaded(new TestNode(xml), null);
+
+            // Assert
+            _view.TextFilter.Received().Enabled = true;
+        }
+
+        [Test]
+        public void OnTestUnloaded_TextFilter_IsDisabled()
+        {
+            // Arrange + Act
+            _strategy.OnTestUnloaded();
+
+            // Assert
+            _view.TextFilter.Received().Enabled = false;
+        }
     }
 
 


### PR DESCRIPTION
I have noticed one issue with the new TextFilter (#1161) that I would like to fix with this PR:

We actually want the filters to be disabled when no project is loaded. And that's how we implemented it already for the OutcomeFilter. 
However I missed to add this for the new TextFilter. This PR now makes up for this!
(File: DisplayStrategy.cs and NUnitTreeDisplayStrategy.cs)
