### PR TITLE
Issue 1191

### DIFF
--- a/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.Designer.cs
@@ -39,18 +39,13 @@ namespace TestCentric.Gui.Dialogs
             this.testPropertiesView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.testPropertiesView.AssertCount = "";
-            this.testPropertiesView.Assertions = "";
             this.testPropertiesView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.testPropertiesView.Categories = "";
             this.testPropertiesView.Description = "";
-            this.testPropertiesView.ElapsedTime = "";
             this.testPropertiesView.FullName = "";
             this.testPropertiesView.Header = "";
             this.testPropertiesView.Location = new System.Drawing.Point(6, 30);
             this.testPropertiesView.Name = "testPropertiesView";
-            this.testPropertiesView.Outcome = "";
-            this.testPropertiesView.Output = "";
             this.testPropertiesView.PackageSettings = "";
             this.testPropertiesView.Properties = "";
             this.testPropertiesView.RunState = "";

--- a/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/TestPropertiesDialog.cs
@@ -80,9 +80,6 @@ namespace TestCentric.Gui.Dialogs
 
             InitializeTestPackageSubView(_testNode);
             InitializeTestPropertiesSubView(_testNode);
-            InitializeTestResultSubView(_testNode);
-            InitializeTestOutputSubView(_testNode);
-
             AdjustSubViewHeights();
 #endif
 
@@ -140,37 +137,6 @@ namespace TestCentric.Gui.Dialogs
             _view.TestPropertiesSubView.Visible = true;
         }
 
-        private void InitializeTestResultSubView(TestNode testNode)
-        {
-            var resultNode = _model.GetResultForTest(testNode.Id);
-            var visible = resultNode != null;
-
-            if (visible)
-            {
-                _view.Outcome = resultNode.Outcome.ToString();
-                _view.ElapsedTime = resultNode.Duration.ToString("f3");
-                _view.AssertCount = resultNode.AssertCount.ToString();
-                _view.Assertions = GetAssertionResults(resultNode);
-
-                _visibleSubViews.Add(_view.TestResultSubView);
-            }
-
-            _view.TestResultSubView.Visible = visible;
-        }
-
-        private void InitializeTestOutputSubView(TestNode testNode)
-        {
-            var resultNode = _model.GetResultForTest(testNode.Id);
-            var visible = resultNode != null;
-
-            if (visible)
-            {
-                _view.Output = resultNode.Xml.SelectSingleNode("output")?.InnerText;
-                _visibleSubViews.Add(_view.TestOutputSubView);
-            }
-
-            _view.TestOutputSubView.Visible = visible;
-        }
 
         private void AdjustSubViewHeights()
         {

--- a/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
@@ -168,15 +168,15 @@ namespace TestCentric.Gui.Presenters
 
         private void InitializeTestResultSubView()
         {
-            _view.Outcome = (_selectedResult != null) ? _selectedResult.Outcome.ToString() : "";
-            _view.ElapsedTime = (_selectedResult != null) ? _selectedResult.Duration.ToString("f3") : "";
-            _view.AssertCount = (_selectedResult != null) ? _selectedResult.AssertCount.ToString() : "";
-            _view.Assertions = (_selectedResult != null) ? GetAssertionResults(_selectedResult) : "";
+            _view.TestResultSubView.Outcome = (_selectedResult != null) ? _selectedResult.Outcome.ToString() : "";
+            _view.TestResultSubView.ElapsedTime = (_selectedResult != null) ? _selectedResult.Duration.ToString("f3") : "";
+            _view.TestResultSubView.AssertCount = (_selectedResult != null) ? _selectedResult.AssertCount.ToString() : "";
+            _view.TestResultSubView.Assertions = (_selectedResult != null) ? GetAssertionResults(_selectedResult) : "";
         }
 
         private void InitializeTestOutputSubView()
         {
-            _view.Output = (_selectedResult != null) ? _selectedResult.Xml.SelectSingleNode("output")?.InnerText : "";
+            _view.TestOutputSubView.Output = (_selectedResult != null) ? _selectedResult.Xml.SelectSingleNode("output")?.InnerText : "";
         }
 
         private string GetAssertionResults(ResultNode resultNode)

--- a/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
@@ -8,7 +8,8 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Presenters
 {
-    using System.Drawing.Text;
+    using System.IO;
+    using System.Text;
     using System.Xml;
     using Model;
     using Model.Settings;
@@ -29,7 +30,7 @@ namespace TestCentric.Gui.Presenters
             _model = model;
             _settings = model.Settings;
 
-            _view.Font = _settings.Gui.FixedFont;
+            _view.SetFixedFont(_settings.Gui.FixedFont);
             _view.SplitterPosition = _settings.Gui.ErrorDisplay.SplitterPosition;
             _view.EnableToolTips = _settings.Gui.ErrorDisplay.ToolTipsEnabled;
 
@@ -73,7 +74,8 @@ namespace TestCentric.Gui.Presenters
 
             _model.Settings.Changed += (object sender, SettingsEventArgs e) =>
             {
-                _view.Font = _settings.Gui.FixedFont;
+                if (e.SettingName == "TestCentric.Gui.FixedFont")
+                    _view.SetFixedFont(_settings.Gui.FixedFont);
             };
 
             // Events that arise in the view
@@ -133,6 +135,9 @@ namespace TestCentric.Gui.Presenters
                 else
                     AddResult(_selectedResult);
             }
+
+            InitializeTestResultSubView();
+            InitializeTestOutputSubView();
         }
 
         private void AddResult(string testName, AssertionResult assertion)
