### PR TITLE
Sort tree nodes by name or duration

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -11,8 +11,6 @@ namespace TestCentric.Gui.Presenters
     using Model;
     using Model.Settings;
     using Views;
-	using Elements;
-    using System.IO;
     using System.Linq;
 
     /// <summary>
@@ -96,6 +94,10 @@ namespace TestCentric.Gui.Presenters
 
         public virtual void OnTestRunFinished()
         {
+            if (_view.SortCommand.SelectedItem == TreeViewNodeComparer.Duration)
+            {
+                _view.InvokeIfRequired(() => _view.Sort());
+            }
             if (_settings.Gui.TestTree.ShowTestDuration)
                 _view.InvokeIfRequired(() => UpdateTreeNodeNames());
         }

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewNodeComparer.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewNodeComparer.cs
@@ -1,0 +1,146 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Collections;
+using System.Windows.Forms;
+using TestCentric.Gui.Model;
+
+namespace TestCentric.Gui.Presenters
+{
+    /// <summary>
+    /// This class is responsible for the sorting functionality of tree nodes
+    /// by providing different IComparer implementations.
+    /// </summary>
+    public class TreeViewNodeComparer
+    {
+        public const string Name = "Name";
+        public const string Duration = "Duration";
+        public const string Ascending = "Ascending";
+        public const string Descending = "Descending";
+
+
+        /// <summary>
+        /// Get a IComparer implementation used to sort the tree nodes
+        /// The sortModes are used by the context menu items in their Tag property
+        /// </summary>
+        public static IComparer GetComparer(ITestModel model, string sortMode, string sortDirection, bool showNamespaces)
+        {
+            bool ascending = sortDirection == Ascending;
+
+            if (sortMode == Name && !showNamespaces)
+                return new NameComparer(ascending);
+            if (sortMode == Duration)
+                return new DurationComparer(model, ascending);
+
+            return new FullnameComparer(ascending);
+        }
+
+        /// <summary>
+        /// The FullnameComparer uses the FullName of the TestNodes (Namespace + class + method name)
+        /// It's indented to provide the same order as provided by NUnit
+        /// </summary>
+        private class FullnameComparer : IComparer
+        {
+            private bool _ascending;
+
+            internal FullnameComparer(bool ascending)
+            {
+                _ascending = ascending;
+            }
+
+            public int Compare(object x, object y)
+            {
+                TreeNode node1 = x as TreeNode;
+                TreeNode node2 = y as TreeNode;
+
+                TestNode testNode1 = node1.Tag as TestNode;
+                TestNode testNode2 = node2.Tag as TestNode;
+
+                if (!_ascending)
+                    Swap(ref testNode1, ref testNode2);
+
+                if (testNode1 == null || testNode2 == null)
+                    return 1;
+
+                return testNode1.FullName.CompareTo(testNode2.FullName);
+            }
+        }
+
+        /// <summary>
+        /// The NameComparer uses the Name of the TestNodes (either Namespace or class or method name)
+        /// If Namespaces are shown in the tree, it will provide the same results as the FullnameComparer
+        /// However if Namespaces are hidden, the NameComparer will sort the class names properly.
+        /// </summary>
+        private class NameComparer : IComparer
+        {
+            private bool _ascending;
+
+            internal NameComparer(bool ascending)
+            {
+                _ascending = ascending;
+            }
+
+            public int Compare(object x, object y)
+            {
+                TreeNode node1 = x as TreeNode;
+                TreeNode node2 = y as TreeNode;
+
+                if (!_ascending)
+                    Swap(ref node1, ref node2);
+
+                if (node1 != null && node2 != null)
+                        return node1.Text.CompareTo(node2.Text);
+
+                return 1;
+            }
+        }
+
+        /// <summary>
+        /// The DurationComparer uses the Duration of the TestResults
+        /// It no test results are available yet, it uses the Name.
+        /// </summary>
+        private class DurationComparer : IComparer
+        {
+            private ITestModel _model;
+            private bool _ascending;
+
+            internal DurationComparer(ITestModel model, bool ascending)
+            {
+                _model = model;
+                _ascending = ascending;
+            }
+
+            public int Compare(object x, object y)
+            {
+                TreeNode node1 = x as TreeNode;
+                TreeNode node2 = y as TreeNode;
+
+                if (!_ascending)
+                    Swap(ref node1, ref node2);
+
+                TestNode testNode1 = node1?.Tag as TestNode;
+                TestNode testNode2 = node2?.Tag as TestNode;
+
+                if (testNode1 == null || testNode2 == null)
+                    return 1;
+
+                ResultNode resultNode1 = _model.GetResultForTest(testNode1.Id);
+                ResultNode resultNode2 = _model.GetResultForTest(testNode2.Id);
+
+                if (resultNode1 != null && resultNode2 != null)
+                        return resultNode1.Duration.CompareTo(resultNode2.Duration);
+
+                return node1.Text.CompareTo(node2.Text); ;
+            }
+        }
+
+        internal static void Swap<T>(ref T x, ref T y)
+        {
+            T tmp = x;
+            x = y;
+            y = tmp;
+        }
+    }
+}

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewNodeComparer.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewNodeComparer.cs
@@ -25,53 +25,19 @@ namespace TestCentric.Gui.Presenters
         /// Get a IComparer implementation used to sort the tree nodes
         /// The sortModes are used by the context menu items in their Tag property
         /// </summary>
