### PR TITLE
Fix for showing test result overview for test groups

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/ErrorsAndFailuresPresenter.cs
@@ -66,6 +66,11 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.TestFinished += (TestResultEventArgs e) => OnNewResult(e.Result);
             _model.Events.SuiteFinished += (TestResultEventArgs e) => OnNewResult(e.Result);
+            _model.Events.RunFinished += (TestResultEventArgs e) =>
+            {
+                if (_selectedItem is TestGroup)
+                    InitializeTestResultSubView();
+            };
 
             _model.Events.SelectedItemChanged += (TestItemEventArgs e) =>
             {
@@ -180,8 +185,7 @@ namespace TestCentric.Gui.Presenters
 
         private void InitializeTestResultSubView()
         {
-            if (_selectedItem is TestNode testNode)
-                _testSubViewPresenter.Update(testNode);
+            _testSubViewPresenter.Update(_selectedItem);
         }
 
         private void InitializeTestOutputSubView()

--- a/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/ErrorsAndFailuresView.Designer.cs
@@ -169,6 +169,7 @@ namespace TestCentric.Gui.Views
             this.Controls.Add(this.panel1);
             this.Controls.Add(testResultSubView);
             this.Controls.Add(this.header);
+            this.BackColor = System.Drawing.SystemColors.Control;
             this.Name = "ErrorsAndFailuresView";
             this.Size = new System.Drawing.Size(496, 288);
             this.panel1.ResumeLayout(false);

--- a/src/TestCentric/testcentric.gui/Views/ITestResultSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/ITestResultSubView.cs
@@ -24,7 +24,7 @@ namespace TestCentric.Gui.Views
         /// View is separated in two section: Caption and detail section
         /// Caption section contain the overall outcome, duration and test + assertion count
         /// </summary>
-        void UpdateCaption(TestResultCounts testCounts, ResultNode result);
+        void UpdateCaption(TestResultCounts testCounts, ResultState resultState);
 
         /// <summary>
         /// View is separated in two section: Caption and detail section

--- a/src/TestCentric/testcentric.gui/Views/TestResultSubView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestResultSubView.cs
@@ -45,14 +45,14 @@ namespace TestCentric.Gui.Views
             notRunPictureBox.Image = imageSet.LoadImage("Skipped");
         }
 
-        public void UpdateCaption(TestResultCounts testCounts, ResultNode result)
+        public void UpdateCaption(TestResultCounts testCounts, ResultState resultState)
         {
             InvokeIfRequired(() =>
             {
                 testCount.Text = testCounts.TestCount.ToString();
-                outcome.Text = result?.Outcome.ToString();
-                duration.Text = result?.Duration.ToString("f3");
-                assertCount.Text = result?.AssertCount.ToString();
+                outcome.Text = resultState?.ToString();
+                duration.Text = testCounts.Duration.ToString("f3");
+                assertCount.Text = testCounts.AssertCount.ToString();
             });
         }
 
@@ -96,22 +96,6 @@ namespace TestCentric.Gui.Views
                 // 3. Expand height of view to show detail section
                 Height = detailSectionFlowLayoutPanel.Bottom + 10;
             });
-        }
-
-        private Image LoadAlternateImage(string name, string imageDir)
-        {
-            string[] extensions = { ".png", ".jpg" };
-
-            foreach (string ext in extensions)
-            {
-                string filePath = Path.Combine(imageDir, name + ext);
-                if (File.Exists(filePath))
-                {
-                    return Image.FromFile(filePath);
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -233,13 +233,13 @@ namespace TestCentric.Gui.Presenters
         }
 
         [Test]
-        public void WhenSelectedItemChanged_ToTestItem_TestResultSubView_IsNotUpdated()
+        public void WhenSelectedItemChanged_ToTestItem_TestResultSubView_IsUpdated()
         {
             ITestItem testItem = Substitute.For<ITestItem>();
 
             _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testItem));
 
-            _testResultPresenter.DidNotReceiveWithAnyArgs().Update(null);
+            _testResultPresenter.Received().Update(testItem);
         }
 
         [Test]