@@ -159,6 +164,81 @@ namespace TestCentric.Gui.Presenters
         private string IndentMessage(string message)
         {
             return message == null ? null : message.StartsWith("  ") ? message : "  " + message;
+        }
+
+        private void InitializeTestResultSubView()
+        {
+            _view.Outcome = (_selectedResult != null) ? _selectedResult.Outcome.ToString() : "";
+            _view.ElapsedTime = (_selectedResult != null) ? _selectedResult.Duration.ToString("f3") : "";
+            _view.AssertCount = (_selectedResult != null) ? _selectedResult.AssertCount.ToString() : "";
+            _view.Assertions = (_selectedResult != null) ? GetAssertionResults(_selectedResult) : "";
+        }
+
+        private void InitializeTestOutputSubView()
+        {
+            _view.Output = (_selectedResult != null) ? _selectedResult.Xml.SelectSingleNode("output")?.InnerText : "";
+        }
+
+        private string GetAssertionResults(ResultNode resultNode)
+        {
+            var assertionResults = resultNode.Assertions;
+
+            // If there were no actual assertionresult entries, we fake
+            // one if there is a message to display
+            if (assertionResults.Count == 0)
+            {
+                if (resultNode.Outcome.Status == TestStatus.Failed)
+                {
+                    string status = resultNode.Outcome.Label ?? "Failed";
+                    XmlNode failure = resultNode.Xml.SelectSingleNode("failure");
+                    if (failure != null)
+                        assertionResults.Add(new AssertionResult(failure, status));
+                }
+                else
+                {
+                    string status = resultNode.Outcome.Label ?? "Skipped";
+                    XmlNode reason = resultNode.Xml.SelectSingleNode("reason");
+                    if (reason != null)
+                        assertionResults.Add(new AssertionResult(reason, status));
+                }
+            }
+
+            StringBuilder sb = new StringBuilder();
+            int index = 0;
+            foreach (var assertion in assertionResults)
+            {
+                sb.AppendLine($"{++index}) {assertion.Status.ToUpper()} {assertion.Message}");
+                if (assertion.StackTrace != null)
+                    sb.AppendLine(AdjustStackTrace(assertion.StackTrace));
+
+            }
+
+            return sb.ToString();
+        }
+
+        // Some versions of the framework return the stacktrace
+        // without leading spaces, so we add them if needed.
+        // TODO: Make sure this is valid across various cultures.
+        private const string LEADING_SPACES = "   ";
+
+        private static string AdjustStackTrace(string stackTrace)
+        {
+            // Check if no adjustment needed. We assume that all
+            // lines start the same - either with or without spaces.
+            if (stackTrace.StartsWith(LEADING_SPACES))
+                return stackTrace;
+
+            var sr = new StringReader(stackTrace);
+            var sb = new StringBuilder();
+            string line = sr.ReadLine();
+            while (line != null)
+            {
+                sb.Append(LEADING_SPACES);
+                sb.AppendLine(line);
+                line = sr.ReadLine();
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -128,6 +128,7 @@ namespace TestCentric.Gui.Presenters
                 UpdateViewCommands();
 
                 _lastFilesLoaded = _model.TestCentricProject.TestFiles.ToArray();
+                _view.ResultTabs.InvokeIfRequired(() => _view.ResultTabs.SelectedIndex = 0);
             };
 
             _model.Events.TestsUnloading += (TestEventArgse) =>
@@ -210,6 +211,8 @@ namespace TestCentric.Gui.Presenters
 
                 string resultPath = Path.Combine(_model.WorkDirectory, "TestResult.xml");
                 _model.SaveResults(resultPath);
+                _view.ResultTabs.InvokeIfRequired(() => _view.ResultTabs.SelectedIndex = 1);
+
                 //try
                 //{
                 //    _model.SaveResults(resultPath);

--- a/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.Designer.cs
@@ -31,7 +31,6 @@ namespace TestCentric.Gui.Views
         {
             this.components = new System.ComponentModel.Container();
             this.header = new System.Windows.Forms.Label();
-            this.noErrorsMessage = new System.Windows.Forms.Label();
             this.detailList = new System.Windows.Forms.ListBox();
             this.tabSplitter = new System.Windows.Forms.Splitter();
             this.errorBrowser = new NUnit.UiException.Controls.ErrorBrowser();
@@ -39,8 +38,12 @@ namespace TestCentric.Gui.Views
             this.stackTraceDisplay = new NUnit.UiException.Controls.StackTraceDisplay();
             this.detailListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyDetailMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.flowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.testResultSubView = new TestCentric.Gui.Views.TestResultSubView();
+            this.testOutputSubView = new TestCentric.Gui.Views.TestOutputSubView();
             this.panel1.SuspendLayout();
             this.detailListContextMenuStrip.SuspendLayout();
+            this.flowLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // header
@@ -56,24 +59,34 @@ namespace TestCentric.Gui.Views
             this.header.TabIndex = 0;
             this.header.Text = "Test name goes here";
             // 
-            // noErrorsMessage
+            // testResultSubView
             // 
-            this.noErrorsMessage.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.noErrorsMessage.AutoSize = true;
-            this.noErrorsMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.noErrorsMessage.Location = new System.Drawing.Point(120, 45);
-            this.noErrorsMessage.Name = "noErrorsMessage";
-            this.noErrorsMessage.Size = new System.Drawing.Size(229, 20);
-            this.noErrorsMessage.TabIndex = 1;
-            this.noErrorsMessage.Text = "No Errors, Failures or Warnings";
+            this.testResultSubView.AssertCount = "";
+            this.testResultSubView.Assertions = "";
+            this.testResultSubView.BackColor = System.Drawing.SystemColors.Control;
+            this.testResultSubView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.testResultSubView.ElapsedTime = "";
+            this.testResultSubView.MinimumSize = new System.Drawing.Size(2, 108);
+            this.testResultSubView.Name = "testResultSubView";
+            this.testResultSubView.Outcome = "";
+            this.testResultSubView.Size = new System.Drawing.Size(519, 111);
+            this.testResultSubView.Visible = true;
+            // 
+            // testOutputSubView
+            // 
+            this.testOutputSubView.BackColor = System.Drawing.SystemColors.Control;
+            this.testOutputSubView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.testOutputSubView.MinimumSize = new System.Drawing.Size(2, 70);
+            this.testOutputSubView.Name = "testOutputSubView";
+            this.testOutputSubView.Output = "";
+            this.testOutputSubView.Size = new System.Drawing.Size(519, 72);
+            this.testOutputSubView.Visible = true;
             // 
             // detailList
             // 
-            this.detailList.Dock = System.Windows.Forms.DockStyle.Top;
             this.detailList.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
             this.detailList.Font = new System.Drawing.Font("Courier New", 8F);
             this.detailList.HorizontalScrollbar = true;
-            this.detailList.Location = new System.Drawing.Point(0, 0);
             this.detailList.Name = "detailList";
             this.detailList.ScrollAlwaysVisible = true;
             this.detailList.Size = new System.Drawing.Size(496, 128);
@@ -84,6 +97,20 @@ namespace TestCentric.Gui.Views
             this.detailList.MouseLeave += new System.EventHandler(this.detailList_MouseLeave);
             this.detailList.MouseHover += new System.EventHandler(this.OnMouseHover);
             this.detailList.MouseMove += new System.Windows.Forms.MouseEventHandler(this.detailList_MouseMove);
+            // 
+            // flowLayoutPanel
+            // 
+            this.flowLayoutPanel.BackColor = System.Drawing.SystemColors.Control;
+            this.flowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.flowLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel.Name = "flowLayoutPanel";
+            this.flowLayoutPanel.Size = new System.Drawing.Size(496, 128);
+            this.flowLayoutPanel.Controls.Add(this.testResultSubView);
+            this.flowLayoutPanel.Controls.Add(this.testOutputSubView);
+            this.flowLayoutPanel.Controls.Add(this.detailList);
+            this.flowLayoutPanel.WrapContents = false;
+            this.flowLayoutPanel.AutoScroll = true;
             // 
             // tabSplitter
             // 
@@ -110,7 +137,7 @@ namespace TestCentric.Gui.Views
             // 
             this.panel1.Controls.Add(this.errorBrowser);
             this.panel1.Controls.Add(this.tabSplitter);
-            this.panel1.Controls.Add(this.detailList);
+            this.panel1.Controls.Add(this.flowLayoutPanel);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(0, 18);
             this.panel1.Name = "panel1";
@@ -141,13 +168,13 @@ namespace TestCentric.Gui.Views
             // 
             // ErrorsAndFailuresView
             // 
-            this.Controls.Add(this.noErrorsMessage);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.header);
             this.Name = "ErrorsAndFailuresView";
             this.Size = new System.Drawing.Size(496, 288);
             this.panel1.ResumeLayout(false);
             this.detailListContextMenuStrip.ResumeLayout(false);
+            this.flowLayoutPanel.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -163,6 +190,8 @@ namespace TestCentric.Gui.Views
         public System.Windows.Forms.Splitter tabSplitter;
         private System.Windows.Forms.ContextMenuStrip detailListContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem copyDetailMenuItem;
-        private System.Windows.Forms.Label noErrorsMessage;
+        private TestCentric.Gui.Views.TestResultSubView testResultSubView;
+        private TestCentric.Gui.Views.TestOutputSubView testOutputSubView;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel;
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
@@ -64,9 +64,9 @@ namespace TestCentric.Gui.Views
         public event EventHandler SourceCodeSplitOrientationChanged;
         public event EventHandler SourceCodeDisplayChanged;
 
-        public TestResultSubView TestResultSubView => testResultSubView;
+        public ITestResultSubView TestResultSubView => testResultSubView;
 
-        public TestOutputSubView TestOutputSubView => testOutputSubView;
+        public ITestOutputSubView TestOutputSubView => testOutputSubView;
 
         public string Header
         {
@@ -141,36 +141,6 @@ namespace TestCentric.Gui.Views
                         errorBrowser.SelectedDisplay = stackTraceDisplay;
                 });
             }