-        public static IComparer GetComparer(ITestModel model, string sortMode, string sortDirection, bool showNamespaces)
+        public static IComparer GetComparer(ITestModel model, string sortMode, string sortDirection)
         {
             bool ascending = sortDirection == Ascending;
 
-            if (sortMode == Name && !showNamespaces)
-                return new NameComparer(ascending);
             if (sortMode == Duration)
                 return new DurationComparer(model, ascending);
 
-            return new FullnameComparer(ascending);
-        }
-
-        /// <summary>
-        /// The FullnameComparer uses the FullName of the TestNodes (Namespace + class + method name)
-        /// It's indented to provide the same order as provided by NUnit
-        /// </summary>
-        private class FullnameComparer : IComparer
-        {
-            private bool _ascending;
-
-            internal FullnameComparer(bool ascending)
-            {
-                _ascending = ascending;
-            }
-
-            public int Compare(object x, object y)
-            {
-                TreeNode node1 = x as TreeNode;
-                TreeNode node2 = y as TreeNode;
-
-                TestNode testNode1 = node1.Tag as TestNode;
-                TestNode testNode2 = node2.Tag as TestNode;
-
-                if (!_ascending)
-                    Swap(ref testNode1, ref testNode2);
-
-                if (testNode1 == null || testNode2 == null)
-                    return 1;
-
-                return testNode1.FullName.CompareTo(testNode2.FullName);
-            }
+            return new NameComparer(ascending);
         }
 
         /// <summary>
         /// The NameComparer uses the Name of the TestNodes (either Namespace or class or method name)
-        /// If Namespaces are shown in the tree, it will provide the same results as the FullnameComparer
-        /// However if Namespaces are hidden, the NameComparer will sort the class names properly.
+        /// It's invoked by Windows Forms for all nodes of one hierarchy level to provide a proper ordering
         /// </summary>
         private class NameComparer : IComparer
         {

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -41,6 +41,7 @@ namespace TestCentric.Gui.Presenters
             _view.ShowCheckBoxes.Checked = _view.CheckBoxes = _treeSettings.ShowCheckBoxes;
             _view.ShowTestDuration.Checked = _treeSettings.ShowTestDuration;
             _view.AlternateImageSet = _treeSettings.AlternateImageSet;
+            UpdateTreeViewSortMode();
 
             WireUpEvents();
         }
@@ -133,7 +134,6 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
                     case "TestCentric.Gui.TestTree.ShowNamespace":
-                        SortTreeView();
                         Strategy?.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
@@ -170,9 +170,9 @@ namespace TestCentric.Gui.Presenters
                 Strategy?.UpdateTreeNodeNames();
             };
 
-            _view.SortCommand.SelectionChanged += () => SortTreeView();
+            _view.SortCommand.SelectionChanged += () => UpdateTreeViewSortMode();
 
-            _view.SortDirectionCommand.SelectionChanged += () => SortTreeView();
+            _view.SortDirectionCommand.SelectionChanged += () => UpdateTreeViewSortMode();
 
             _view.RunContextCommand.Execute += () =>
             {
@@ -302,7 +302,7 @@ namespace TestCentric.Gui.Presenters
             //};
         }
 
