### PR TITLE
TestResultSubView: change image set - fix missing call to WireUpEvents()

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestResultSubViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestResultSubViewPresenter.cs
@@ -34,6 +34,7 @@ namespace TestCentric.Gui.Presenters
 
             string imageSet = _model.Settings.Gui.TestTree.AlternateImageSet;
             _view.LoadImages(imageSet);
+            WireUpEvents();
         }
 
         /// <summary>

--- a/src/TestCentric/tests/Presenters/TestResultSubViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestResultSubViewPresenterTests.cs
@@ -93,5 +93,22 @@ namespace TestCentric.Gui.Presenters
 
             view.Received().UpdateDetailSection(Arg.Any<TestResultCounts>());
         }
+
+        [Test]
+        public void SettingsChanged_AlternateImageSet_LoadImagesIsCalled()
+        {
+            // 1. Arrange
+            ITestResultSubView view = Substitute.For<ITestResultSubView>();
+            ITestModel model = Substitute.For<ITestModel>();
+            var settings = new FakeUserSettings();
+            model.Settings.Returns(settings);
+
+            // 2. Act
+            TestResultSubViewPresenter presenter = new TestResultSubViewPresenter(view, model);
+            settings.Gui.TestTree.AlternateImageSet = "Classic";
+
+            // 3. Assert
+            view.Received().LoadImages("Classic");
+        }
     }
 }


### PR DESCRIPTION
This PR takes care about the use case that an alternative image set is selected in the settings. In this case the images in the TestResultSubView should be updated to match the tree images.

The actual code for this use case was prepared, but it was missed to call the `WireUpEvents()` method which register to setting changes. This is fixed with this PR.