-        }
-
-        public string Outcome
-        {
-            get { return testResultSubView.Outcome; }
-            set { testResultSubView.Outcome = value; }
-        }
-
-        public string ElapsedTime
-        {
-            get { return testResultSubView.ElapsedTime; }
-            set { testResultSubView.ElapsedTime = value; }
-        }
-
-        public string AssertCount
-        {
-            get { return testResultSubView.AssertCount; }
-            set { testResultSubView.AssertCount = value; }
-        }
-
-        public string Assertions
-        {
-            get { return testResultSubView.Assertions; }
-            set { testResultSubView.Assertions = value; }
-        }
-
-        public string Output
-        {
-            get { return testOutputSubView.Output; }
-            set { testOutputSubView.Output = value; }
         }
 
         public void Clear()

--- a/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
@@ -51,6 +51,8 @@ namespace TestCentric.Gui.Views
             {
                 SourceCodeDisplayChanged?.Invoke(this, new EventArgs());
             };
+
+            flowLayoutPanel.Layout += FlowLayoutPanel_Layout;
         }
 
         #endregion
@@ -147,7 +149,6 @@ namespace TestCentric.Gui.Views
                 detailList.Items.Clear();
                 detailList.ContextMenuStrip = null;
                 errorBrowser.StackTraceSource = "";
