### PR TITLE
Add menu item to remove test subpackage from test project

### DIFF
--- a/src/TestCentric/testcentric.gui/Elements/ControlElements/KeyCommand.cs
+++ b/src/TestCentric/testcentric.gui/Elements/ControlElements/KeyCommand.cs
@@ -1,0 +1,45 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace TestCentric.Gui.Elements
+{
+    /// <summary>
+    /// This class is responsible to handle key events of a control
+    /// </summary>
+    internal class KeyCommand : IKeyCommand
+    {
+
+        public event CommandHandler KeyUp;
+        public event CommandHandler KeyDown;
+
+        private IEnumerable<Keys> _upKeys;
+        private IEnumerable<Keys> _downKeys;
+
+        public KeyCommand(Control control, IEnumerable<Keys> upkeys, IEnumerable<Keys> downkeys)
+        {
+            _upKeys = upkeys ?? new List<Keys>();
+            _downKeys = downkeys ?? new List<Keys>();
+
+            control.KeyUp += OnKeyUp;
+            control.KeyUp += OnKeyDown;
+        }
+
+        private void OnKeyUp(object sender, KeyEventArgs e)
+        {
+            if (_upKeys.Contains(e.KeyCode))
+                KeyUp?.Invoke();
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (_downKeys.Contains(e.KeyCode))
+                KeyDown?.Invoke();
+        }
+    }
+}

--- a/src/TestCentric/testcentric.gui/Elements/IKeyCommand.cs
+++ b/src/TestCentric/testcentric.gui/Elements/IKeyCommand.cs
@@ -1,0 +1,23 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Elements
+{
+    /// <summary>
+    /// Interface to handle keyboard commands
+    /// </summary>
+    public interface IKeyCommand
+    {
+        /// <summary>
+        /// Triggered on key up event
+        /// </summary>
+        event CommandHandler KeyUp;
+
+        /// <summary>
+        /// Triggered on key down event
+        /// </summary>
+        event CommandHandler KeyDown;
+    }
+}

--- a/src/TestCentric/testcentric.gui/Elements/README.md
+++ b/src/TestCentric/testcentric.gui/Elements/README.md
@@ -30,6 +30,10 @@ In the current implementation, there are two separate hierarchies of UI Elements
 
 **NOTE:** The `ContextMenu` property returns a Windows `Menu` instance and `ContextMenuStrip` returns a `ToolStripDropDownMenu`, both of these exposing the underlying Windows implementation. This interface and its use will be reviewed in the future.
 
+### IKeyCommand
+
+`IKeyCommand` provide two events `KeyUp` and `KeyDown`. It encapsulate the Window Forms `Keys` enums.
+
 ### IListBox
 
 `IListBox` extends `IControlElement` to provide the properties `Items` and `SelectedItems`, event `DoubleClick` and methods `Add` and `Remove`. It exposed a great deal of the underlying Windows implementation and is no longer used. It is now marked as Obsolete.
@@ -73,6 +77,10 @@ A `ButtonElement` wraps a Windows `Button` control and implements `ICommand`. Th
 ### CheckBoxElement
 
 A `CheckBoxElement` wraps  a Windows `CheckBox` control and implements `IChecked`. Although Windows still uses the term "checked," the visual display may or may not use a check mark.
+
+### KeyCommand
+
+A `KeyCommand` wraps a Windows `Control` and implements `IKeyCommand` to handle keyboard events.
 
 ### ListBoxElement
 

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -165,6 +165,9 @@ namespace TestCentric.Gui.Presenters
             _view.CollapseAllCommand.Execute += () => _view.CollapseAll();
             _view.ExpandAllCommand.Execute += () => _view.ExpandAll();
             _view.CollapseToFixturesCommand.Execute += () => Strategy.CollapseToFixtures();
+            _view.RemoveTestPackageCommand.Execute += () => RemoveTestPackage();
+            _view.TreeViewDeleteKeyCommand.KeyUp += () => RemoveTestPackage();
+
             _view.ShowCheckBoxes.CheckedChanged += () =>
             {
                 _view.CheckBoxes = _view.ShowCheckBoxes.Checked;
@@ -508,9 +511,27 @@ namespace TestCentric.Gui.Presenters
             var layout = _model.Settings.Gui.GuiLayout;
             _view.TestPropertiesCommand.Visible = layout == "Mini";
 
+            var selectedNode = _view.ContextNode?.Tag as TestNode;
+            _view.RemoveTestPackageCommand.Visible = CanRemovePackageNode(selectedNode);
+
             // If a test is already running, no new test run should be started.
             _view.RunContextCommand.Enabled = _model.HasTests && !_model.IsTestRunning;
             _view.DebugContextCommand.Enabled = _model.HasTests && !_model.IsTestRunning;
+        }
+
+        private void RemoveTestPackage()
+        {
+            var testNode = _view.SelectedNode?.Tag as TestNode;
+            if (CanRemovePackageNode(testNode))
+            {
+                var subPackage = _model.GetPackageForTest(testNode.Id);
+                _model.RemoveTestPackage(subPackage);
+            }
+        }
+
+        private bool CanRemovePackageNode(TestNode testNode)
+        {
+            return _model.HasTests && !_model.IsTestRunning && testNode != null && testNode.IsAssembly && _model.TestCentricProject.SubPackages.Count > 1;
         }
 
         #endregion

