### PR TITLE
Fix outcome filter for tests with resultState=Warning

### DIFF
--- a/src/TestModel/model/Filter/OutcomeFilter.cs
+++ b/src/TestModel/model/Filter/OutcomeFilter.cs
@@ -54,6 +54,7 @@ namespace TestCentric.Gui.Model.Filter
                         break;
                     case TestStatus.Inconclusive:
                     case TestStatus.Skipped:
+                    case TestStatus.Warning:
                         outcome = "Warning";
                         break;
                 }

--- a/src/TestModel/tests/Filter/OutcomeFilterTests.cs
+++ b/src/TestModel/tests/Filter/OutcomeFilterTests.cs
@@ -26,6 +26,9 @@ namespace TestCentric.Gui.Model.Filter
 
         [TestCase(new[] { "Passed" }, "Passed")]
         [TestCase(new[] { "Failed", "Passed" }, "Passed")]
+        [TestCase(new[] { "Warning" }, "Warning")]
+        [TestCase(new[] { "Warning" }, "Skipped")]
+        [TestCase(new[] { "Warning" }, "Inconclusive")]
         [TestCase(new string[0] , "Passed")]
         [TestCase(new[] { OutcomeFilter.AllOutcome }, "Passed")]
         public void IsMatching_TestOutcomeMatchesOutcomeFilter_ReturnsTrue(IList<string> outcomeFilter, string testOutcome)

--- a/src/TestModel/tests/Filter/TestCentricTestFilterTests.cs
+++ b/src/TestModel/tests/Filter/TestCentricTestFilterTests.cs
@@ -166,7 +166,7 @@ namespace TestCentric.Gui.Model.Filter
                 new object[] { new List<string>() { "Passed", OutcomeFilter.NotRunOutcome }, new List<string>() { "3-1000", "3-1001", "3-1010", "3-1011", "3-1012", "3-1020", "3-1022", "3-1030", "3-1031", "3-1032" } },
                 new object[] { new List<string>() { "Passed", "Failed" }, new List<string>() { "3-1000", "3-1001", "3-1010", "3-1011", "3-1012", "3-1020", "3-1022", "3-1020", "3-1021" } },
                 new object[] { new List<string>() { OutcomeFilter.NotRunOutcome, "Failed" }, new List<string>() { "3-1000", "3-1001", "3-1030", "3-1031", "3-1032", "3-1020", "3-1021" } },
-                new object[] { new List<string>() { "Warning"}, new List<string>() { "3-1000", "3-1001", "3-1040", "3-1042"} },
+                new object[] { new List<string>() { "Warning"}, new List<string>() { "3-1000", "3-1001", "3-1040", "3-1042", "3-1043" } },
                 new object[] { new List<string>() { OutcomeFilter.AllOutcome }, new List<string>() { "3-1000", "3-1001", "3-1010", "3-1011", "3-1012", "3-1020", "3-1021", "3-1022", "3-1030", "3-1031", "3-1032", "3-1040", "3-1041", "3-1042" } },
                 new object[] { new List<string>(), new List<string>() { "3-1000", "3-1001", "3-1010", "3-1011", "3-1012", "3-1020", "3-1021", "3-1022", "3-1030", "3-1031", "3-1032", "3-1040", "3-1041", "3-1042" } },
         };
@@ -190,7 +190,8 @@ namespace TestCentric.Gui.Model.Filter
                             CreateTestcaseXml("3-1032", "TestB", "")) +
                         CreateTestFixtureXml("3-1040", "Fixture_4", "",
                             CreateTestcaseXml("3-1041", "TestA", ""),
-                            CreateTestcaseXml("3-1042", "TestB", "Skipped")))));
+                            CreateTestcaseXml("3-1042", "TestB", "Skipped"),
+                            CreateTestcaseXml("3-1043", "TestC", "Warning")))));
             _model.LoadedTests.Returns(testNode);
 
             // Act


### PR DESCRIPTION
This PR fixes an incorrect outcome filtering for tests with result state = Warning.
Unfortunately these kind of tests were filtered as 'Not run' outcome, which is obviously wrong. Instead they should be filtered exactly as 'Skipped', 'Ignored' or 'Noninclusive' tests with the warning filter.

From code perspective:
it was missed to handle the enum state `TestStatus.Warning` in the case statement properly.