@@ -314,6 +314,44 @@ namespace TestCentric.Gui.Presenters
 
             _view.TestOutputSubView.Received().Output = "Hello world";
         }
+
+        [Test]
+        public void WhenTestRunFinishes_SelectedNodeIsGroup_TestResultSubView_IsUpdated()
+        {
+            // Arrange
+            TestNode testItem = new TestNode("<test-case id='1' name='TestA' />");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' />");
+            _model.GetResultForTest("1").Returns(resultNode);
+
+            TestGroup testGroup = new TestGroup("TestGroup") { testItem };
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testGroup));
+            _testResultPresenter.ClearReceivedCalls();
+
+            // Act
+            FireRunFinishedEvent(resultNode);
+
+            // Assert
+            _testResultPresenter.Received().Update(testGroup);
+        }
+
+        [Test]
+        public void WhenTestRunFinishes_SelectedNodeIsTestNode_TestResultSubView_IsNotUpdated()
+        {
+            // Arrange
+            TestNode testItem = new TestNode("<test-case id='1' name='TestA' />");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' />");
+            _model.GetResultForTest("1").Returns(resultNode);
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testItem));
+            _testResultPresenter.ClearReceivedCalls();
+
+            // Act
+            FireRunFinishedEvent(resultNode);
+
+            // Assert
+            _testResultPresenter.DidNotReceiveWithAnyArgs().Update(testItem);
+        }
+
+
 
         private void VerifyDisplay(bool shouldDisplay)
         {

--- a/src/TestCentric/tests/Presenters/TestResultCountsTests.cs
+++ b/src/TestCentric/tests/Presenters/TestResultCountsTests.cs
@@ -154,5 +154,90 @@ namespace TestCentric.Gui.Presenters
             Assert.That(resultCounts.NotRunCount, Is.EqualTo(0));
             Assert.That(resultCounts.TestCount, Is.EqualTo(3));
         }