-                noErrorsMessage.Show();
             });
         }
 
@@ -155,7 +156,6 @@ namespace TestCentric.Gui.Views
         {
             InvokeIfRequired(() =>
             {
-                noErrorsMessage.Hide();
                 InsertTestResultItem(new TestResultItem(status, testName, message, stackTrace));
             });
         }
@@ -296,6 +296,20 @@ namespace TestCentric.Gui.Views
         private void tabSplitter_SplitterMoved(object sender, SplitterEventArgs e)
         {
             SplitterPositionChanged?.Invoke(this, new EventArgs());
+        }
+
+        private void FlowLayoutPanel_Layout(object sender, LayoutEventArgs e)
+        {
+            // Adjust width of all controls 
+            var subViewWidth = flowLayoutPanel.ClientRectangle.Width - testResultSubView.Margin.Left - testResultSubView.Margin.Right;
+            detailList.Width = subViewWidth;
+            testResultSubView.Width = subViewWidth;
+            testOutputSubView.Width = subViewWidth;
+
+            // Adjust height of detaillist view
+            var subViewHeight = flowLayoutPanel.ClientRectangle.Height - 6;
+            int margin = testResultSubView.Margin.Top + testResultSubView.Margin.Bottom + testOutputSubView.Margin.Top + testOutputSubView.Margin.Bottom + detailList.Margin.Top;
+            detailList.Height = Math.Max(100, subViewHeight - testResultSubView.Height - testOutputSubView.Height - margin);
         }
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.cs
@@ -64,6 +64,10 @@ namespace TestCentric.Gui.Views
         public event EventHandler SourceCodeSplitOrientationChanged;
         public event EventHandler SourceCodeDisplayChanged;
 