-        private void SortTreeView()
+        private void UpdateTreeViewSortMode()
         {
             var sortMode = _view.SortCommand.SelectedItem;
 
@@ -310,7 +310,7 @@ namespace TestCentric.Gui.Presenters
             if (sortMode == TreeViewNodeComparer.Duration)
                 _view.ShowTestDuration.Checked = true;
           
-            IComparer comparer = TreeViewNodeComparer.GetComparer(_model, sortMode, _view.SortDirectionCommand.SelectedItem, _treeSettings.ShowNamespace);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(_model, sortMode, _view.SortDirectionCommand.SelectedItem);
             _view.Sort(comparer);
         }
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -4,19 +4,16 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
-using TestCentric.Common;
 
 namespace TestCentric.Gui.Presenters
 {
     using Model;
     using Views;
     using Dialogs;
-    using System.Xml;
-    using System.Drawing;
     using System.IO;
     using TestCentric.Gui.Controls;
+    using System.Collections;
 
     /// <summary>
     /// TreeViewPresenter is the presenter for the TestTreeView
@@ -136,6 +133,7 @@ namespace TestCentric.Gui.Presenters
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
                     case "TestCentric.Gui.TestTree.ShowNamespace":
+                        SortTreeView();
                         Strategy?.Reload();
                         break;
                     case "TestCentric.Gui.TestTree.ShowCheckBoxes":
@@ -171,6 +169,10 @@ namespace TestCentric.Gui.Presenters
                 _treeSettings.ShowTestDuration = _view.ShowTestDuration.Checked;
                 Strategy?.UpdateTreeNodeNames();
             };
+
+            _view.SortCommand.SelectionChanged += () => SortTreeView();
+
+            _view.SortDirectionCommand.SelectionChanged += () => SortTreeView();
 
             _view.RunContextCommand.Execute += () =>
             {
@@ -298,6 +300,18 @@ namespace TestCentric.Gui.Presenters
             //            CloseXmlDisplay();
             //    }
             //};
+        }
+
+        private void SortTreeView()
+        {
+            var sortMode = _view.SortCommand.SelectedItem;
+
+            // Activate 'ShowTestDuration' in case sort by duration is selected
+            if (sortMode == TreeViewNodeComparer.Duration)
+                _view.ShowTestDuration.Checked = true;
+          
+            IComparer comparer = TreeViewNodeComparer.GetComparer(_model, sortMode, _view.SortDirectionCommand.SelectedItem, _treeSettings.ShowNamespace);
+            _view.Sort(comparer);
         }
 
         private void UpdateTreeSettingsFromVisualState(VisualState visualState)

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
 {
+    using System.Collections;
     using System.Collections.Generic;
     using Elements;
 
@@ -29,6 +30,9 @@ namespace TestCentric.Gui.Views
         IToolStripMenu ActiveConfiguration { get; }
         IChecked ShowCheckBoxes { get; }
         IChecked ShowTestDuration { get; }
+        ISelection SortCommand { get; }
+        ISelection SortDirectionCommand { get; }
+
         ICommand ExpandAllCommand { get; }
         ICommand CollapseAllCommand { get; }
         ICommand CollapseToFixturesCommand { get; }
@@ -66,6 +70,9 @@ namespace TestCentric.Gui.Views
         void Add(TreeNode treeNode);
         void ExpandAll();
         void CollapseAll();
+
+        void Sort();
+        void Sort(IComparer comparer);
         void SetImageIndex(TreeNode treeNode, int imageIndex);
 
         /// <summary>

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -54,6 +54,14 @@ namespace TestCentric.Gui.Views
             this.showCheckboxesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showTestDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.expandAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.contextMenuSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.contextMenuSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.sortByMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortByNameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortByDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortMenuSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.sortAscendingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortDescendingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseToFixturesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.treeImages = new System.Windows.Forms.ImageList(this.components);
@@ -171,11 +179,15 @@ namespace TestCentric.Gui.Views
             this.contextMenuSeparator2,
             this.showCheckboxesMenuItem,
             this.showTestDurationMenuItem,
+            this.contextMenuSeparator3,
+            this.sortByMenuItem,
+            this.contextMenuSeparator4,
             this.expandAllMenuItem,
             this.collapseAllMenuItem,
             this.collapseToFixturesMenuItem});
             this.testTreeContextMenu.Name = "testTreeContextMenu";
             this.testTreeContextMenu.Size = new System.Drawing.Size(181, 236);
+            this.sortByMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { sortByNameMenuItem, sortByDurationMenuItem, sortMenuSeparator, sortAscendingMenuItem, sortDescendingMenuItem });
             // 
             // runMenuItem
             // 