--- a/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestTreeView.cs
@@ -38,6 +38,8 @@ namespace TestCentric.Gui.Views
         ICommand CollapseToFixturesCommand { get; }
         ICommand TestPropertiesCommand { get; }
         ICommand ViewAsXmlCommand { get; }
+        ICommand RemoveTestPackageCommand { get; }
+        IKeyCommand TreeViewDeleteKeyCommand { get; }
 
         // Tree Properties
         ContextMenuStrip TreeContextMenu { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -50,6 +50,7 @@ namespace TestCentric.Gui.Views
             this.contextMenuSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.testPropertiesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewAsXmlMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.removeTestPackageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.activeConfigMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.showCheckboxesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -187,6 +188,7 @@ namespace TestCentric.Gui.Views
             this.contextMenuSeparator1,
             this.testPropertiesMenuItem,
             this.viewAsXmlMenuItem,
+            this.removeTestPackageMenuItem,
             this.activeConfigMenuItem,
             this.contextMenuSeparator2,
             this.showCheckboxesMenuItem,
@@ -229,6 +231,12 @@ namespace TestCentric.Gui.Views
             this.viewAsXmlMenuItem.Name = "viewAsXmlMenuItem";
             this.viewAsXmlMenuItem.Size = new System.Drawing.Size(190, 22);
             this.viewAsXmlMenuItem.Text = "View as XML...";
+            // 
+            // removeTestFileMenuItem
+            // 
+            this.removeTestPackageMenuItem.Name = "removeTestFileMenuItem";
+            this.removeTestPackageMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.removeTestPackageMenuItem.Text = "Remove test file";
             // 
             // activeConfigMenuItem
             // 
@@ -381,5 +389,6 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.ToolStripSeparator contextMenuSeparator3;
         private System.Windows.Forms.ToolStripSeparator contextMenuSeparator4;
         private System.Windows.Forms.ToolStripMenuItem viewAsXmlMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem removeTestPackageMenuItem;
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.cs
@@ -49,6 +49,8 @@ namespace TestCentric.Gui.Views
             CollapseToFixturesCommand = new CommandMenuElement(collapseToFixturesMenuItem);
             TestPropertiesCommand = new CommandMenuElement(testPropertiesMenuItem);
             ViewAsXmlCommand = new CommandMenuElement(viewAsXmlMenuItem);
+            RemoveTestPackageCommand = new CommandMenuElement(removeTestPackageMenuItem);
+            TreeViewDeleteKeyCommand = new KeyCommand(treeView, new[] { Keys.Delete, Keys.Back }, null);
             SortCommand = new CheckedToolStripMenuGroup("Sort", sortByNameMenuItem, sortByDurationMenuItem);
             SortDirectionCommand = new CheckedToolStripMenuGroup("SortDirection", sortAscendingMenuItem, sortDescendingMenuItem);
             OutcomeFilter = new MultiCheckedToolStripButtonGroup(new[] { filterOutcomePassedButton, filterOutcomeFailedButton, filterOutcomeWarningButton, filterOutcomeNotRunButton });
@@ -128,6 +130,11 @@ namespace TestCentric.Gui.Views
         public ISelection SortDirectionCommand { get; private set; }
         public ICommand ExpandAllCommand { get; private set; }
         public ICommand CollapseAllCommand { get; private set; }
+
+        public ICommand RemoveTestPackageCommand { get; private set; }
+
+        public IKeyCommand TreeViewDeleteKeyCommand { get; private set; }
+        
         public ICommand CollapseToFixturesCommand { get; private set; }
         public ICommand TestPropertiesCommand { get; private set; }
         public ICommand ViewAsXmlCommand { get; private set; }

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -342,6 +342,122 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.CategoryFilter.ReceivedWithAnyArgs().SelectedItems = null;
         }
 