+        public TestResultSubView TestResultSubView => testResultSubView;
+
+        public TestOutputSubView TestOutputSubView => testOutputSubView;
+
         public string Header
         {
             get { return header.Text; }
@@ -72,21 +76,18 @@ namespace TestCentric.Gui.Views
 
         public bool EnableToolTips { get; set; }
 
-        public override Font Font
+        public void SetFixedFont(Font font)
         {
-            get { return base.Font; }
-            set
+            if (detailList.Font == font)
+                return;
+
+            InvokeIfRequired(() =>
             {
-                if (value != base.Font)
-                    InvokeIfRequired(() =>
-                    {
-                        base.Font = value;
-                        detailList.Font = value;
-                        stackTraceDisplay.Font = value;
-                        sourceCode.CodeDisplayFont = value;
-                        RefillDetailList();
-                    });
-            }
+                detailList.Font = font;
+                stackTraceDisplay.Font = font;
+                sourceCode.CodeDisplayFont = font;
+                RefillDetailList();
+            });
         }
 
         public int SplitterPosition
@@ -140,6 +141,36 @@ namespace TestCentric.Gui.Views
                         errorBrowser.SelectedDisplay = stackTraceDisplay;
                 });
             }
+        }
+
+        public string Outcome
+        {
+            get { return testResultSubView.Outcome; }
+            set { testResultSubView.Outcome = value; }
+        }
+
+        public string ElapsedTime
+        {
+            get { return testResultSubView.ElapsedTime; }
+            set { testResultSubView.ElapsedTime = value; }
+        }
+
+        public string AssertCount
+        {
+            get { return testResultSubView.AssertCount; }
+            set { testResultSubView.AssertCount = value; }
+        }
+
+        public string Assertions
+        {
+            get { return testResultSubView.Assertions; }
+            set { testResultSubView.Assertions = value; }
+        }
+
+        public string Output
+        {
+            get { return testOutputSubView.Output; }
+            set { testOutputSubView.Output = value; }
         }
 
         public void Clear()

--- a/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
@@ -24,14 +24,8 @@ namespace TestCentric.Gui.Views
         Orientation SourceCodeSplitOrientation { get; set; }
         bool SourceCodeDisplay { get; set; }
 
-        TestResultSubView TestResultSubView { get; }
-        TestOutputSubView TestOutputSubView { get; }
-
-        string Outcome { get; set; }
-        string ElapsedTime { get; set; }
-        string AssertCount { get; set; }
-        string Assertions { get; set; }
-        string Output { get; set; }
+        ITestResultSubView TestResultSubView { get; }
+        ITestOutputSubView TestOutputSubView { get; }
 
         void Clear();
         void AddResult(string status, string testName, string message, string stackTrace);

--- a/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IErrorsAndFailuresView.cs
@@ -19,13 +19,22 @@ namespace TestCentric.Gui.Views
         string Header { get; set; }
 
         bool EnableToolTips { get; set; }
-        Font Font { get; set; }
         int SplitterPosition { get; set; }
         float SourceCodeSplitterDistance { get; set; }
         Orientation SourceCodeSplitOrientation { get; set; }
         bool SourceCodeDisplay { get; set; }
 
+        TestResultSubView TestResultSubView { get; }
+        TestOutputSubView TestOutputSubView { get; }
+
+        string Outcome { get; set; }
+        string ElapsedTime { get; set; }
+        string AssertCount { get; set; }
+        string Assertions { get; set; }
+        string Output { get; set; }
+
         void Clear();
         void AddResult(string status, string testName, string message, string stackTrace);
+        void SetFixedFont(Font font);
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/ITestOutputSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestOutputSubView.cs
@@ -1,0 +1,12 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Views
+{
+    public interface ITestOutputSubView
+    {
+        string Output { get; set; }
+    }
+}

--- a/src/TestCentric/testcentric.gui/Views/ITestPropertiesVIew.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestPropertiesVIew.cs
@@ -26,18 +26,10 @@ namespace TestCentric.Gui.Views
         string SkipReason { get; set; }
         bool DisplayHiddenProperties { get; }
         string Properties { get; set; }
