### PR TITLE
Add submenu for grouping to 'Fixture list' and 'Test list' menu item

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -260,10 +260,10 @@ namespace TestCentric.Gui.Presenters
                         UpdateViewCommands();
                         break;
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
-                        _view.GroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
+                        _view.TestListGroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
                         break;
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
-                        _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
+                        _view.FixtureListGroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                         break;
                     case "TestCentric.Gui.TestTree.ShowNamespace":
                         _view.ShowNamespace.Checked = _settings.Gui.TestTree.ShowNamespace;
@@ -501,17 +501,14 @@ namespace TestCentric.Gui.Presenters
                 _settings.Gui.TestTree.ShowFilter = _view.ShowHideFilterButton.Checked;
             };
 
-            _view.GroupBy.SelectionChanged += () =>
+            _view.TestListGroupBy.SelectionChanged += () =>
             {
-                switch(_view.DisplayFormat.SelectedItem)
-                {
-                    case "TEST_LIST":
-                        _settings.Gui.TestTree.TestList.GroupBy = _view.GroupBy.SelectedItem;
-                        break;
-                    case "FIXTURE_LIST":
-                        _settings.Gui.TestTree.FixtureList.GroupBy = _view.GroupBy.SelectedItem;
-                        break;
-                }
+                _settings.Gui.TestTree.TestList.GroupBy = _view.TestListGroupBy.SelectedItem;
+            };
+
+            _view.FixtureListGroupBy.SelectionChanged += () =>
+            {
+                _settings.Gui.TestTree.FixtureList.GroupBy = _view.FixtureListGroupBy.SelectedItem;
             };
 
             _view.StopRunButton.Execute += ExecuteNormalStop;
@@ -964,19 +961,11 @@ namespace TestCentric.Gui.Presenters
 
             switch (displayFormat)
             {
-                case "NUNIT_TREE":
-                    _view.GroupBy.Enabled = false;
-                    break;
                 case "TEST_LIST":
-                    _view.GroupBy.Enabled = true;
-                    _view.GroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
+                    _view.TestListGroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
                     break;
                 case "FIXTURE_LIST":
-                    _view.GroupBy.Enabled = true;
-                    // HACK: Should be handled by the element itself
-                    if (_view.GroupBy is Elements.CheckedToolStripMenuGroup menuGroup)
-                        menuGroup.MenuItems[1].Enabled = false;
-                    _view.GroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
+                    _view.FixtureListGroupBy.SelectedItem = _settings.Gui.TestTree.FixtureList.GroupBy;
                     break;
             }
 

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -75,7 +75,10 @@ namespace TestCentric.Gui.Views
 
         IViewElement DisplayFormatButton { get; }
         ISelection DisplayFormat { get; }
