### PR TITLE
Save project: update title bar and add to recent file list

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -99,15 +99,9 @@ namespace TestCentric.Gui.Presenters
         {
             #region Model Events
 
-            _model.Events.TestCentricProjectLoaded += (TestEventArgs e) =>
-            {
-                _view.Title = $"TestCentric - {_model.TestCentricProject?.FileName ?? "UNNAMED.tcproj"}";
-            };
+            _model.Events.TestCentricProjectLoaded += (TestEventArgs e) => UpdateTitlebar();
 
-            _model.Events.TestCentricProjectUnloaded += (TestEventArgs e) =>
-            {
-                _view.Title = "TestCentric Runner for NUnit";
-            };
+            _model.Events.TestCentricProjectUnloaded += (TestEventArgs e) => UpdateTitlebar();
 
             _model.Events.TestsLoading += (TestFilesLoadingEventArgs e) =>
             {
@@ -675,12 +669,24 @@ namespace TestCentric.Gui.Presenters
                 try
                 {
                     _model.SaveProject(projectPath);
+                    UpdateTitlebar();
                 }
                 catch (Exception exception)
                 {
-                    _view.MessageDisplay.Error("Unable to Save Results\n\n" + MessageBuilder.FromException(exception));
+                    _view.MessageDisplay.Error("Unable to save project\n\n" + MessageBuilder.FromException(exception));
                 }
             }
+        }
+
+        private void UpdateTitlebar()
+        {
+            string title = "TestCentric Runner for NUnit";
+            if (_model.TestCentricProject != null)
+            {
+                title = $"TestCentric - {_model.TestCentricProject.FileName ?? "UNNAMED.tcproj"}";
+
+            }
+            _view.Title = title;
         }
 
         #endregion

--- a/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
+using TestCentric.Gui.Elements;
 using TestCentric.Gui.Model;
 
 namespace TestCentric.Gui.Presenters.Main
@@ -33,6 +34,24 @@ namespace TestCentric.Gui.Presenters.Main
             FireProjectUnloadedEvent();
 
             _view.Received().Title = "TestCentric Runner for NUnit"; 
+        }
+
+
+        [Test]
+        public void WhenProjectIsSaved_TitleBarIsSet()
+        {
+            // Arrange
+            var project = new TestCentricProject(_model, "dummy.dll");
+            _model.TestCentricProject.Returns(project);
+            _view.DialogManager.GetFileSavePath(null, null, null, null).ReturnsForAnyArgs("TestCentric.tcproj");
+
+            // Act
+            project.SaveAs("TestCentric.tcproj");
+            _view.SaveProjectCommand.Execute += Raise.Event<CommandHandler>();
+
+            // Assert
+            _model.Received().SaveProject("TestCentric.tcproj");
+            _view.Received().Title = "TestCentric - TestCentric.tcproj";
         }
     }
 }

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -326,6 +326,7 @@ namespace TestCentric.Gui.Model
         public void SaveProject(string filename)
         {
             TestCentricProject.SaveAs(filename);
+            RecentFiles.Latest = TestCentricProject.ProjectPath;
         }
 
         public void CloseProject()

--- a/src/TestModel/tests/TestModelTests.cs
+++ b/src/TestModel/tests/TestModelTests.cs
@@ -62,5 +62,21 @@ namespace TestCentric.Gui.Model
             // Assert
             Assert.That(projectLoadedCalled, Is.True);
         }
+
+        [Test]
+        public void SaveProject_RecentFiles_ContainsProjectName()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new CommandLineOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            // Act
+            model.CreateNewProject();
+            model.SaveProject("TestCentric.tcproj");
+
+            // Assert
+            Assert.That(model.RecentFiles.Latest, Is.EqualTo("TestCentric.tcproj"));
+        }
     }
 }


### PR DESCRIPTION
This PR resolves #1200:
When a test project is saved:
- The title bar is updated to reflect the new project name
- The test project file is added to the recent file list