-        string Outcome { get; set; }
-        string ElapsedTime { get; set; }
-        string AssertCount { get; set; }
-        string Assertions { get; set; }
-        string Output { get; set; }
         string PackageSettings { get; set; }
 
         TestPackageSubView TestPackageSubView { get; }
         TestPropertiesSubView TestPropertiesSubView { get; }
-        TestResultSubView TestResultSubView { get; }
-        TestOutputSubView TestOutputSubView { get; }
-
         TestPropertiesView.SubView[] SubViews { get; }
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/ITestResultSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestResultSubView.cs
@@ -1,0 +1,15 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Views
+{
+    public interface ITestResultSubView
+    {
+        string Outcome { get; set; }
+        string ElapsedTime { get; set; }
+        string AssertCount { get; set; }
+        string Assertions { get; set; }
+    }
+}

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -942,20 +942,15 @@ namespace TestCentric.Gui.Views
             // 
             // propertiesView
             // 
-            this.propertiesView.AssertCount = "";
-            this.propertiesView.Assertions = "";
             this.propertiesView.AutoScroll = true;
             this.propertiesView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.propertiesView.Categories = "";
             this.propertiesView.Description = "";
             this.propertiesView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.propertiesView.ElapsedTime = "";
             this.propertiesView.FullName = "";
             this.propertiesView.Header = "";
             this.propertiesView.Location = new System.Drawing.Point(0, 0);
             this.propertiesView.Name = "propertiesView";
-            this.propertiesView.Outcome = "";
-            this.propertiesView.Output = "";
             this.propertiesView.PackageSettings = "";
             this.propertiesView.Properties = "";
             this.propertiesView.RunState = "";

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -972,7 +972,7 @@ namespace TestCentric.Gui.Views
             this.errorTab.Name = "errorTab";
             this.errorTab.Size = new System.Drawing.Size(490, 333);
             this.errorTab.TabIndex = 0;
-            this.errorTab.Text = "Errors and Failures";
+            this.errorTab.Text = "Test Results";
             this.errorTab.UseVisualStyleBackColor = true;
             // 
             // errorsAndFailuresView1