@@ -231,6 +243,59 @@ namespace TestCentric.Gui.Views
             this.showTestDurationMenuItem.Size = new System.Drawing.Size(190, 22);
             this.showTestDurationMenuItem.Text = "Show Test Duration";
             // 
+            // sortByMenuItem
+            // 
+            this.sortByMenuItem.Name = "sortByMenuItem";
+            this.sortByMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.sortByMenuItem.Text = "Sort by ...";
+            // 
+            // sortByNameMenuItem
+            // 
+            this.sortByNameMenuItem.CheckOnClick = true;
+            this.sortByNameMenuItem.Name = "sortByNameMenuItem";
+            this.sortByNameMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.sortByNameMenuItem.Text = "Name";
+            this.sortByNameMenuItem.Tag = "Name";
+            // 
+            // sortByDurationMenuItem
+            // 
+            this.sortByDurationMenuItem.CheckOnClick = true;
+            this.sortByDurationMenuItem.Name = "sortByDurationMenuItem";
+            this.sortByDurationMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.sortByDurationMenuItem.Text = "Duration";
+            this.sortByDurationMenuItem.Tag = "Duration";
+            // 
+            // sortAscendingMenuItem
+            // 
+            this.sortAscendingMenuItem.CheckOnClick = true;
+            this.sortAscendingMenuItem.Name = "sortAscendingMenuItem";
+            this.sortAscendingMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.sortAscendingMenuItem.Text = "Ascending";
+            this.sortAscendingMenuItem.Tag = "Ascending";
+            // 
+            // sortDescendingMenuItem
+            // 
+            this.sortDescendingMenuItem.CheckOnClick = true;
+            this.sortDescendingMenuItem.Name = "sortDescendingMenuItem";
+            this.sortDescendingMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.sortDescendingMenuItem.Text = "Descending";
+            this.sortDescendingMenuItem.Tag = "Descending";
+            // 
+            // sortMenuSeparator
+            // 
+            this.sortMenuSeparator.Name = "sortMenuSeparator";
+            this.sortMenuSeparator.Size = new System.Drawing.Size(187, 6);
+            // 
+            // contextMenuSeparator3
+            // 
+            this.contextMenuSeparator3.Name = "contextMenuSeparator3";
+            this.contextMenuSeparator3.Size = new System.Drawing.Size(187, 6);
+            // 
+            // contextMenuSeparator4
+            // 
+            this.contextMenuSeparator4.Name = "contextMenuSeparator4";
+            this.contextMenuSeparator4.Size = new System.Drawing.Size(187, 6);
+            // 
             // expandAllMenuItem
             // 
             this.expandAllMenuItem.Name = "expandAllMenuItem";
@@ -284,6 +349,12 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.ToolStripTextBox filterTextBox;
         private System.Windows.Forms.ToolStripMenuItem runMenuItem;
         private System.Windows.Forms.ToolStripMenuItem expandAllMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sortByMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sortByNameMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sortByDurationMenuItem;
+        private System.Windows.Forms.ToolStripSeparator sortMenuSeparator;
+        private System.Windows.Forms.ToolStripMenuItem sortAscendingMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sortDescendingMenuItem;
         private System.Windows.Forms.ToolStripMenuItem collapseAllMenuItem;
         private System.Windows.Forms.ToolStripMenuItem collapseToFixturesMenuItem;
         private System.Windows.Forms.ImageList treeImages;
@@ -294,6 +365,8 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.ToolStripSeparator contextMenuSeparator2;
         private System.Windows.Forms.ToolStripMenuItem testPropertiesMenuItem;
         private System.Windows.Forms.ToolStripSeparator contextMenuSeparator1;
+        private System.Windows.Forms.ToolStripSeparator contextMenuSeparator3;
+        private System.Windows.Forms.ToolStripSeparator contextMenuSeparator4;
         private System.Windows.Forms.ToolStripMenuItem viewAsXmlMenuItem;
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 namespace TestCentric.Gui.Views
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using Elements;
 
@@ -48,6 +49,8 @@ namespace TestCentric.Gui.Views
             CollapseToFixturesCommand = new CommandMenuElement(collapseToFixturesMenuItem);
             TestPropertiesCommand = new CommandMenuElement(testPropertiesMenuItem);
             ViewAsXmlCommand = new CommandMenuElement(viewAsXmlMenuItem);
