### PR TITLE
Fix presence of different .Net versions of a IDriverFactory extension

### DIFF
--- a/src/TestEngine/testcentric.engine.core/Services/ExtensionService.cs
+++ b/src/TestEngine/testcentric.engine.core/Services/ExtensionService.cs
@@ -338,6 +338,13 @@ namespace TestCentric.Engine.Services
                 {
                     var candidate = new ExtensionAssembly(filePath, fromWildCard);
 
+                    if (!CanLoadTargetFramework(Assembly.GetEntryAssembly(), candidate))
+                    {
+                        log.Debug("  Unable to load this assembly");
+                        return;
+                    }
+
+
                     for (int i = 0; i < _assemblies.Count; i++)
                     {
                         var assembly = _assemblies[i];


### PR DESCRIPTION
This PR contains a proposal for fixing #1220 in TestCentric **1.7.0**

The crucial question, however, is whether we actually want to have a new release 1.7.1 at all.
The arguments in favor would be that this issue is currently blocking: As described in the issue the extension works fine using NUnit console, but TestCentric fails to use the extension at all now. That means that TestCentric can no longer run .Net 4.8 tests - the presence of the Net80 folder (containing the DriverFactory for Net80) is already sufficient that TestCentric cannot load a Net48 test using its DriverFactory.

The other option would be to fix this only in version 2.0. However I think a TestCentric 2.0 release is not expected in the near future and we also already noticed that some further work is required to support extensions in 2.0 in general (#1088).

This PR solves only the crucial part of the issue: to load Net48 tests using its DriverFactory even if a Net80 version of that DriverFactory exists.