+
+        [Test]
+        public void TestGroupNode_WithoutResult_ReturnsExpectedCount()
+        {
+            // 1. Arrange
+            TestNode testNode = new TestNode("<test-case id='1' />");
+            TestGroup testGroup = new TestGroup("TestGroup") { testNode };
+            ITestModel model = Substitute.For<ITestModel>();
+            model.GetResultForTest("1").Returns((ResultNode)null);
+
+            // 2. Act
+            TestResultCounts resultCounts = TestResultCounts.GetResultCounts(model, testGroup);
+
+            // 3. Assert
+            Assert.That(resultCounts.IgnoreCount, Is.EqualTo(0));
+            Assert.That(resultCounts.ExplicitCount, Is.EqualTo(0));
+
+            Assert.That(resultCounts.PassedCount, Is.EqualTo(0));
+            Assert.That(resultCounts.FailedCount, Is.EqualTo(0));
+            Assert.That(resultCounts.WarningCount, Is.EqualTo(0));
+            Assert.That(resultCounts.InconclusiveCount, Is.EqualTo(0));
+            Assert.That(resultCounts.NotRunCount, Is.EqualTo(1));
+            Assert.That(resultCounts.TestCount, Is.EqualTo(1));
+            Assert.That(resultCounts.AssertCount, Is.EqualTo(0));
+            Assert.That(resultCounts.Duration, Is.EqualTo(0.0).Within(0.001));
+        }
+
+        [Test]
+        public void TestGroupNode_WithoutChildNodes_ReturnsExpectedCount()
+        {
+            // 1. Arrange
+            TestGroup testGroup = new TestGroup("TestGroup");
+            ITestModel model = Substitute.For<ITestModel>();
+
+            // 2. Act
+            TestResultCounts resultCounts = TestResultCounts.GetResultCounts(model, testGroup);
+
+            // 3. Assert
+            Assert.That(resultCounts.IgnoreCount, Is.EqualTo(0));
+            Assert.That(resultCounts.ExplicitCount, Is.EqualTo(0));
+
+            Assert.That(resultCounts.PassedCount, Is.EqualTo(0));
+            Assert.That(resultCounts.FailedCount, Is.EqualTo(0));
+            Assert.That(resultCounts.WarningCount, Is.EqualTo(0));
+            Assert.That(resultCounts.InconclusiveCount, Is.EqualTo(0));
+            Assert.That(resultCounts.NotRunCount, Is.EqualTo(0));
+            Assert.That(resultCounts.TestCount, Is.EqualTo(0));
+            Assert.That(resultCounts.AssertCount, Is.EqualTo(0));
+            Assert.That(resultCounts.Duration, Is.EqualTo(0.0).Within(0.001));
+        }
+
+        [Test]
+        public void TestGroupNode_WithOutcome_ReturnsExpectedCount()
+        {
+            // 1. Arrange
+            TestNode testNode1 = new TestNode("<test-case id='1' />");
+            ResultNode resultNode1 = new ResultNode($"<test-case id='1' result='Passed' asserts='2' duration='1.0'/>");
+
+            TestNode testNode2 = new TestNode("<test-case id='2' />");
+            ResultNode resultNode2 = new ResultNode($"<test-case id='2' result='Failed' asserts='3' duration='1.0'/>");
+
+            ITestModel model = Substitute.For<ITestModel>();
+            model.GetResultForTest("1").Returns(resultNode1);
+            model.GetResultForTest("2").Returns(resultNode2);
+
+            TestGroup testGroup = new TestGroup("TestGroup") { testNode1, testNode2 };
+
+            // 2. Act
+            TestResultCounts resultCounts = TestResultCounts.GetResultCounts(model, testGroup);
+
+            // 3. Assert
+            Assert.That(resultCounts.PassedCount, Is.EqualTo(1));
+            Assert.That(resultCounts.FailedCount, Is.EqualTo(1));
+            Assert.That(resultCounts.WarningCount, Is.EqualTo(0));
+            Assert.That(resultCounts.InconclusiveCount, Is.EqualTo(0));
+
+            Assert.That(resultCounts.IgnoreCount, Is.EqualTo(0));
+            Assert.That(resultCounts.ExplicitCount, Is.EqualTo(0));
+            Assert.That(resultCounts.NotRunCount, Is.EqualTo(0));
+            Assert.That(resultCounts.TestCount, Is.EqualTo(2));
+
+            Assert.That(resultCounts.AssertCount, Is.EqualTo(5));
+            Assert.That(resultCounts.Duration, Is.EqualTo(2.0).Within(0.001));
+
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/TestResultSubViewPresenterTests.cs
+++ b/src/TestCentric/tests/Presenters/TestResultSubViewPresenterTests.cs
@@ -50,7 +50,7 @@ namespace TestCentric.Gui.Presenters
             presenter.Update(testNode);
 
             // 3. Assert
-            view.Received().UpdateCaption(Arg.Any<TestResultCounts>(), resultNode);
+            view.Received().UpdateCaption(Arg.Any<TestResultCounts>(), Model.ResultState.Success);
             view.Received().UpdateDetailSectionVisibility(false);
             view.Received().ShrinkToCaption();
         }


### PR DESCRIPTION
This PR contributes to the previous work done for #1191 and #1193.
That work shows the test results of a selected tree node in the 'Test result tab'. However it did not work yet, if a **TestGroup** node was selected. In particular if the Tree is grouped and a category node or outcome node is selected.
Here's a screenshot: 
<img src="https://github.com/user-attachments/assets/477639c2-bfd3-46f6-b6be-aaca03956fcf" width="700">

This PR solves the described behavior for TestGroup.
