### PR TITLE
TestCentricProject - revisit IsDirty flag to reduce number of prompts to save changed project

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -653,7 +653,10 @@ namespace TestCentric.Gui.Presenters
         {
             var files = _view.DialogManager.SelectMultipleFiles("New Project", CreateOpenFileFilter());
             if (files.Count > 0)
-                _model.CreateNewProject(files);
+            {
+                _model.CreateNewProject();
+                _model.AddTests(files);
+            }
         }
 
         private void OpenProject()
@@ -708,12 +711,7 @@ namespace TestCentric.Gui.Presenters
             var filesToAdd = _view.DialogManager.SelectMultipleFiles("Add Test Files", CreateOpenFileFilter());
 
             if (filesToAdd.Count > 0)
-            {
-                var files = new List<string>(_model.TestCentricProject.TestFiles);
-                files.AddRange(filesToAdd);
-
-                _model.CreateNewProject(files);
-            }
+                _model.AddTests(filesToAdd);
         }
 
         #endregion

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -59,7 +59,8 @@ namespace TestCentric.Gui.Presenters.Main
 
             _view.NewProjectCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().CreateNewProject(files);
+            _model.Received().CreateNewProject();
+            _model.Received().AddTests(files);
         }
 
         [Test]
@@ -100,12 +101,9 @@ namespace TestCentric.Gui.Presenters.Main
             var filesToAdd = new string[] { Path.GetFullPath("/path/to/test.dll") };
             _view.DialogManager.SelectMultipleFiles(null, null).ReturnsForAnyArgs(filesToAdd);
 
-            var allFiles = new List<string>(testFiles);
-            allFiles.AddRange(filesToAdd);
-
             _view.AddTestFilesCommand.Execute += Raise.Event<CommandHandler>();
 
-            _model.Received().CreateNewProject(Arg.Compat.Is<List<string>>(l => l.SequenceEqual(allFiles)));
+            _model.Received().AddTests(filesToAdd);
         }
 
         [Test]

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -101,6 +101,16 @@ namespace TestCentric.Gui.Model
         // Create a new project containing the provided test files
         TestCentricProject CreateNewProject(IList<string> filenames);
 
+        /// <summary>
+        /// Create a new empty project
+        /// </summary>
+        TestCentricProject CreateNewProject();
+
+        /// <summary>
+        /// Add the test files to the current test project
+        /// </summary>
+        void AddTests(IEnumerable<string> fileNames);
+
         void OpenExistingProject(string filename);
 
         void OpenMostRecentFile();

--- a/src/TestModel/model/TestCentricProject.cs
+++ b/src/TestModel/model/TestCentricProject.cs
@@ -38,8 +38,7 @@ namespace TestCentric.Gui.Model
             :base(filenames)
         {
             _model = model;
-            TestFiles = filenames;
-            IsDirty = true;
+            TestFiles = new List<string>(filenames);
 
             var engineSettings = _model.Settings.Engine;
             var options = model.Options;
@@ -86,6 +85,8 @@ namespace TestCentric.Gui.Model
                     case ".tcproj":
                         throw new InvalidOperationException("A TestCentric project may not contain another TestCentric project.");
                 }
+
+            IsDirty = false;
         }
 
         public void Load(string path)
@@ -113,6 +114,8 @@ namespace TestCentric.Gui.Model
                     throw new Exception("Unable to deserialize TestProject.", ex);
                 }
             }
+
+            IsDirty = false;
         }
 
         public void SaveAs(string projectPath)
@@ -156,6 +159,7 @@ namespace TestCentric.Gui.Model
         public new void AddSubPackage(string fullName)
         {
             base.AddSubPackage(fullName);
+            TestFiles.Add(fullName);
             IsDirty = true;
         }
         public new void AddSubPackage(TestPackage subPackage)

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -269,6 +269,27 @@ namespace TestCentric.Gui.Model
             return TestCentricProject;
         }
 
+        public TestCentricProject CreateNewProject()
+        {
+            if (IsProjectLoaded)
+                CloseProject();
+
+            TestCentricProject = new TestCentricProject(this);
+            return TestCentricProject;
+        }
+
+        public void AddTests(IEnumerable<string> fileNames)
+        {
+            if (!IsProjectLoaded)
+                return;
+
+            foreach( string fileName in fileNames)
+                TestCentricProject.AddSubPackage(fileName);
+
+            TestCentricProject.LoadTests();
+            _events.FireTestCentricProjectLoaded();
+        }
+
         public void OpenExistingProject(string projectPath)
         {
             if (IsProjectLoaded)

--- a/src/TestModel/tests/CreateNewProjectTests.cs
+++ b/src/TestModel/tests/CreateNewProjectTests.cs
@@ -113,10 +113,10 @@ namespace TestCentric.Gui.Model
 
 
         [Test]
-        public void NewProjectIsDirty()
+        public void NewProject_IsNotDirty()
         {
             var project = new TestCentricProject(_model, new[] { "dummy.dll" });
-            Assert.That(project.IsDirty);
+            Assert.That(project.IsDirty, Is.False);
         }
 
         public void NewProjectIsNotDirtyAfterSaving()

--- a/src/TestModel/tests/TestModelTests.cs
+++ b/src/TestModel/tests/TestModelTests.cs
@@ -1,0 +1,66 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using NSubstitute;
+using NUnit.Engine;
+using NUnit.Framework;
+using TestCentric.Gui.Model.Fakes;
+
+namespace TestCentric.Gui.Model
+{
+    [TestFixture]
+    public class TestModelTests
+    {
+        [Test]
+        public void CreateNewEmptyProject_IsDirty_IsFalse()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new CommandLineOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            // Act
+            model.CreateNewProject();
+
+            // Assert
+            Assert.That(model.TestCentricProject.IsDirty, Is.False);
+        }
+
+        [Test]
+        public void AddTests_IsDirty_IsTrue()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new CommandLineOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            // Act
+            model.CreateNewProject();
+            model.AddTests(new[] { "Dummy.dll" });
+
+            // Assert
+            Assert.That(model.TestCentricProject.IsDirty, Is.True);
+        }
+
+        [Test]
+        public void AddTests_TestCentricProjectLoadedEvent_IsTriggered()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new CommandLineOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            bool projectLoadedCalled = false;
+            model.Events.TestCentricProjectLoaded += (t) => projectLoadedCalled = true;
+
+            // Act
+            model.CreateNewProject();
+            model.AddTests(new[] { "Dummy.dll" });
+
+            // Assert
+            Assert.That(projectLoadedCalled, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #1187 by reducing the use cases in which the "Do you want to save?" MessageBox show up.

The MessageBox is shown now only in these two use cases:
- The user actively created a new project
- The user actively added a test to an existing project

In contrast the MessageBox is not shown anymore, if a user loads an existing tcproj file. Or if a test is opened from the recent file list - this includes the use case if the last recent file is opened when starting the application.

I think that we don't need to ask the user again in the later use case. He already made his decision in his previous session and it seems to be bit intrusive if we ask over and over again.