+            SortCommand = new CheckedToolStripMenuGroup("Sort", sortByNameMenuItem, sortByDurationMenuItem);
+            SortDirectionCommand = new CheckedToolStripMenuGroup("SortDirection", sortAscendingMenuItem, sortDescendingMenuItem);
             OutcomeFilter = new MultiCheckedToolStripButtonGroup(new[] { filterOutcomePassedButton, filterOutcomeFailedButton, filterOutcomeWarningButton, filterOutcomeNotRunButton });
             TextFilter = new ToolStripTextBoxElement(filterTextBox, "Filter...");
             CategoryFilter = new ToolStripCategoryFilterButton(filterByCategory);
@@ -119,6 +122,9 @@ namespace TestCentric.Gui.Views
         public IToolStripMenu ActiveConfiguration { get; private set; }
         public IChecked ShowCheckBoxes { get; private set; }
         public IChecked ShowTestDuration { get; private set; }
+
+        public ISelection SortCommand { get; private set; }
+        public ISelection SortDirectionCommand { get; private set; }
         public ICommand ExpandAllCommand { get; private set; }
         public ICommand CollapseAllCommand { get; private set; }
         public ICommand CollapseToFixturesCommand { get; private set; }
@@ -243,6 +249,28 @@ namespace TestCentric.Gui.Views
 
             this.Invalidate();
             this.Refresh();
+        }
+
+        /// <summary>
+        /// Apply the current active TreeViewNodeSorter to sort the tree view
+        /// </summary>
+        public void Sort()
+        {
+            // Restore selected node after tree sorting
+            var selectedNode = treeView.SelectedNode;
+            treeView.Sort();
+            treeView.SelectedNode = selectedNode;
+        }
+
+        /// <summary>
+        /// Set a comparer as the TreeViewNodeSorter to sort the tree view
+        /// </summary>
+        public void Sort(IComparer comparer)
+        {
+            // Restore selected node after tree sorting
+            var selectedNode = treeView.SelectedNode;
+            treeView.TreeViewNodeSorter = comparer;
+            treeView.SelectedNode = selectedNode;
         }
 
         #endregion