-        ISelection GroupBy { get; }
+        ISelection TestListGroupBy { get; }
+
+        ISelection FixtureListGroupBy { get; }
+
         IChecked ShowNamespace { get; }
         IChecked ShowHideFilterButton { get; }
         ICommand RunParametersButton { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -88,13 +88,16 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
-        private ToolStripSeparator toolStripSeparator13;
-        private ToolStripMenuItem ungroupedMenuItem;
-        private ToolStripMenuItem byAssemblyMenuItem;
-        private ToolStripMenuItem byFixtureMenuItem;
-        private ToolStripMenuItem byCategoryMenuItem;
-        private ToolStripMenuItem byOutcomeMenuItem;
-        private ToolStripMenuItem byDurationMenuItem;
+        private ToolStripMenuItem textListUngroupedMenuItem;
+        private ToolStripMenuItem textListByAssemblyMenuItem;
+        private ToolStripMenuItem textListByFixtureMenuItem;
+        private ToolStripMenuItem textListByCategoryMenuItem;
+        private ToolStripMenuItem textListByOutcomeMenuItem;
+        private ToolStripMenuItem textListByDurationMenuItem;
+        private ToolStripMenuItem fixtureListByCategoryMenuItem;
+        private ToolStripMenuItem fixtureListByOutcomeMenuItem;
+        private ToolStripMenuItem fixtureListByDurationMenuItem;
+        private ToolStripMenuItem fixtureListUngroupedMenuItem;
         private ToolStripButton stopRunButton;
         private ToolStripButton forceStopButton;
         private ProgressBarView progressBar;
@@ -175,9 +178,10 @@ namespace TestCentric.Gui.Views
             DisplayFormat = new CheckedToolStripMenuGroup(
                 "displayFormat",
                 nunitTreeMenuItem, fixtureListMenuItem, testListMenuItem);
-            GroupBy = new CheckedToolStripMenuGroup(
-                "testGrouping",
-                ungroupedMenuItem, byAssemblyMenuItem, byFixtureMenuItem, byCategoryMenuItem, byOutcomeMenuItem, byDurationMenuItem);
+            TestListGroupBy = new CheckedToolStripMenuGroup(
+                "TestListGroupBy",
+                textListUngroupedMenuItem, textListByAssemblyMenuItem, textListByFixtureMenuItem, textListByCategoryMenuItem, textListByOutcomeMenuItem, textListByDurationMenuItem);
+            FixtureListGroupBy = new CheckedToolStripMenuGroup("FixtureListGroupBy", fixtureListUngroupedMenuItem, fixtureListByCategoryMenuItem, fixtureListByOutcomeMenuItem, fixtureListByDurationMenuItem);
             ShowNamespace = new CheckedMenuElement(nunitTreeShowNamespaceMenuItem);
             ShowHideFilterButton = new ToolStripButtonElement(showFilterButton);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
@@ -223,13 +227,16 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.ungroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byOutcomeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.byDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fixtureListUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListByAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListByFixtureMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListByCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListByOutcomeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textListByDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fixtureListByCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fixtureListByOutcomeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fixtureListByDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showFilterButton = new System.Windows.Forms.ToolStripButton();
             this.runParametersButton = new System.Windows.Forms.ToolStripButton();
             this.mainMenu = new System.Windows.Forms.MenuStrip();
@@ -401,14 +408,7 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.nunitTreeMenuItem,
             this.fixtureListMenuItem,
-            this.testListMenuItem,
-            this.toolStripSeparator13,
-            this.ungroupedMenuItem,
-            this.byAssemblyMenuItem,
-            this.byFixtureMenuItem,
-            this.byCategoryMenuItem,
-            this.byOutcomeMenuItem,
-            this.byDurationMenuItem});
+            this.testListMenuItem});
             this.displayFormatButton.Image = ((System.Drawing.Image)(resources.GetObject("displayFormatButton.Image")));
             this.displayFormatButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.displayFormatButton.Name = "displayFormatButton";
@@ -419,10 +419,11 @@ namespace TestCentric.Gui.Views
             // 
             // nunitTreeShowNamespaceMenuItem
             // 
-            this.nunitTreeShowNamespaceMenuItem.Name = "NUNIT_TREE_SHOW_NAMESPACE";
+            this.nunitTreeShowNamespaceMenuItem.Name = "nunitTreeShowNamespaceMenuItem";
             this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
             this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
+            this.nunitTreeShowNamespaceMenuItem.Visible = false;
             // 
             // nunitTreeMenuItem
             // 
