### PR TITLE
Enable VisualStyles for application

### DIFF
--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -28,6 +28,7 @@ namespace TestCentric.Gui
         [STAThread]
         public static int Main(string[] args)
         {
+            Application.EnableVisualStyles();
             var options = new CommandLineOptions(args);
 
             if (options.ShowHelp)


### PR DESCRIPTION
This PR fixes #1184 by adding this one line statement:
`Application.EnableVisualStyles()`

I think there's not much to discuss about the change itself, but maybe more about the impact. Some benefits of enabling the visual styles are mentioned in the related issue. Unfortunately, there is no concrete list of new features in the Microsoft documentation. But nonetheless I believe that we should enable this feature: it clearly has these benefits and is nowadays always included in all newly created Windows Forms applications.

If we come across strange artifacts, we can reconsider this decision.