+        [Test]
+        public void RemoveTestPackageCommand_SelectedNode_IsNull_TestPackageIsNotRemoved()
+        {
+            // 1. Arrange
+            _view.SelectedNode.Returns((TreeNode)null);
+
+            // 2. Act
+            _view.RemoveTestPackageCommand.Execute += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _model.DidNotReceiveWithAnyArgs().RemoveTestPackage(null);
+        }
+
+        [TestCase(false, false, "TestSuite")]
+        [TestCase(true, false, "TestSuite")]
+        [TestCase(true, false, "TestSuite")]
+        [TestCase(true, false, "Assembly")]
+        public void RemoveTestPackageCommand_NotAllConditionsMeet_TestPackageIsNotRemoved(bool hasTests, bool isTestRunning, string testNodeType)
+        {
+            // 1. Arrange
+            TestNode testNode = new TestNode($"<test-suite id='1' type='{testNodeType}' />");
+            TreeNode treeNode = new TreeNode();
+            treeNode.Tag = testNode; 
+            _view.SelectedNode.Returns(treeNode);
+            _model.HasTests.Returns(hasTests);
+            _model.IsTestRunning.Returns(isTestRunning);
+
+            var project = new TestCentricProject(_model, "dummy.dll");
+            _model.TestCentricProject.Returns(project);
+
+            // 2. Act
+            _view.RemoveTestPackageCommand.Execute += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _model.DidNotReceiveWithAnyArgs().RemoveTestPackage(null);
+        }
+
+        [Test]
+        public void RemoveTestPackageCommand_AllConditionsMeet_TestPackageIsRemoved()
+        {
+            // 1. Arrange
+            TestNode testNode = new TestNode($"<test-suite id='1' type='Assembly' />");
+            TreeNode treeNode = new TreeNode();
+            treeNode.Tag = testNode;
+            _view.SelectedNode.Returns(treeNode);
+            _model.HasTests.Returns(true);
+            _model.IsTestRunning.Returns(false);
+
+            var project = new TestCentricProject(_model, new[] { "dummy.dll", "dummy2.dll" });
+            _model.TestCentricProject.Returns(project);
+
+            // 2. Act
+            _view.RemoveTestPackageCommand.Execute += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            _model.ReceivedWithAnyArgs().RemoveTestPackage(null);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_ConextNode_IsNull_RemoveTestPackageCommandContextMenu_IsNotVisible()
+        {
+            // 1. Arrange
+            _view.ContextNode.Returns((TreeNode)null);
+
+            // 2. Act
+            _view.RemoveTestPackageCommand.Execute += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            Assert.That(_view.RemoveTestPackageCommand.Visible, Is.False);
+        }
+
+        [TestCase(false, false, "TestSuite")]
+        [TestCase(true, false, "TestSuite")]
+        [TestCase(true, false, "TestSuite")]
+        [TestCase(true, false, "Assembly")]
+        public void WhenContextMenuIsDisplayed_RemoveTestPackageCommandContextMenu_IsNotVisible(bool hasTests, bool isTestRunning, string testNodeType)
+        {
+            // 1. Arrange
+            TestNode testNode = new TestNode($"<test-suite id='1' type='{testNodeType}' />");
+            TreeNode treeNode = new TreeNode();
+            treeNode.Tag = testNode;
+            _view.ContextNode.Returns(treeNode);
+            _model.HasTests.Returns(hasTests);
+            _model.IsTestRunning.Returns(isTestRunning);
+
+            var project = new TestCentricProject(_model, "dummy.dll");
+            _model.TestCentricProject.Returns(project);
+
+            // 2. Act
+            _view.RemoveTestPackageCommand.Execute += Raise.Event<CommandHandler>();
+
+            // 3. Assert
+            Assert.That(_view.RemoveTestPackageCommand.Visible, Is.False);
+        }
+
+        [Test]
+        public void WhenContextMenuIsDisplayed_RemoveTestPackageCommandContextMenu_IsVisible()
+        {
+            // 1. Arrange
+            TestNode testNode = new TestNode($"<test-suite id='1' type='Assembly' />");
+            TreeNode treeNode = new TreeNode();
+            treeNode.Tag = testNode;
+            _view.ContextNode.Returns(treeNode);
+            _model.HasTests.Returns(true);
+            _model.IsTestRunning.Returns(false);
+
+            var project = new TestCentricProject(_model, new[] { "dummy.dll", "dummy2.dll" });
+            _model.TestCentricProject.Returns(project);
+
+            // 2. Act
+            _view.ContextMenuOpening += Raise.Event<EventHandler>();
+
+            // 3. Assert
+            Assert.That(_view.RemoveTestPackageCommand.Visible, Is.True);
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenContextNodeIsNotNull_RunCommandExecutesThatTest()

--- a/src/TestModel/model/ITestModel.cs
+++ b/src/TestModel/model/ITestModel.cs
@@ -111,6 +111,12 @@ namespace TestCentric.Gui.Model
         /// </summary>
         void AddTests(IEnumerable<string> fileNames);
 
+        /// <summary>
+        /// Remove a test package from the current test project
+        /// </summary>
+        void RemoveTestPackage(TestPackage subPackage);
+
+
         void OpenExistingProject(string filename);
 
         void OpenMostRecentFile();

--- a/src/TestModel/model/TestCentricProject.cs
+++ b/src/TestModel/model/TestCentricProject.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
 using TestCentric.Engine;
-using TestCentric.Gui.Model.Settings;
 
 namespace TestCentric.Gui.Model
 {
@@ -103,7 +102,6 @@ namespace TestCentric.Gui.Model
 
                     foreach (var subPackage in newPackage.SubPackages)
                     {
-                        TestFiles.Add(subPackage.FullName);
                         AddSubPackage(subPackage.FullName);
                     }
 
@@ -166,6 +164,16 @@ namespace TestCentric.Gui.Model
         {
             base.AddSubPackage(subPackage);
             IsDirty = true;
+        }
+
+        public void RemoveSubPackage(TestPackage subPackage)
+        {
+            if (subPackage != null)
+            {
+                SubPackages.Remove(subPackage);
+                TestFiles.Remove(subPackage.FullName);
+                IsDirty = true;
+            }
         }
 
         public new void AddSetting(string key, object value)

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -290,6 +290,17 @@ namespace TestCentric.Gui.Model
             _events.FireTestCentricProjectLoaded();
         }
 
+        public void RemoveTestPackage(TestPackage subPackage)
+        {
+            if (!IsProjectLoaded || IsTestRunning || subPackage == null || TestCentricProject.SubPackages.Count <= 1)
+                return;
+
+            TestCentricProject.RemoveSubPackage(subPackage);
+
+            TestCentricProject.LoadTests();
+            _events.FireTestCentricProjectLoaded();
+        }
+
         public void OpenExistingProject(string projectPath)
         {
             if (IsProjectLoaded)

--- a/src/TestModel/tests/CreateNewProjectTests.cs
+++ b/src/TestModel/tests/CreateNewProjectTests.cs
@@ -152,5 +152,27 @@ namespace TestCentric.Gui.Model
             project.AddSetting("NewSetting", "VALUE");
             Assert.That(project.IsDirty);
         }
+
+        [Test]
+        public void RemoveSubPackage_MakesProjectDirty()
+        {
+            var project = _model.CreateNewProject(new[] { "dummy.dll", "dummy2.dll" });
+            project.SaveAs("temp.tcproj");
+
+            var subPackage = project.SubPackages[0];
+            project.RemoveSubPackage(subPackage);
+            Assert.That(project.IsDirty);
+        }
+
+        [Test]
+        public void RemoveSubPackage_PackagesIsDecreased()
+        {
+            var project = _model.CreateNewProject(new[] { "dummy.dll", "dummy2.dll" });
+            project.SaveAs("temp.tcproj");
+
+            var subPackage = project.SubPackages[0];
+            project.RemoveSubPackage(subPackage);
+            Assert.That(project.SubPackages.Count, Is.EqualTo(1));
+        }
     }
 }

