### PR TITLE
Add submenu for grouping to 'Fixture list' and 'Test list' menu item

### DIFF
--- a/src/TestCentric/testcentric.gui/Elements/ToolStripElements/CheckedToolStripMenuGroup.cs
+++ b/src/TestCentric/testcentric.gui/Elements/ToolStripElements/CheckedToolStripMenuGroup.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -190,7 +190,7 @@ namespace TestCentric.Gui.Elements
 
         public void InvokeIfRequired(MethodInvoker _delegate)
         {
-            if (ToolStrip.InvokeRequired)
+            if (ToolStrip != null && ToolStrip.InvokeRequired)
                 ToolStrip.BeginInvoke(_delegate);
             else
                 _delegate();

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -964,18 +964,10 @@ namespace TestCentric.Gui.Presenters
 
             switch (displayFormat)
             {
-                case "NUNIT_TREE":
-                    _view.GroupBy.Enabled = false;
-                    break;
                 case "TEST_LIST":
-                    _view.GroupBy.Enabled = true;
                     _view.GroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
                     break;
                 case "FIXTURE_LIST":
-                    _view.GroupBy.Enabled = true;
-                    // HACK: Should be handled by the element itself
-                    if (_view.GroupBy is Elements.CheckedToolStripMenuGroup menuGroup)
-                        menuGroup.MenuItems[1].Enabled = false;
                     _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                     break;
             }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -88,7 +88,6 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
-        private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem byAssemblyMenuItem;
         private ToolStripMenuItem byFixtureMenuItem;
         private ToolStripMenuItem byCategoryMenuItem;
@@ -222,7 +221,6 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.byCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -399,13 +397,7 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.nunitTreeMenuItem,
             this.fixtureListMenuItem,
-            this.testListMenuItem,
-            this.toolStripSeparator13,
-            this.byAssemblyMenuItem,
-            this.byFixtureMenuItem,
-            this.byCategoryMenuItem,
-            this.byOutcomeMenuItem,
-            this.byDurationMenuItem});
+            this.testListMenuItem });
             this.displayFormatButton.Image = ((System.Drawing.Image)(resources.GetObject("displayFormatButton.Image")));
             this.displayFormatButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.displayFormatButton.Name = "displayFormatButton";
@@ -416,7 +408,7 @@ namespace TestCentric.Gui.Views
             // 
             // nunitTreeShowNamespaceMenuItem
             // 
-            this.nunitTreeShowNamespaceMenuItem.Name = "NUNIT_TREE_SHOW_NAMESPACE";
+            this.nunitTreeShowNamespaceMenuItem.Name = "nunitTreeShowNamespaceMenuItem";
             this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
             this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
@@ -436,6 +428,7 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem.Size = new System.Drawing.Size(198, 22);
             this.fixtureListMenuItem.Tag = "FIXTURE_LIST";
             this.fixtureListMenuItem.Text = "Fixture List";
+            this.fixtureListMenuItem.CheckedChanged += DisplayFormatFixtureListChanged;
             // 
             // testListMenuItem
             // 
@@ -443,11 +436,7 @@ namespace TestCentric.Gui.Views
             this.testListMenuItem.Size = new System.Drawing.Size(198, 22);
             this.testListMenuItem.Tag = "TEST_LIST";
             this.testListMenuItem.Text = "Test List";
-            // 
-            // toolStripSeparator13
-            // 
-            this.toolStripSeparator13.Name = "toolStripSeparator13";
-            this.toolStripSeparator13.Size = new System.Drawing.Size(195, 6);
+            this.testListMenuItem.CheckedChanged += DisplayFormatTestListChanged;
             // 
             // byAssemblyMenuItem
             // 
