### PR TITLE
Set Tooltip of RunSelectedTests ToolbarButton depending on ShowCheckBox state

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -20,6 +20,7 @@ namespace TestCentric.Gui.Presenters
     using Model.Settings;
     using Views;
     using Dialogs;
+    using TestCentric.Gui.Elements;
 
     /// <summary>
     /// TestCentricPresenter does all file opening and closing that
@@ -81,6 +82,7 @@ namespace TestCentric.Gui.Presenters
 
             UpdateViewCommands();
             UpdateTreeDisplayMenuItem();
+            UpdateRunSelectedTestsTooltip();
 
             foreach (string format in _model.ResultFormats)
                 if (format != "cases" && format != "user")
@@ -550,6 +552,8 @@ namespace TestCentric.Gui.Presenters
 
             _view.OpenWorkDirectoryCommand.Execute += () => System.Diagnostics.Process.Start(_model.WorkDirectory);
 
+            _view.TreeView.ShowCheckBoxes.CheckedChanged += () => UpdateRunSelectedTestsTooltip();
+
             _view.ExtensionsCommand.Execute += () =>
             {
                 using (var extensionsDialog = new ExtensionDialog(_model.Services.ExtensionService))
@@ -654,7 +658,7 @@ namespace TestCentric.Gui.Presenters
             var files = _view.DialogManager.SelectMultipleFiles("New Project", CreateOpenFileFilter());
             if (files.Count > 0)
                 _model.CreateNewProject(files);
-        }
+            }
 
         private void OpenProject()
         {
@@ -804,6 +808,14 @@ namespace TestCentric.Gui.Presenters
             _view.RecentFilesMenu.Enabled = !testRunning && !testLoading;
             _view.ExitCommand.Enabled = !testLoading;
             _view.SaveResultsCommand.Enabled = _view.SaveResultsAsMenu.Enabled = !testRunning && !testLoading && hasResults;
+        }
+
+        private void UpdateRunSelectedTestsTooltip()
+        {
+            bool showCheckBoxes = _view.TreeView.ShowCheckBoxes.Checked;
+            IToolTip tooltip = _view.RunSelectedButton as IToolTip;
+            if (tooltip != null)
+                tooltip.ToolTipText = showCheckBoxes ? "Run Checked Tests" : "Run Selected Tests";
         }
 
         private string CreateOpenFileFilter()

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -83,7 +83,7 @@ namespace TestCentric.Gui.Views
         IChecked RunSummaryButton { get; }
 
         // SubViews
-        TestTreeView TreeView { get; }
+        ITestTreeView TreeView { get; }
         StatusBarView StatusBarView { get; }
         ProgressBarView ProgressBarView { get; }
         TestPropertiesView TestPropertiesView { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -1175,7 +1175,7 @@ namespace TestCentric.Gui.Views
 
         #region Subordinate Views contained in main form
 
-        public TestTreeView TreeView => treeView;
+        public ITestTreeView TreeView => treeView;
 
         public ProgressBarView ProgressBarView => progressBar;
 

--- a/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -5,6 +5,7 @@
 
 using NSubstitute;
 using NUnit.Framework;
+using TestCentric.Gui.Elements;
 
 namespace TestCentric.Gui.Presenters.Main
 {
@@ -105,6 +106,22 @@ namespace TestCentric.Gui.Presenters.Main
 
             // 3. Assert
             _view.ShowHideFilterButton.Received().Checked = filterIsVisible;
+        }
+
+        [TestCase(true, "Run Checked Tests")]
+        [TestCase(false, "Run Selected Tests")]
+        public void FilterRunSelectedTestButton_Tooltip_IsUpdated(bool checkBoxVisible, string expectedTooltip)
+        {
+            // 1. Arrange
+            ICommand runSelectedTestsButton = Substitute.For<ICommand, IToolTip>();
+            _view.RunSelectedButton.Returns(runSelectedTestsButton);
+            _view.TreeView.ShowCheckBoxes.Checked.Returns(checkBoxVisible);
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+
+            // 3. Assert
+            (runSelectedTestsButton as IToolTip).Received().ToolTipText = expectedTooltip;
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -5,6 +5,7 @@
 
 using NSubstitute;
 using NUnit.Framework;
+using TestCentric.Gui.Elements;
 
 namespace TestCentric.Gui.Presenters.Main
 {
@@ -71,6 +72,23 @@ namespace TestCentric.Gui.Presenters.Main
             // 3. Assert
             Assert.That(_view.ShowHideFilterButton.Visible, Is.EqualTo(expectedState));
             Assert.That(_view.ShowHideFilterButton.Enabled, Is.EqualTo(expectedState));
+        }
+
+        [TestCase(true, "Run Checked Tests")]
+        [TestCase(false, "Run Selected Tests")]
+        public void ShowCheckBoxes_Changed_Tooltip_IsUpdated(bool checkBoxVisible, string expectedTooltip)
+        {
+            // 1. Arrange
+            ICommand runSelectedTestsButton = Substitute.For<ICommand, IToolTip>();
+            _view.RunSelectedButton.Returns(runSelectedTestsButton);
+            _view.TreeView.ShowCheckBoxes.Checked.Returns(checkBoxVisible);
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+            _view.TreeView.ShowCheckBoxes.CheckedChanged += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            (runSelectedTestsButton as IToolTip).Received().ToolTipText = expectedTooltip;
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1188 .

It updates the Tooltip of the toolbar button 'RunSelected tests' depending on the 'Show checkboxes' state. It will display either 'Show selected tests' or 'Show checked tests'.

Besides this change regarding the tooltip, I also changed property IMainView.TreeView from the concrete class 'TestTreeView' to the interface 'ITestTreeView'. This change was required for testing purpose.