### PR TITLE
Fix crash loading project file

### DIFF
--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -202,6 +202,10 @@ namespace TestCentric.Gui
 
         public void Save(string fileName)
         {
+            string path = Path.GetDirectoryName(fileName);
+            if (!string.IsNullOrEmpty(path) && !Directory.Exists(path))
+                return;
+
             using (StreamWriter writer = new StreamWriter(fileName))
             {
                 Save(writer);

--- a/src/TestModel/model/Services/AssemblyWatcher.cs
+++ b/src/TestModel/model/Services/AssemblyWatcher.cs
@@ -4,7 +4,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Timers;
 
@@ -12,8 +12,8 @@ namespace TestCentric.Gui.Model.Services
 {
     public class AssemblyWatcher : IAsemblyWatcher
     {
-        private FileSystemWatcher[] fileWatchers;
-        private FileInfo[] files;
+        private List<FileSystemWatcher> fileWatchers;
+        private List<FileInfo> files;
 
         protected System.Timers.Timer timer;
         protected string changedAssemblyPath;
@@ -28,23 +28,30 @@ namespace TestCentric.Gui.Model.Services
             Setup(delay, new string[] { assemblyFileName });
         }
 
-        public void Setup(int delay, IList assemblies)
+        public void Setup(int delay, IList<string> assemblies)
         {
 
-            files = new FileInfo[assemblies.Count];
-            fileWatchers = new FileSystemWatcher[assemblies.Count];
+            files = new List<FileInfo>();
+            fileWatchers = new List<FileSystemWatcher>();
 
-            for (int i = 0; i < assemblies.Count; i++)
+            foreach(string assemblyName in assemblies)
             {
+                var fileInfo = new FileInfo(assemblyName);
+                if (!Directory.Exists(fileInfo.DirectoryName))
+                {
+                    continue;
+                }
 
-                files[i] = new FileInfo((string)assemblies[i]);
+                files.Add(fileInfo);
 
-                fileWatchers[i] = new FileSystemWatcher();
-                fileWatchers[i].Path = files[i].DirectoryName;
-                fileWatchers[i].Filter = files[i].Name;
-                fileWatchers[i].NotifyFilter = NotifyFilters.Size | NotifyFilters.LastWrite;
-                fileWatchers[i].Changed += new FileSystemEventHandler(OnChanged);
-                fileWatchers[i].EnableRaisingEvents = false;
+                var fileWatcher = new FileSystemWatcher();
+                fileWatcher.Path = fileInfo.DirectoryName;
+                fileWatcher.Filter = fileInfo.Name;
+                fileWatcher.NotifyFilter = NotifyFilters.Size | NotifyFilters.LastWrite;
+                fileWatcher.Changed += new FileSystemEventHandler(OnChanged);
+                fileWatcher.EnableRaisingEvents = false;
+
+                fileWatchers.Add(fileWatcher);
             }
 
             timer = new System.Timers.Timer(delay);

--- a/src/TestModel/model/Services/IAsemblyWatcher.cs
+++ b/src/TestModel/model/Services/IAsemblyWatcher.cs
@@ -4,7 +4,7 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 
 namespace TestCentric.Gui.Model.Services
 {
@@ -29,7 +29,7 @@ namespace TestCentric.Gui.Model.Services
         /// <param name="delayInMs">The delay in ms.</param>
         /// <param name="assemblies">The assemblies.</param>
 
-        void Setup(int delayInMs, IList assemblies);
+        void Setup(int delayInMs, IList<string> assemblies);
 
 
         /// <summary>

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -372,7 +372,7 @@ namespace TestCentric.Gui.Model
 
             ClearResults();
 
-            _assemblyWatcher.Setup(1000, files as IList);
+            _assemblyWatcher.Setup(1000, files);
             _assemblyWatcher.AssemblyChanged += (path) => _events.FireTestChanged();
             _assemblyWatcher.Start();
 


### PR DESCRIPTION
This PR fixes #1201 by handling non existing folder names in tcproj files.

There were two code locations which fail if the tcsproj file contains a non existing folder name:

- AssemblyWatcher:
  The FileSystemWatcher will throw an exception whenever it is used with a non existing folder.
  Therefore the existance of the folder is checked in advance now. 
  As a result this assembly is simply not watched for changes, but the project gets loaded. The assembly is marked as invalid in the tree.
- VisualState:
In case such a project is getting closed, there was another exception. The VisualState tries to save a visualstate file in the non existing folder. Here again a check is added if the folder exists at all. If not, the save is aborted.