@@ -430,8 +431,8 @@ namespace TestCentric.Gui.Views
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(198, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
             this.nunitTreeMenuItem.Text = "NUnit Tree";
+            this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
             this.nunitTreeMenuItem.CheckedChanged += DisplayFormatNUnitTreeChanged;
-
             // 
             // fixtureListMenuItem
             // 
@@ -439,6 +440,8 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem.Size = new System.Drawing.Size(198, 22);
             this.fixtureListMenuItem.Tag = "FIXTURE_LIST";
             this.fixtureListMenuItem.Text = "Fixture List";
+            this.fixtureListMenuItem.DropDownItems.AddRange(new ToolStripItem[] { fixtureListUngroupedMenuItem, fixtureListByCategoryMenuItem, fixtureListByOutcomeMenuItem, fixtureListByDurationMenuItem });
+            this.fixtureListMenuItem.CheckedChanged += DisplayFormatFixtureListChanged;
             // 
             // testListMenuItem
             // 
@@ -446,53 +449,88 @@ namespace TestCentric.Gui.Views
             this.testListMenuItem.Size = new System.Drawing.Size(198, 22);
             this.testListMenuItem.Tag = "TEST_LIST";
             this.testListMenuItem.Text = "Test List";
-            // 
-            // toolStripSeparator13
-            // 
-            this.toolStripSeparator13.Name = "toolStripSeparator13";
-            this.toolStripSeparator13.Size = new System.Drawing.Size(195, 6);
+            this.testListMenuItem.DropDownItems.AddRange(new ToolStripItem[] { textListUngroupedMenuItem, textListByAssemblyMenuItem, textListByFixtureMenuItem, textListByCategoryMenuItem, textListByOutcomeMenuItem, textListByDurationMenuItem });
+            this.testListMenuItem.CheckedChanged += DisplayFormatTestListChanged;
             //
-            // ungroupedMenuItem
+            // textListUngroupedMenuItem
             //
-            this.ungroupedMenuItem.Name = "ungroupedMenuItem";
-            this.ungroupedMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.ungroupedMenuItem.Tag = "UNGROUPED";
-            this.ungroupedMenuItem.Text = "Simple List";
+            this.textListUngroupedMenuItem.Name = "textListUngroupedMenuItem";
+            this.textListUngroupedMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListUngroupedMenuItem.Tag = "UNGROUPED";
+            this.textListUngroupedMenuItem.Text = "Simple List";
+            this.textListUngroupedMenuItem.Visible = false;
             // 
-            // byAssemblyMenuItem
+            // textListByAssemblyMenuItem
             // 
-            this.byAssemblyMenuItem.Name = "byAssemblyMenuItem";
-            this.byAssemblyMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byAssemblyMenuItem.Tag = "ASSEMBLY";
-            this.byAssemblyMenuItem.Text = "By Assembly";
+            this.textListByAssemblyMenuItem.Name = "textListByAssemblyMenuItem";
+            this.textListByAssemblyMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListByAssemblyMenuItem.Tag = "ASSEMBLY";
+            this.textListByAssemblyMenuItem.Text = "By Assembly";
+            this.textListByAssemblyMenuItem.Visible = false;
             // 
-            // byFixtureMenuItem
+            // textListByFixtureMenuItem
             // 
-            this.byFixtureMenuItem.Name = "byFixtureMenuItem";
-            this.byFixtureMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byFixtureMenuItem.Tag = "FIXTURE";
-            this.byFixtureMenuItem.Text = "By Fixture";
+            this.textListByFixtureMenuItem.Name = "textListByFixtureMenuItem";
+            this.textListByFixtureMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListByFixtureMenuItem.Tag = "FIXTURE";
+            this.textListByFixtureMenuItem.Text = "By Fixture";
+            this.textListByFixtureMenuItem.Visible = false;
             // 
-            // byCategoryMenuItem
+            // textListByCategoryMenuItem
             // 
-            this.byCategoryMenuItem.Name = "byCategoryMenuItem";
-            this.byCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byCategoryMenuItem.Tag = "CATEGORY";
-            this.byCategoryMenuItem.Text = "By Category";
+            this.textListByCategoryMenuItem.Name = "textListByCategoryMenuItem";
+            this.textListByCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListByCategoryMenuItem.Tag = "CATEGORY";
+            this.textListByCategoryMenuItem.Text = "By Category";
+            this.textListByCategoryMenuItem.Visible = false;
             // 
-            // byOutcomeMenuItem
+            // textListByOutcomeMenuItem
             // 
-            this.byOutcomeMenuItem.Name = "byOutcomeMenuItem";
-            this.byOutcomeMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byOutcomeMenuItem.Tag = "OUTCOME";
-            this.byOutcomeMenuItem.Text = "By Outcome";
+            this.textListByOutcomeMenuItem.Name = "textListByOutcomeMenuItem";
+            this.textListByOutcomeMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListByOutcomeMenuItem.Tag = "OUTCOME";
+            this.textListByOutcomeMenuItem.Text = "By Outcome";
+            this.textListByOutcomeMenuItem.Visible = false;
             // 
-            // byDurationMenuItem
+            // textListByDurationMenuItem
             // 
-            this.byDurationMenuItem.Name = "byDurationMenuItem";
-            this.byDurationMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.byDurationMenuItem.Tag = "DURATION";
-            this.byDurationMenuItem.Text = "By Duration";
+            this.textListByDurationMenuItem.Name = "textListByDurationMenuItem";
+            this.textListByDurationMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.textListByDurationMenuItem.Tag = "DURATION";
+            this.textListByDurationMenuItem.Text = "By Duration";
+            this.textListByDurationMenuItem.Visible = false;
+            //
+            // fixtureListUngroupedMenuItem
+            //
+            this.fixtureListUngroupedMenuItem.Name = "fixtureListUngroupedMenuItem";
+            this.fixtureListUngroupedMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.fixtureListUngroupedMenuItem.Tag = "UNGROUPED";
+            this.fixtureListUngroupedMenuItem.Text = "Simple List";
+            this.fixtureListUngroupedMenuItem.Visible = false;
+            // 
+            // fixtureListByCategoryMenuItem
+            // 
+            this.fixtureListByCategoryMenuItem.Name = "fixtureListByCategoryMenuItem";
+            this.fixtureListByCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.fixtureListByCategoryMenuItem.Tag = "CATEGORY";
+            this.fixtureListByCategoryMenuItem.Text = "By Category";
+            this.fixtureListByCategoryMenuItem.Visible = false;
+            // 
+            // fixtureListByOutcomeMenuItem
+            // 
+            this.fixtureListByOutcomeMenuItem.Name = "fixtureListByOutcomeMenuItem";
+            this.fixtureListByOutcomeMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.fixtureListByOutcomeMenuItem.Tag = "OUTCOME";
+            this.fixtureListByOutcomeMenuItem.Text = "By Outcome";
+            this.fixtureListByOutcomeMenuItem.Visible = false;
+            // 
+            // fixtureListByDurationMenuItem
+            // 
+            this.fixtureListByDurationMenuItem.Name = "fixtureListByDurationMenuItem";
+            this.fixtureListByDurationMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.fixtureListByDurationMenuItem.Tag = "DURATION";
+            this.fixtureListByDurationMenuItem.Text = "By Duration";
+            this.fixtureListByDurationMenuItem.Visible = false;
             // 
             // showFilterButton
             // 
@@ -1073,12 +1111,29 @@ namespace TestCentric.Gui.Views
 
         private void DisplayFormatNUnitTreeChanged(object sender, EventArgs e)
         {
-            this.nunitTreeMenuItem.DropDownItems.Clear();
-            if (nunitTreeMenuItem.Checked)
-            {
-                this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+            nunitTreeShowNamespaceMenuItem.Visible = nunitTreeMenuItem.Checked;
+            if (nunitTreeMenuItem.Checked && nunitTreeMenuItem.Visible)
                 this.nunitTreeMenuItem.DropDown.Show();
-            }
+        }
+
+        private void DisplayFormatFixtureListChanged(object sender, EventArgs e)
+        {
+            fixtureListUngroupedMenuItem.Visible = fixtureListByCategoryMenuItem.Visible = fixtureListByOutcomeMenuItem.Visible = fixtureListByDurationMenuItem.Visible = fixtureListMenuItem.Checked;
+            if (fixtureListMenuItem.Checked && fixtureListMenuItem.Visible)
+                fixtureListMenuItem.DropDown.Show();
+        }
+
+        private void DisplayFormatTestListChanged(object sender, EventArgs e)
+        {
+            textListUngroupedMenuItem.Visible =
+            textListByAssemblyMenuItem.Visible =
+            textListByFixtureMenuItem.Visible =
+            textListByCategoryMenuItem.Visible =
+            textListByOutcomeMenuItem.Visible =
+            textListByDurationMenuItem.Visible = testListMenuItem.Checked;
+
+            if (testListMenuItem.Checked && testListMenuItem.Visible)
+                this.testListMenuItem.DropDown.Show();
         }
 
         #endregion
@@ -1162,7 +1217,10 @@ namespace TestCentric.Gui.Views
 
         public IViewElement DisplayFormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
-        public ISelection GroupBy { get; private set; }
+        public ISelection TestListGroupBy { get; private set; }
+
+        public ISelection FixtureListGroupBy { get; private set; }
+
         public IChecked ShowNamespace { get; private set; }
 
         public IChecked ShowHideFilterButton { get; private set; }

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -283,15 +283,27 @@ namespace TestCentric.Gui.Presenters.Main
         //}
 
         [Test]
-        public void GroupByChange_ChangesModelSetting()
+        public void TestListGroupByChange_ChangesModelSetting()
         {
             _view.DisplayFormat.SelectedItem.Returns("TEST_LIST");
-            _view.GroupBy.SelectedItem.Returns("OUTCOME");
-            _view.GroupBy.SelectionChanged += Raise.Event<CommandHandler>();
+            _view.TestListGroupBy.SelectedItem.Returns("OUTCOME");
+            _view.TestListGroupBy.SelectionChanged += Raise.Event<CommandHandler>();
 
             // FakeSettings saves the setting so we can check if it was set
             var setting = (string)_model.Settings.GetSetting("Gui.TestTree.TestList.GroupBy");
             Assert.That(setting, Is.EqualTo("OUTCOME"));
+        }
+
+        [Test]
+        public void FixtureListGroupByChange_ChangesModelSetting()
+        {
+            _view.DisplayFormat.SelectedItem.Returns("FIXTURE_LIST");
+            _view.FixtureListGroupBy.SelectedItem.Returns("CATEGORY");
+            _view.FixtureListGroupBy.SelectionChanged += Raise.Event<CommandHandler>();
+
+            // FakeSettings saves the setting so we can check if it was set
+            var setting = (string)_model.Settings.GetSetting("Gui.TestTree.FixtureList.GroupBy");
+            Assert.That(setting, Is.EqualTo("CATEGORY"));
         }
 
         [Test]

--- a/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -65,7 +65,7 @@ namespace TestCentric.Gui.Presenters.Main
         [TestCase("ASSEMBLY")]
         [TestCase("CATEGORY")]
         [TestCase("OUTCOME")]
-        public void CheckMenu_GroupBy_SelectedItem_FixtureList_IsInitialzedFromSettings(string groupBy)
+        public void CheckMenu_FixtureListGroupBy_SelectedItem_FixtureList_IsInitialzedFromSettings(string groupBy)
         {
             // 1. Arrange
             _settings.Gui.TestTree.DisplayFormat = "FIXTURE_LIST";
@@ -75,13 +75,13 @@ namespace TestCentric.Gui.Presenters.Main
             _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
 
             // 3. Assert
-            _view.GroupBy.Received().SelectedItem = groupBy;
+            _view.FixtureListGroupBy.Received().SelectedItem = groupBy;
         }
 
         [TestCase("ASSEMBLY")]
         [TestCase("CATEGORY")]
         [TestCase("OUTCOME")]
-        public void CheckMenu_GroupBy_SelectedItem_TestList_IsInitialzedFromSettings(string groupBy)
+        public void CheckMenu_TestListGroupBy_SelectedItem_TestList_IsInitialzedFromSettings(string groupBy)
         {
             // 1. Arrange
             _settings.Gui.TestTree.DisplayFormat = "TEST_LIST";
@@ -91,7 +91,7 @@ namespace TestCentric.Gui.Presenters.Main
             _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
 
             // 3. Assert
-            _view.GroupBy.Received().SelectedItem = groupBy;
+            _view.TestListGroupBy.Received().SelectedItem = groupBy;
         }
 
         [TestCase(true)]

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -32,7 +32,7 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.FixtureList.GroupBy = groupBy;
 
             // 2. Assert
-            Assert.That(_view.GroupBy.SelectedItem, Is.EqualTo(groupBy));
+            Assert.That(_view.FixtureListGroupBy.SelectedItem, Is.EqualTo(groupBy));
         }
 
         [TestCase("ASSEMBLY")]
