### PR TITLE
Add cancel button to 'Do you want to save?' message box

### DIFF
--- a/src/TestCentric/testcentric.gui/IMessageDisplay.cs
+++ b/src/TestCentric/testcentric.gui/IMessageDisplay.cs
@@ -18,6 +18,25 @@ namespace TestCentric.Gui
 
         bool YesNo(string message);
 
+        MessageBoxResult YesNoCancel(string message);
+
         bool OkCancel(string message);
+    }
+
+    /// <summary>
+    /// Enum representing the return value of a MessageBox
+    /// It contains the identical values in same order as the DialogResult enum from Windows Forms
+    /// It has the same intention as the interface <see cref="IMessageDisplay"/> to hide any implementation details to the caller.
+    /// </summary>
+    public enum MessageBoxResult
+    { 
+        None,
+        OK,
+        Cancel,
+        Abort,
+        Retry,
+        Ignore,
+        Yes,
+        No,
     }
 }

--- a/src/TestCentric/testcentric.gui/MessageBoxDisplay.cs
+++ b/src/TestCentric/testcentric.gui/MessageBoxDisplay.cs
@@ -59,6 +59,13 @@ namespace TestCentric.Gui
             return MessageBox.Show(message, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
         }
 
+        public static MessageBoxResult YesNoCancel(string message, string caption)
+        {
+            DialogResult dialogResult = MessageBox.Show(message, caption, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            return dialogResult == DialogResult.Yes ? MessageBoxResult.Yes : 
+                   dialogResult == DialogResult.No ? MessageBoxResult.No : MessageBoxResult.Cancel;
+        }
+
         public static bool OkCancel(string message)
         {
             return OkCancel(message, DEFAULT_CAPTION);
@@ -86,6 +93,11 @@ namespace TestCentric.Gui
         bool IMessageDisplay.YesNo(string message)
         {
             return YesNo(message, _caption);
+        }
+
+        MessageBoxResult IMessageDisplay.YesNoCancel(string message)
+        {
+            return YesNoCancel(message, _caption);
         }
 
         bool IMessageDisplay.OkCancel(string message)

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -346,9 +346,8 @@ namespace TestCentric.Gui.Presenters
                         _model.StopTestRun(true);
                     }
 
-                    CloseProject();
-                    //if (CloseProject() == DialogResult.Cancel)
-                    //    e.Cancel = true;
+                    if (CloseProject() == MessageBoxResult.Cancel)
+                        e.Cancel = true;
                 }
 
                 if (!e.Cancel)
@@ -684,15 +683,20 @@ namespace TestCentric.Gui.Presenters
 
         #region Close Methods
 
-        public void CloseProject()
+        public MessageBoxResult CloseProject()
         {
-            if (!_options.Unattended && _model.TestCentricProject.IsDirty &&
-                _view.MessageDisplay.YesNo($"Do you want to save {_model.TestCentricProject.Name}?"))
+            MessageBoxResult messageBoxResult = MessageBoxResult.OK;
+            if (!_options.Unattended && _model.TestCentricProject.IsDirty)
             {
-                SaveProject();
+                messageBoxResult = _view.MessageDisplay.YesNoCancel($"Do you want to save {_model.TestCentricProject.Name}?");
+                if (messageBoxResult == MessageBoxResult.Yes)
+                    SaveProject();
             }
 
-            _model.CloseProject();
+            if (messageBoxResult != MessageBoxResult.Cancel)
+                _model.CloseProject();
+
+            return messageBoxResult;
         }
 
         #endregion


### PR DESCRIPTION
This PR fixes #1183 by adding a cancel button to the 'Do you want to save?' message box.

Overall the MessageBox looks like this now:
<img src="https://github.com/user-attachments/assets/b8c53ed7-5532-4c37-b149-68694783aac2" width="250">

From a technial point of view I introduced a new enum `MessageBoxResult` representing the return values of a MessageBox. 
This enum is intended to pursue the idea of the `IMessageBox` interface further: hiding the implementation details of the Windows Forms MessageBox to the caller.
So far a boolean return value was sufficient for all methods of the IMessageBox interface - however the new method `YesNoCancel` requires more than a boolean state - do I decided to use that enum.


