### PR TITLE
Keep expand/collapse state of tree nodes when changing the tree filter

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -102,12 +102,13 @@ namespace TestCentric.Gui.Presenters
 
         // Called when either the display strategy or the grouping
         // changes. May need to distinguish these cases.
-        public void Reload()
+        public void Reload(bool applyVisualState = false)
         {
             TestNode testNode = _model.LoadedTests;
             if (testNode != null)
             {
-                OnTestLoaded(testNode, null);
+                VisualState visualState = applyVisualState ? CreateVisualState() : null;
+                OnTestLoaded(testNode, visualState);
 
                 if (_view.Nodes != null) // TODO: Null when mocked
                     foreach (TreeNode treeNode in _view.Nodes)

--- a/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ITreeDisplayStrategy.cs
@@ -23,7 +23,7 @@ namespace TestCentric.Gui.Presenters
         /// <summary>
         /// Reload tree: clear all tree nodes first and rebuild all nodes afterwards
         /// </summary>
-        void Reload();
+        void Reload(bool applyVisualState=false);
 
         /// <summary>
         /// Save the visual state of the tree display strategy into a file

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -112,7 +112,7 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.TestFilterChanged += (ea) =>
             {
-                Strategy?.Reload();
+                Strategy?.Reload(true);
             };
 
             _model.Events.TestFinished += OnTestFinished;

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -262,6 +262,21 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.TestCentricTestFilter.Received().TextFilter = "TestA";
         }
 
+        [Test]
+        public void FilterChanged_ReloadTree_IsInvoked()
+        {
+            // 1. Arrange
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+            _model.Settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
+
+            // 2. Act
+            _model.Events.TestFilterChanged += Raise.Event<TestEventHandler>(new TestEventArgs());
+
+            // 3. Assert
+            strategy.Received().Reload(true);
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenContextNodeIsNotNull_RunCommandExecutesThatTest()


### PR DESCRIPTION
This PR is another contribution to the test filter functionality (#1148, #1161, #1147).

This PR propose to keep the expand/collapse state of the tree nodes constant, whenever a test filter is modified. For example if a user expanded certain tree nodes and afterwards apply a test filter, all those tree nodes which are still visible after the filtering should remain their expand/collapse state. 

The idea is that the user is familiar with the view after the filtering and does not have to adjust the expand/collapse state again right away. So overal this PR tries to improve the usability when working with test filters.