### PR TITLE
Menuitem for 'Display format NUnit': simplify 'show namespace' submenu

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -272,7 +272,7 @@ namespace TestCentric.Gui.Presenters
                         _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                         break;
                     case "TestCentric.Gui.TestTree.ShowNamespace":
-                        _view.ShowNamespace.SelectedIndex = _settings.Gui.TestTree.ShowNamespace ? 0 : 1;
+                        _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
                         break;
                 }
             };
@@ -497,9 +497,9 @@ namespace TestCentric.Gui.Presenters
                 _settings.Gui.TestTree.DisplayFormat = _view.DisplayFormat.SelectedItem;
             };
 
-            _view.ShowNamespace.SelectionChanged += () =>
+            _view.ShowNamespace.CheckedChanged += () =>
             {
-                _settings.Gui.TestTree.ShowNamespace = _view.ShowNamespace.SelectedIndex == 0;
+                _settings.Gui.TestTree.ShowNamespace = _view.ShowNamespace.Checked;
             };
 
             _view.ShowHideFilterButton.CheckedChanged += () =>
@@ -974,7 +974,7 @@ namespace TestCentric.Gui.Presenters
                     break;
             }
 
-            _view.ShowNamespace.SelectedIndex = _settings.Gui.TestTree.ShowNamespace ? 0 : 1;
+            _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
             _view.ShowNamespace.Enabled = displayFormat == "NUNIT_TREE";
         }
 

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -76,7 +76,7 @@ namespace TestCentric.Gui.Views
         IViewElement DisplayFormatButton { get; }
         ISelection DisplayFormat { get; }
         ISelection GroupBy { get; }
-        ISelection ShowNamespace { get; }
+        IChecked ShowNamespace { get; }
         IChecked ShowHideFilterButton { get; }
         ICommand RunParametersButton { get; }
 

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -88,7 +88,6 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
-        private ToolStripMenuItem nunitTreeHideNamespaceMenuItem;
         private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem byAssemblyMenuItem;
         private ToolStripMenuItem byFixtureMenuItem;
@@ -178,7 +177,7 @@ namespace TestCentric.Gui.Views
             GroupBy = new CheckedToolStripMenuGroup(
                 "testGrouping",
                 byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
-            ShowNamespace = new CheckedToolStripMenuGroup("showNamespace", nunitTreeShowNamespaceMenuItem, nunitTreeHideNamespaceMenuItem);
+            ShowNamespace = new CheckedMenuElement(nunitTreeShowNamespaceMenuItem);
             ShowHideFilterButton = new ToolStripButtonElement(showFilterButton);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
             RunSummaryButton = new CheckBoxElement(runSummaryButton);
@@ -223,7 +222,6 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.nunitTreeHideNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -414,7 +412,7 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton.Size = new System.Drawing.Size(29, 21);
             this.displayFormatButton.Text = "Display";
             this.displayFormatButton.ToolTipText = "Tree Display Format";
-
+            this.displayFormatButton.DropDown.Closing += DisplayFormatDropDown_Closing;
             // 
             // nunitTreeShowNamespaceMenuItem
             // 
@@ -422,15 +420,6 @@ namespace TestCentric.Gui.Views
             this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
             this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
-
-            // 
-            // nunitTreeHideNamespaceMenuItem
-            // 
-            this.nunitTreeHideNamespaceMenuItem.Name = "NUNIT_TREE_HIDE_NAMESPACE";
-            this.nunitTreeHideNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.nunitTreeHideNamespaceMenuItem.Tag = "NUNIT_TREE_HIDE_NAMESPACE";
-            this.nunitTreeHideNamespaceMenuItem.Text = "Hide Namespace";
-
             // 
             // nunitTreeMenuItem
             // 
@@ -438,7 +427,7 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
             this.nunitTreeMenuItem.Text = "NUnit Tree";
-            nunitTreeMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { nunitTreeShowNamespaceMenuItem, nunitTreeHideNamespaceMenuItem });
+            this.nunitTreeMenuItem.CheckedChanged += DisplayFormatNUnitTreeChanged;
 
             // 
             // fixtureListMenuItem