--- a/src/TestCentric/testcentric.gui/Views/TestOutputSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestOutputSubView.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
 {
-    public partial class TestOutputSubView : TestPropertiesView.SubView
+    public partial class TestOutputSubView : TestPropertiesView.SubView, ITestOutputSubView
     {
         public TestOutputSubView()
         {

--- a/src/TestCentric/testcentric.gui/Views/TestPropertiesView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestPropertiesView.Designer.cs
@@ -32,8 +32,6 @@ namespace TestCentric.Gui.Views
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.testPackageSubView = new TestCentric.Gui.Views.TestPackageSubView();
             this.testPropertiesSubView = new TestCentric.Gui.Views.TestPropertiesSubView();
-            this.testResultSubView = new TestCentric.Gui.Views.TestResultSubView();
-            this.testOutputSubView = new TestCentric.Gui.Views.TestOutputSubView();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -54,8 +52,6 @@ namespace TestCentric.Gui.Views
             this.flowLayoutPanel1.Controls.Add(this.header);
             this.flowLayoutPanel1.Controls.Add(this.testPackageSubView);
             this.flowLayoutPanel1.Controls.Add(this.testPropertiesSubView);
-            this.flowLayoutPanel1.Controls.Add(this.testResultSubView);
-            this.flowLayoutPanel1.Controls.Add(this.testOutputSubView);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
@@ -92,35 +88,6 @@ namespace TestCentric.Gui.Views
             this.testPropertiesSubView.TestCount = "";
             this.testPropertiesSubView.TestType = "";
             // 
-            // testResultSubView
-            // 
-            this.testResultSubView.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.testResultSubView.AssertCount = "";
-            this.testResultSubView.Assertions = "";
-            this.testResultSubView.BackColor = System.Drawing.SystemColors.Control;
-            this.testResultSubView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.testResultSubView.ElapsedTime = "";
-            this.testResultSubView.Location = new System.Drawing.Point(3, 313);
-            this.testResultSubView.MinimumSize = new System.Drawing.Size(2, 108);
-            this.testResultSubView.Name = "testResultSubView";
-            this.testResultSubView.Outcome = "";
-            this.testResultSubView.Size = new System.Drawing.Size(519, 111);
-            this.testResultSubView.TabIndex = 29;
-            // 
-            // testOutputSubView
-            // 
-            this.testOutputSubView.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.testOutputSubView.BackColor = System.Drawing.SystemColors.Control;
-            this.testOutputSubView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.testOutputSubView.Location = new System.Drawing.Point(3, 430);
-            this.testOutputSubView.MinimumSize = new System.Drawing.Size(2, 70);
-            this.testOutputSubView.Name = "testOutputSubView";
-            this.testOutputSubView.Output = "";
-            this.testOutputSubView.Size = new System.Drawing.Size(519, 72);
-            this.testOutputSubView.TabIndex = 29;
-            // 
             // TestPropertiesView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -139,9 +106,6 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.Label header;
         private TestPackageSubView testPackageSubView;
         private TestCentric.Gui.Views.TestPropertiesSubView testPropertiesSubView;
-        private TestCentric.Gui.Views.TestResultSubView testResultSubView;
-        private TestCentric.Gui.Views.TestOutputSubView testOutputSubView;
-
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/TestPropertiesView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestPropertiesView.cs
@@ -35,8 +35,6 @@ namespace TestCentric.Gui.Views
             header.Width = subViewWidth;
             testPackageSubView.Width = subViewWidth;
             testPropertiesSubView.Width = subViewWidth;
-            testResultSubView.Width = subViewWidth;
-            testOutputSubView.Width = subViewWidth;
         }
 
         public int ClientHeight => ClientRectangle.Height - TestPackageSubView.Top - 40; // Value of 40 allows for non-client areas and spacing
@@ -51,11 +49,7 @@ namespace TestCentric.Gui.Views
 
         public TestPropertiesSubView TestPropertiesSubView => testPropertiesSubView;
 
-        public TestResultSubView TestResultSubView => testResultSubView;
-
-        public TestOutputSubView TestOutputSubView => testOutputSubView;
-
-        public SubView[] SubViews => new SubView[] { TestPackageSubView, TestPropertiesSubView, TestResultSubView, TestOutputSubView }; 
+        public SubView[] SubViews => new SubView[] { TestPackageSubView, TestPropertiesSubView }; 
 
         public string TestType
         {
@@ -108,36 +102,6 @@ namespace TestCentric.Gui.Views
         {
             get { return testPropertiesSubView.Properties; }
             set { testPropertiesSubView.Properties = value; }
-        }
-
-        public string Outcome
-        {
-            get { return testResultSubView.Outcome; }
-            set { testResultSubView.Outcome = value; }
-        }
-
-        public string ElapsedTime
-        {
-            get { return testResultSubView.ElapsedTime; }
-            set { testResultSubView.ElapsedTime = value; }
-        }
-
-        public string AssertCount
-        {
-            get { return testResultSubView.AssertCount; }
-            set { testResultSubView.AssertCount = value; }
-        }
-
-        public string Assertions
-        {
-            get { return testResultSubView.Assertions; }
-            set { testResultSubView.Assertions = value; }
-        }
-
-        public string Output
-        {
-            get { return testOutputSubView.Output; }
-            set { testOutputSubView.Output = value; }
         }
 
         public string PackageSettings

--- a/src/TestCentric/testcentric.gui/Views/TestResultSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestResultSubView.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
 {
-    public partial class TestResultSubView : TestPropertiesView.SubView
+    public partial class TestResultSubView : TestPropertiesView.SubView, ITestResultSubView
     {
         public TestResultSubView()
         {

--- a/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -117,7 +117,7 @@ namespace TestCentric.Gui.Presenters
         public void WhenPresenterIsCreated_FontIsSetToDefault()
         {
             var font = _settings.Gui.FixedFont;
-            _view.Received().Font = font;
+            _view.Received().SetFixedFont(font);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace TestCentric.Gui.Presenters
             _view.ClearReceivedCalls();
             var newFont = new Font(FontFamily.GenericMonospace, 12.0f);
             _settings.Gui.FixedFont = newFont;
-            _view.Received().Font = newFont;
+            _view.Received().SetFixedFont(newFont);
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters.Main
 {
+    using System.Windows.Forms;
     using Model;
 
     public class WhenTestRunCompletes : MainPresenterTestBase
@@ -22,6 +23,7 @@ namespace TestCentric.Gui.Presenters.Main
             _model.ResultSummary.Returns(new ResultSummary() { FailureCount = 1 });
             _model.IsTestRunning.Returns(false);
             _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' />") }));
+            _view.ResultTabs.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
             var resultNode = new ResultNode("<test-run id='XXX' result='Failed' />");
             FireRunFinishedEvent(resultNode);
@@ -60,6 +62,12 @@ namespace TestCentric.Gui.Presenters.Main
         public void RunSummaryIsDisplayed()
         {
             _view.RunSummaryButton.Received().Checked = true;
+        }
+
+        [Test]
+        public void TestResultTabIsDisplay()
+        {
+            _view.ResultTabs.Received().SelectedIndex = 1;
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters.Main
 {
+    using System.Windows.Forms;
     using Model;
 
     public class WhenTestsAreLoaded : MainPresenterTestBase
@@ -23,6 +24,7 @@ namespace TestCentric.Gui.Presenters.Main
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
             _model.SelectedTests.Returns(new TestSelection(new[] { testNode }));
+            _view.ResultTabs.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
             var project = new TestCentricProject(_model, "dummy.dll");
             _model.TestCentricProject.Returns(project);
@@ -57,6 +59,12 @@ namespace TestCentric.Gui.Presenters.Main
         public void CheckElementVisibility(string propName, bool visible)
         {
             ViewElement(propName).Received().Visible = visible;
+        }
+
+        [Test]
+        public void TestPropertiesTabIsDisplay()
+        {
+            _view.ResultTabs.Received().SelectedIndex = 0;
         }
 
 #if NYI

--- a/src/TestCentric/tests/Views/ErrorsAndFailuresViewTests.cs
+++ b/src/TestCentric/tests/Views/ErrorsAndFailuresViewTests.cs
@@ -31,9 +31,14 @@ namespace TestCentric.Gui.Views
             AssertControlExists("panel1", typeof(Panel));
 
             var panelTester = new ControlTester(_control.Controls["panel1"]);
-            panelTester.AssertControlExists("detailList", typeof(ListBox));
+            panelTester.AssertControlExists("flowLayoutPanel", typeof(FlowLayoutPanel));
             panelTester.AssertControlExists("tabSplitter", typeof(Splitter));
             panelTester.AssertControlExists("errorBrowser", typeof(NUnit.UiException.Controls.ErrorBrowser));
+
+            var flowLayoutPanelTester = new ControlTester(_control.Controls["panel1"].Controls["flowLayoutPanel"]);
+            flowLayoutPanelTester.AssertControlExists("detailList", typeof(ListBox));
+            flowLayoutPanelTester.AssertControlExists("testOutputSubView", typeof(TestOutputSubView));
+            flowLayoutPanelTester.AssertControlExists("testResultSubView", typeof(TestResultSubView));
         }
 
         //[Test]

--- a/src/TestModel/model/Settings/ErrorDisplaySettings.cs
+++ b/src/TestModel/model/Settings/ErrorDisplaySettings.cs
@@ -32,7 +32,7 @@ namespace TestCentric.Gui.Model.Settings
 
         public bool SourceCodeDisplay
         {
-            get { return GetSetting(nameof(SourceCodeDisplay), false); }
+            get { return GetSetting(nameof(SourceCodeDisplay), true); }
             set { SaveSetting(nameof(SourceCodeDisplay), value); }
         }
 

--- a/src/TestModel/tests/Settings/SettingsTests.cs
+++ b/src/TestModel/tests/Settings/SettingsTests.cs
@@ -86,7 +86,7 @@ namespace TestCentric.Gui.Model.Settings
             new TestCaseData("SplitterPosition", 0, 12),
             new TestCaseData("WordWrapEnabled", true, false),
             new TestCaseData("ToolTipsEnabled", true, false),
-            new TestCaseData("SourceCodeDisplay", false, true),
+            new TestCaseData("SourceCodeDisplay", true, false),
             new TestCaseData("SourceCodeSplitterOrientation", Orientation.Vertical, Orientation.Horizontal),
             new TestCaseData("SourceCodeVerticalSplitterPosition", 0.3f, 0.5f),
             new TestCaseData("SourceCodeHorizontalSplitterPosition", 0.3f, 0.5f)


### PR DESCRIPTION
This PR solves #1191 by displaying all information about the test results in the 'Test result' tab.

Here's an overview about the functionality:

- Rename 'Errors and Failures' tab to 'Test Results'
- Switch to 'Test Results' tab automatically when test run finished
- Switch to 'Test Properties' tab automatically when test is loaded
- Add TestResultSubView and TestOutputSubView to 'Test Results' tab
- Remove TestResultSubView and TestOutputSubView from 'Test Properties' tab

Overall the test properties and test results are clearly separated and it supports the user to keep the focus. However further improvement is required to simplify the visualization of the test results. This will be done by a separate issue.