--- a/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -178,6 +178,30 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
+        public void OnTestFinished_SortByDurationIsActive_Tree_IsSorted()
+        {
+            // Arrange
+            _settings.Gui.TestTree.ShowTestDuration = true;
+            TestNode testNode = new TestNode("<test-case id='1' name='Test1'/>");
+            var treeNode = _strategy.MakeTreeNode(testNode, false);
+            ResultNode result = new ResultNode($"<test-case id='1' result='Passed' duration='1.5'/>");
+            _model.GetResultForTest(testNode.Id).Returns(result);
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
+            _view.SortCommand.SelectedItem.Returns(TreeViewNodeComparer.Duration);
+
+            var nodes = new TreeNode().Nodes;
+            nodes.Add(treeNode);
+            _view.Nodes.Returns(nodes);
+            _view.TreeView.Returns(new TreeView());
+
+            // Act
+            _strategy.OnTestRunFinished();
+
+            // Assert
+            _view.Received().Sort();
+        }
+
+        [Test]
         public void MakeTreeNode_ShowDurationIsActive_TreeNodeName_ContainsDuration()
         {
             // Arrange

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -44,22 +44,6 @@ namespace TestCentric.Gui.Presenters.TestTree
 
         [TestCase(true)]
         [TestCase(false)]
-        public void WhenSettingsAreChanged_ShowNamespace_Tree_IsSorted(bool showNamespace)
-        {
-            // Arrange
-            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
-            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
-            _model.Settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
-
-            // Act
-            _model.Settings.Gui.TestTree.ShowNamespace = showNamespace;
-
-            // Assert
-            _view.ReceivedWithAnyArgs().Sort(null);
-        }
-
-        [TestCase(true)]
-        [TestCase(false)]
         public void WhenSettingsAreChanged_ShowFilter_FilterVisibilityIsCalled(bool show)
         {
 

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -29,7 +29,7 @@ namespace TestCentric.Gui.Presenters.TestTree
 
         [TestCase(true)]
         [TestCase(false)]
-        public void WhenSettingsAreChanged_ShowNamespace_StrategyIsReloaed(bool showNamespace)
+        public void WhenSettingsAreChanged_ShowNamespace_StrategyIsReloaded(bool showNamespace)
         {
             ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
             _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
@@ -40,6 +40,22 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             // Assert
             strategy.Received(2).Reload();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void WhenSettingsAreChanged_ShowNamespace_Tree_IsSorted(bool showNamespace)
+        {
+            // Arrange
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+            _model.Settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
+
+            // Act
+            _model.Settings.Gui.TestTree.ShowNamespace = showNamespace;
+
+            // Assert
+            _view.ReceivedWithAnyArgs().Sort(null);
         }
 
         [TestCase(true)]
@@ -275,6 +291,43 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             // 3. Assert
             strategy.Received().Reload(true);
+        }
+
+        [Test]
+        public void SortChanged_Sort_IsInvoked()
+        {
+            // 1. Arrange
+
+            // 2. Act
+            _view.SortCommand.SelectionChanged += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _view.ReceivedWithAnyArgs().Sort(null);
+        }
+
+        [Test]
+        public void SortDirectionChanged_Sort_IsInvoked()
+        {
+            // 1. Arrange
+
+            // 2. Act
+            _view.SortCommand.SelectionChanged += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _view.ReceivedWithAnyArgs().Sort(null);
+        }
+
+        [Test]
+        public void SortChanged_ToDuration_ShowDuration_IsSet()
+        {
+            // 1. Arrange
+            _view.SortCommand.SelectedItem.Returns(TreeViewNodeComparer.Duration);
+
+            // 2. Act
+            _view.SortCommand.SelectionChanged += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _view.ShowTestDuration.Received().Checked = true;
         }
 
         // TODO: Version 1 Test - Make it work if needed.

--- a/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenPresenterIsCreated.cs
@@ -5,6 +5,7 @@
 
 using NUnit.Framework;
 using NSubstitute;
+using System.Collections;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
@@ -29,6 +30,12 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             bool showTestDuration = _settings.Gui.TestTree.ShowTestDuration;
             _view.ShowTestDuration.Received().Checked = showTestDuration;
+        }
+
+        [Test]
+        public void SortingMode_IsUpdated_ToDefaultSorter()
+        {
+            _view.Received().Sort(Arg.Is<IComparer>(c => c.GetType().Name == "NameComparer"));
         }
 
         //[Test]

--- a/src/TestCentric/tests/Presenters/TreeViewNodeComparerTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewNodeComparerTests.cs
@@ -14,19 +14,17 @@ namespace TestCentric.Gui.Presenters
     [TestFixture]
     public class TreeViewNodeComparerTests
     {
-        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, false, "NameComparer")]
-        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, true, "FullnameComparer")]
-        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, false, "NameComparer")]
-        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, true, "FullnameComparer")]
-        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending, false, "DurationComparer")]
-        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending, true, "DurationComparer")]
-        public void GetComparer(string sortMode, string sortDirection, bool showNamespace, string expectedComparerName)
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, "NameComparer")]
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, "NameComparer")]
+        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending, "DurationComparer")]
+        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending, "DurationComparer")]
+        public void GetComparer(string sortMode, string sortDirection, string expectedComparerName)
         {
             // Arrange
             ITestModel model = Substitute.For<ITestModel>();
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, sortMode, sortDirection, showNamespace);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, sortMode, sortDirection);
 
             // Assert
             string classname = comparer.GetType().Name;
@@ -46,7 +44,7 @@ namespace TestCentric.Gui.Presenters
 
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, false);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending);
             int result = comparer.Compare(treeNode1, treeNode2);
 
             // Assert
@@ -66,56 +64,7 @@ namespace TestCentric.Gui.Presenters
 
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, false);
-            int result = comparer.Compare(treeNode1, treeNode2);
-
-            // Assert
-            Assert.That(result, Is.EqualTo(expectedCompareResult));
-        }
-
-        [TestCase("Namespace1.A", "Namespace1.B", -1)]
-        [TestCase("Namespace1.B", "Namespace1.A", 1)]
-        [TestCase("Namespace1.A", "Namespace1.A", 0)]
-        [TestCase("Namespace1.A", "Namespace1.a", 1)]
-        [TestCase("a", "b", -1)]
-        [TestCase("aba", "aaa", 1)]
-        [TestCase("", "", 0)]
-        public void Fullnamecompare_Ascending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
-        {
-            // Arrange
-            ITestModel model = Substitute.For<ITestModel>();
-            TestNode testNode1 = new TestNode($"<test-start fullname='{text1}'/>");
-            TestNode testNode2 = new TestNode($"<test-start fullname='{text2}'/>");
-
-            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
-            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
-
-            // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, true);
-            int result = comparer.Compare(treeNode1, treeNode2);
-
-            // Assert
-            Assert.That(result, Is.EqualTo(expectedCompareResult));
-        }
-
-        [TestCase("Namespace1.A", "Namespace1.B", 1)]
-        [TestCase("Namespace1.B", "Namespace1.A", -1)]
-        [TestCase("Namespace1.A", "Namespace1.A", 0)]
-        [TestCase("Namespace1.A", "Namespace1.a", -1)]
-        [TestCase("", "", 0)]
-        public void Fullnamecompare_Descending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
-        {
-            // Arrange
-            ITestModel model = Substitute.For<ITestModel>();
-
-            TestNode testNode1 = new TestNode($"<test-start fullname='{text1}'/>");
-            TestNode testNode2 = new TestNode($"<test-start fullname='{text2}'/>");
-
-            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
-            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
-
-            // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, true);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending);
             int result = comparer.Compare(treeNode1, treeNode2);
 
             // Assert
@@ -142,7 +91,7 @@ namespace TestCentric.Gui.Presenters
             TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending, true);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending);
             int result = comparer.Compare(treeNode1, treeNode2);
 
             // Assert
