### PR TITLE
Fix move functionality for pinnable displays

### DIFF
--- a/src/TestCentric/testcentric.gui/Dialogs/PinnableDisplay.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/PinnableDisplay.Designer.cs
@@ -36,7 +36,7 @@ namespace TestCentric.Gui.Dialogs
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PinnableDisplay));
-            this.testName = new System.Windows.Forms.Label();
+            this.testName = new TransparentCaptionLabel();
             this.pinButton = new System.Windows.Forms.CheckBox();
             this.exitButton = new System.Windows.Forms.Button();
             this.SuspendLayout();

--- a/src/TestCentric/testcentric.gui/Dialogs/PinnableDisplay.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/PinnableDisplay.cs
@@ -4,13 +4,8 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Dialogs
@@ -75,6 +70,28 @@ namespace TestCentric.Gui.Dialogs
             exitButton.Left = ClientRectangle.Width - exitButton.Width - 4;
             pinButton.Left = exitButton.Left - pinButton.Width - 4;
             testName.Width = pinButton.Left - testName.Left;
+        }
+    }
+
+    /// <summary>
+    /// This Label is displayed in the caption of a pinnable form <see cref="PinnableDisplay"/>
+    /// This form should support the move functionality (click+hold mouse in caption and move around) like any regular form
+    /// To support this functionality it mustn't process the HitTest window message itself, but pass it to beneath form
+    /// </summary>
+    internal class TransparentCaptionLabel : Label
+    {
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_NCHITTEST = 0x84;
+            const int HTTRANSPARENT = -1;
+
+            switch (m.Msg)
+            {
+                case WM_NCHITTEST:
+                    m.Result = (IntPtr)HTTRANSPARENT;
+                    return;
+            }
+            base.WndProc(ref m);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1096 by making the label transparent for mouse clicks.

This solution idea was already mentioned in the discussion of the issue and a quick google search leads to some descriptions/examples how to solve it.

So overall there's a new dedicated class `TransparentCaptionLabel ` derived from Windows Forms `Label `class. The only purpose of this class is to handle one certain window message, so that mouse clicks are passed to the underlying form - so it's transparent for mouse clicks.