@@ -1066,8 +1055,31 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem.DropDownItems.Clear();
             if (nunitTreeMenuItem.Checked)
             {
-                this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
-                this.nunitTreeMenuItem.DropDown.Show();
+                nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+                if (nunitTreeMenuItem.Visible)
+                    nunitTreeMenuItem.DropDown.Show();
+            }
+        }
+
+        private void DisplayFormatFixtureListChanged(object sender, EventArgs e)
+        {
+            this.fixtureListMenuItem.DropDownItems.Clear();
+            if (fixtureListMenuItem.Checked)
+            {
+                fixtureListMenuItem.DropDownItems.AddRange(new ToolStripItem[] { byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem });
+                if (fixtureListMenuItem.Visible)
+                    fixtureListMenuItem.DropDown.Show();
+            }
+        }
+
+        private void DisplayFormatTestListChanged(object sender, EventArgs e)
+        {
+            this.testListMenuItem.DropDownItems.Clear();
+            if (testListMenuItem.Checked)
+            {
+                this.testListMenuItem.DropDownItems.AddRange(new ToolStripItem[] { byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem });
+                if (testListMenuItem.Visible)
+                    this.testListMenuItem.DropDown.Show();
             }
         }
 

--- a/src/TestCentric/tests/Views/TestCentricMainViewTests.cs
+++ b/src/TestCentric/tests/Views/TestCentricMainViewTests.cs
@@ -1,0 +1,186 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Views
+{
+    [TestFixture]
+    public class TestCentricMainViewTests : ControlTester
+    {
+        [OneTimeSetUp]
+        public void CreateForm()
+        {
+            this.Control = new TestCentricMainView();
+        }
+
+        [OneTimeTearDown]
+        public void CloseForm()
+        {
+            this.Control.Dispose();
+        }
+
+        [Test]
+        public void DisplayFormat_Toolstrip_ExistsWithSubItems()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "nunitTreeMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "fixtureListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "testListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+        }
+
+        [Test]
+        public void NUnitDisplayFormat_Checked_AllSubmenuItems_Exists()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "nunitTreeMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = true;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "nunitTreeShowNamespaceMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        [Test]
+        public void NUnitDisplayFormat_NotChecked_Submenu_IsEmpty()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "nunitTreeMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = false;
+            Assert.That(menuItem.DropDownItems.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void FixtureListFormat_Checked_AllSubmenuItems_Exists()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "fixtureListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = true;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byDurationMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byCategoryMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byOutcomeMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        [Test]
+        public void FixtureListFormat_NotChecked_Submenu_IsEmpty()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "fixtureListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = false;
+            Assert.That(menuItem.DropDownItems.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestListFormat_Checked_AllSubmenuItems_Exists()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "testListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = true;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byDurationMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byCategoryMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byOutcomeMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byAssemblyMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "byFixtureMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestListFormat_NotChecked_Submenu_IsEmpty()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "testListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = false;
+            Assert.That(menuItem.DropDownItems.Count, Is.EqualTo(0));
+        }
+
+        T GetDropDownItem<T>(ToolStripMenuItem menuItem, string name) where T : ToolStripItem
+        {
+            foreach (ToolStripItem ctl in menuItem.DropDownItems)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        T GetDropDownItem<T>(ToolStripDropDownButton dropDownButton, string name) where T : ToolStripItem
+        {
+            foreach (ToolStripItem ctl in dropDownButton.DropDownItems)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        T GetToolStripItem<T>(string name) where T : ToolStripItem
+        {
+            ToolStrip toolStrip = GetToolStrip();
+            foreach (ToolStripItem ctl in toolStrip.Items)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        ToolStrip GetToolStrip()
+        {
+            foreach (Control ctl in _control.Controls)
+            {
+                if (ctl.GetType() == typeof(ToolStrip))
+                    return ctl as ToolStrip;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #1206 by rearranging the grouping submenu items.
As proposed in the related issue, the grouping items are placed now as submenu items of the 'Fixture list' and 'Test list' menu item. This means that the DisplayFormat menu now only has 3 entries - here's a screenshot:

<img src="https://github.com/user-attachments/assets/82affb21-03eb-4e53-aba9-4acd045af6b5" width="350">

The 'Fixture list' supports only three groupings: duration, category and outcome. The assembly grouping is removed as proposed by issue #1205. Also the fixture grouping is not shown anymore - previously it was disabled for 'Fixture list'.

The 'Test list' still supports all kind of groupings. Here's a screenshot:
<img src="https://github.com/user-attachments/assets/a1bd724b-b569-49ec-9191-e556ff9afc59" width="350">

These submenu items are only available if the specific display format is checked, otherwise there's no submenu for that display format. Moreover the display format menu is not getting closed automatically, if a display format is selected. Instead the submenu is shown, so that the user can immediately select his prefered grouping.