--- a/src/TestModel/tests/TestModelTests.cs
+++ b/src/TestModel/tests/TestModelTests.cs
@@ -62,5 +62,25 @@ namespace TestCentric.Gui.Model
             // Assert
             Assert.That(projectLoadedCalled, Is.True);
         }
+
+        [Test]
+        public void RemoveTestPackage_TestCentricProjectLoadedEvent_IsTriggered()
+        {
+            // Arrange
+            var engine = Substitute.For<TestCentric.Engine.ITestEngine>();
+            var options = new CommandLineOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            bool projectLoadedCalled = false;
+            model.Events.TestCentricProjectLoaded += (t) => projectLoadedCalled = true;
+
+            // Act
+            model.CreateNewProject(new[] { "Dummy.dll", "Dummy2.dll" });
+            var subPackage = model.TestCentricProject.SubPackages[1];
+            model.RemoveTestPackage(subPackage);
+
+            // Assert
+            Assert.That(projectLoadedCalled, Is.True);
+        }
     }
 }


### PR DESCRIPTION
With this PR it is now possible to remove a test package from a test project.
The user can trigger this functionality either by a context menu entry or by a keyboard (delete/backspace key).

<img src="https://github.com/user-attachments/assets/a1b5550c-fa6f-4364-9ca6-b85fc5157360" width="300">

This menu item is only available for tree nodes of type `IsAssembly`. For all other types of tree nodes (TestFixture, Test case ...) it's not visible. This operation is also not available during a test run. 

Moreover this operation is also not available if the test project contains only one test package. That might not be necessary, but I don't want to introduce a new state - a test project without any test package. But I preferred to be cautious here.

This PR close #1202.