@@ -169,7 +118,7 @@ namespace TestCentric.Gui.Presenters
             TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending, true);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending);
             int result = comparer.Compare(treeNode1, treeNode2);
 
             // Assert
@@ -192,7 +141,7 @@ namespace TestCentric.Gui.Presenters
             TreeNode treeNode2 = new TreeNode(text2) { Tag = testNode2 };
 
             // Act
-            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, sortDirection, true);
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, sortDirection);
             int result = comparer.Compare(treeNode1, treeNode2);
 
             // Assert

--- a/src/TestCentric/tests/Presenters/TreeViewNodeComparerTests.cs
+++ b/src/TestCentric/tests/Presenters/TreeViewNodeComparerTests.cs
@@ -1,0 +1,202 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Collections;
+using System.Windows.Forms;
+using NSubstitute;
+using NUnit.Framework;
+using TestCentric.Gui.Model;
+
+namespace TestCentric.Gui.Presenters
+{
+    [TestFixture]
+    public class TreeViewNodeComparerTests
+    {
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, false, "NameComparer")]
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, true, "FullnameComparer")]
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, false, "NameComparer")]
+        [TestCase(TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, true, "FullnameComparer")]
+        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending, false, "DurationComparer")]
+        [TestCase(TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending, true, "DurationComparer")]
+        public void GetComparer(string sortMode, string sortDirection, bool showNamespace, string expectedComparerName)
+        {
+            // Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, sortMode, sortDirection, showNamespace);
+
+            // Assert
+            string classname = comparer.GetType().Name;
+            Assert.That(classname, Is.EqualTo(expectedComparerName));
+        }
+
+        [TestCase("a", "b", -1)]
+        [TestCase("aba", "aaa", 1)]
+        [TestCase("abc", "abc", 0)]
+        [TestCase("", "", 0)]
+        public void Namecompare_Ascending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
+        {
+            // Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            TreeNode treeNode1 = new TreeNode(text1);
+            TreeNode treeNode2 = new TreeNode(text2);
+
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, false);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("a", "b", 1)]
+        [TestCase("aba", "aaa", -1)]
+        [TestCase("abc", "abc", 0)]
+        [TestCase("", "", 0)]
+        public void Namecompare_Descending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
+        {
+            // Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            TreeNode treeNode1 = new TreeNode(text1);
+            TreeNode treeNode2 = new TreeNode(text2);
+
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, false);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("Namespace1.A", "Namespace1.B", -1)]
+        [TestCase("Namespace1.B", "Namespace1.A", 1)]
+        [TestCase("Namespace1.A", "Namespace1.A", 0)]
+        [TestCase("Namespace1.A", "Namespace1.a", 1)]
+        [TestCase("a", "b", -1)]
+        [TestCase("aba", "aaa", 1)]
+        [TestCase("", "", 0)]
+        public void Fullnamecompare_Ascending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
+        {
+            // Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            TestNode testNode1 = new TestNode($"<test-start fullname='{text1}'/>");
+            TestNode testNode2 = new TestNode($"<test-start fullname='{text2}'/>");
+
+            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
+            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Ascending, true);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("Namespace1.A", "Namespace1.B", 1)]
+        [TestCase("Namespace1.B", "Namespace1.A", -1)]
+        [TestCase("Namespace1.A", "Namespace1.A", 0)]
+        [TestCase("Namespace1.A", "Namespace1.a", -1)]
+        [TestCase("", "", 0)]
+        public void Fullnamecompare_Descending_ReturnsExpectedResult(string text1, string text2, int expectedCompareResult)
+        {
+            // Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+
+            TestNode testNode1 = new TestNode($"<test-start fullname='{text1}'/>");
+            TestNode testNode2 = new TestNode($"<test-start fullname='{text2}'/>");
+
+            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
+            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Name, TreeViewNodeComparer.Descending, true);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("2", "4", -1)]
+        [TestCase("0.5", "0.8", -1)]
+        [TestCase("0.8", "1.2", -1)]
+        [TestCase("0.8", "0.5", 1)]
+        [TestCase("0.8", "0.8", 0)]
+        public void Durationcompare_Ascending_ReturnsExpectedResult(string duration1, string duration2, int expectedCompareResult)
+        {
+            // Arrange
+            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
+            var resultNode1 = new ResultNode($"<test-case id='1' duration='{duration1}'/>");
+            var resultNode2 = new ResultNode($"<test-case id='2' duration='{duration2}'/>");
+            ITestModel model = Substitute.For<ITestModel>();
+            model.GetResultForTest("1").Returns(resultNode1);
+            model.GetResultForTest("2").Returns(resultNode2);
+
+            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
+            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Ascending, true);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("2", "4", 1)]
+        [TestCase("0.5", "0.8", 1)]
+        [TestCase("0.8", "1.2", 1)]
+        [TestCase("0.8", "0.5", -1)]
+        [TestCase("0.8", "0.8", 0)]
+        public void Durationcompare_Descending_ReturnsExpectedResult(string duration1, string duration2, int expectedCompareResult)
+        {
+            // Arrange
+            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
+            var resultNode1 = new ResultNode($"<test-case id='1' duration='{duration1}'/>");
+            var resultNode2 = new ResultNode($"<test-case id='2' duration='{duration2}'/>");
+            ITestModel model = Substitute.For<ITestModel>();
+            model.GetResultForTest("1").Returns(resultNode1);
+            model.GetResultForTest("2").Returns(resultNode2);
+
+            TreeNode treeNode1 = new TreeNode() { Tag = testNode1 };
+            TreeNode treeNode2 = new TreeNode() { Tag = testNode2 };
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, TreeViewNodeComparer.Descending, true);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+
+        [TestCase("TestA", "TestB", TreeViewNodeComparer.Ascending, -1)]
+        [TestCase("TestA", "TestB", TreeViewNodeComparer.Descending, 1)]
+        [TestCase("TestA", "TestA", TreeViewNodeComparer.Descending, 0)]
+        public void Durationcompare_NoTestResultAvailable_ReturnsExpectedResult(string text1, string text2, string sortDirection, int expectedCompareResult)
+        {
+            // Arrange
+            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
+            ITestModel model = Substitute.For<ITestModel>();
+            model.GetResultForTest("1").Returns((ResultNode)null);
+            model.GetResultForTest("2").Returns((ResultNode)null);
+
+            TreeNode treeNode1 = new TreeNode(text1) { Tag = testNode1 };
+            TreeNode treeNode2 = new TreeNode(text2) { Tag = testNode2 };
+
+            // Act
+            IComparer comparer = TreeViewNodeComparer.GetComparer(model, TreeViewNodeComparer.Duration, sortDirection, true);
+            int result = comparer.Compare(treeNode1, treeNode2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedCompareResult));
+        }
+    }
+}


### PR DESCRIPTION
This PR solves #1149 by adding a context menu that allows the tree to be sorted by duration.

<img src="https://github.com/user-attachments/assets/77aa9ab8-4cfc-40db-a5db-28dd7106d6d2" width="300">

Here's a brief overview of the functionality:
- the tree nodes can be either be sorted by name or duration
- it support ascending or descending order
- if duration sorting is selected, the 'Show duration' option is automatically enabled
- if duration sorting is selected, but no test durations are available at all, the testnodes are sorted by name
- if duration sorting is selected, but test durations are only available partly (subset of tests was executed), the name sorting is applied in general, but the subtree with duration results is sorted by duration.
- the sorting options are **not** stored in the settings or VisualState file
- however if a new project is loaded, the current active sorting options are applied to the newly loaded tree.
- The focus of this issue is the sorting in the NUnit tree display format. However the sorting works also with the Fixture and Test list display format.