@@ -44,7 +44,7 @@ namespace TestCentric.Gui.Presenters.Main
             _settings.Gui.TestTree.TestList.GroupBy = groupBy;
 
             // 2. Assert
-            Assert.That(_view.GroupBy.SelectedItem, Is.EqualTo(groupBy));
+            Assert.That(_view.TestListGroupBy.SelectedItem, Is.EqualTo(groupBy));
         }
 
         [TestCase(true)]

--- a/src/TestCentric/tests/Views/TestCentricMainViewTests.cs
+++ b/src/TestCentric/tests/Views/TestCentricMainViewTests.cs
@@ -1,0 +1,156 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace TestCentric.Gui.Views
+{
+    [TestFixture]
+    public class TestCentricMainViewTests : ControlTester
+    {
+        [OneTimeSetUp]
+        public void CreateForm()
+        {
+            this.Control = new TestCentricMainView();
+        }
+
+        [OneTimeTearDown]
+        public void CloseForm()
+        {
+            this.Control.Dispose();
+        }
+
+        [Test]
+        public void DisplayFormat_Toolstrip_ExistsWithSubItems()
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "nunitTreeMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "fixtureListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "testListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void NUnitDisplayFormat_AllSubmenuItems_Exist(bool checkState)
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "nunitTreeMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = checkState;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "nunitTreeShowNamespaceMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void FixtureListFormat_AllSubmenuItems_Exist(bool checkState)
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "fixtureListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = checkState;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "fixtureListUngroupedMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "fixtureListByDurationMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "fixtureListByCategoryMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "fixtureListByOutcomeMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestListFormat_AllSubmenuItems_Exist(bool checkState)
+        {
+            var displayFormatbutton = GetToolStripItem<ToolStripDropDownButton>("displayFormatButton");
+            Assert.That(displayFormatbutton, Is.Not.Null);
+
+            var menuItem = GetDropDownItem<ToolStripMenuItem>(displayFormatbutton, "testListMenuItem");
+            Assert.That(menuItem, Is.Not.Null);
+
+            menuItem.Checked = checkState;
+            var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListUngroupedMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListByDurationMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListByCategoryMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListByOutcomeMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListByAssemblyMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "textListByFixtureMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+        }
+
+        T GetDropDownItem<T>(ToolStripMenuItem menuItem, string name) where T : ToolStripItem
+        {
+            foreach (ToolStripItem ctl in menuItem.DropDownItems)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        T GetDropDownItem<T>(ToolStripDropDownButton dropDownButton, string name) where T : ToolStripItem
+        {
+            foreach (ToolStripItem ctl in dropDownButton.DropDownItems)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        T GetToolStripItem<T>(string name) where T : ToolStripItem
+        {
+            ToolStrip toolStrip = GetToolStrip();
+            foreach (ToolStripItem ctl in toolStrip.Items)
+            {
+                if (ctl.Name == name)
+                    return ctl as T;
+            }
+
+            return null;
+        }
+
+        ToolStrip GetToolStrip()
+        {
+            foreach (Control ctl in _control.Controls)
+            {
+                if (ctl.GetType() == typeof(ToolStrip))
+                    return ctl as ToolStrip;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This PR rearrange the grouping submenu items.
As proposed in the related issue (#1206), the grouping items are placed now as submenu items of the 'Fixture list' and 'Test list' menu item. This means that the DisplayFormat menu now only has 4 entries - here's a screenshot:
<img src="https://github.com/user-attachments/assets/b2006e2e-3a94-4264-ac9c-944c2aa9ec48" width="350">

The 'Fixture list' supports only four groupings: simple list, duration, category and outcome. The assembly grouping is removed as proposed by issue #1205. Also the fixture grouping is not shown anymore - previously it was disabled for 'Fixture list'.

The 'Test list' still supports all kind of groupings. Here's a screenshot:
<img src="https://github.com/user-attachments/assets/bdf6dd2d-28e2-4022-b661-42f6f78573f8" width="350">

These submenu items are only available if the specific display format is checked, otherwise there's no submenu for that display format. Moreover the display format menu is not getting closed automatically, if a display format is selected. Instead the submenu is shown, so that the user can immediately select his prefered grouping.

This PR closes #1205 and closes #1206.