@@ -1069,9 +1058,17 @@ namespace TestCentric.Gui.Views
 
         private void DisplayFormatDropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
         {
-            e.Cancel =
-                e.CloseReason == ToolStripDropDownCloseReason.ItemClicked ||
-                e.CloseReason == ToolStripDropDownCloseReason.AppFocusChange;
+            e.Cancel = e.CloseReason == ToolStripDropDownCloseReason.ItemClicked;
+        }
+
+        private void DisplayFormatNUnitTreeChanged(object sender, EventArgs e)
+        {
+            this.nunitTreeMenuItem.DropDownItems.Clear();
+            if (nunitTreeMenuItem.Checked)
+            {
+                this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+                this.nunitTreeMenuItem.DropDown.Show();
+            }
         }
 
         #endregion
@@ -1156,7 +1153,7 @@ namespace TestCentric.Gui.Views
         public IViewElement DisplayFormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
         public ISelection GroupBy { get; private set; }
-        public ISelection ShowNamespace { get; private set; }
+        public IChecked ShowNamespace { get; private set; }
 
         public IChecked ShowHideFilterButton { get; private set; }
         public ICommand RunParametersButton { get; private set; }

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -349,18 +349,18 @@ namespace TestCentric.Gui.Presenters.Main
             Assert.That(_view.RunSelectedButton.Enabled, Is.True);
         }
 
-        [TestCase(0, true)]
-        [TestCase(1, false)]
-        public void ShowNamespaceChanged_ChangesModelSetting(int selectedMenuItem, bool expectedShowNamespace)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowNamespaceChanged_ChangesModelSetting(bool showNamespace)
         {
             // Arrange
-            _view.ShowNamespace.SelectedIndex.Returns(selectedMenuItem);
+            _view.ShowNamespace.Checked .Returns(showNamespace);
 
             // Act
-            _view.ShowNamespace.SelectionChanged += Raise.Event<CommandHandler>();
+            _view.ShowNamespace.CheckedChanged += Raise.Event<CommandHandler>();
 
             // Assert
-            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(expectedShowNamespace));
+            Assert.That(_model.Settings.Gui.TestTree.ShowNamespace, Is.EqualTo(showNamespace));
         }
 
         [TestCase(true)]

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -47,15 +47,15 @@ namespace TestCentric.Gui.Presenters.Main
             Assert.That(_view.GroupBy.SelectedItem, Is.EqualTo(groupBy));
         }
 
-        [TestCase(true, 0)]
-        [TestCase(false, 1)]
-        public void ShowNamespace_SettingChanged_MenuItemIsUpdated(bool showNamespace, int expectedMenuIndex)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowNamespace_SettingChanged_MenuItemIsUpdated(bool showNamespace)
         {
             // 1. Act
             _settings.Gui.TestTree.ShowNamespace = showNamespace;
 
             // 2. Assert
-            Assert.That(_view.ShowNamespace.SelectedIndex, Is.EqualTo(expectedMenuIndex));
+            Assert.That(_view.ShowNamespace.Checked, Is.EqualTo(showNamespace));
         }
 
         [TestCase("NUNIT_TREE", true)]


### PR DESCRIPTION
This PR fixes #1204 by replacing the two submenu items "Show namespace" and "Hide namespace" with one single submenu item.

<img src="https://github.com/user-attachments/assets/c0f77c3f-08a7-4326-a013-d4ae66abdb7f" width="400">



In addition this submenu is only available, if the NUnit display format is checked. If another display format is checked, the submenu is not available.

<img src="https://github.com/user-attachments/assets/e7c87653-16b5-47e5-b16c-637545a1bac6" width="300">

If a display format is selected, the menu is not closed automatically anymore. Instead it's kept open, so that the user can select the appropriate submenu item right away.


