### PR TITLE
Fix deadlock when stopping test run (force mode)

### DIFF
--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -16,6 +16,7 @@ using TestCentric.Engine.Services;
 namespace TestCentric.Gui.Model
 {
     using System.Runtime.InteropServices;
+    using System.Threading.Tasks;
     using Services;
     using Settings;
     using TestCentric.Gui.Model.Filter;
@@ -545,7 +546,8 @@ namespace TestCentric.Gui.Model
 
         public void StopTestRun(bool force)
         {
-            Runner.StopRun(force);
+            // Async to avoid blocking the main thread for incoming test events in between
+            Task.Run(() => Runner.StopRun(force));
         }
 
         public void SaveResults(string filePath, string format = "nunit3")


### PR DESCRIPTION
This PR fixes #1164 by invoking the `Runner.StopRun()` async now and thus not blocking the UI thread anymore.

The root cause of this deadlock is already explained in the issue itself: while executing the StopRun() command a test event is triggered in between. The test event handler requires the main thread to update the UI, however the main thread (currently executing StopRun) requires a lock to process some pending notifications - unfortunately this lock is currently possessed by the test event thread (see also screenshots in the issue).

The fix wraps the `Runner.StopRun()` command into a `Task.Run()` block. So the UI thread is not blocked anymore and the incoming test event can be processed.

Although the problem sounds like a rare use case, surprisingly I observe it quite regularly. However only when using a synthetical test project which I created to simulate a huge number of test fixtures/test cases. In that test project all tests only contain a Assert.IsTrue(true) statement. So they are executed really fast and it might occur more frequently than in a real-world project that a test event is triggered while StopRun is executed.

I also noticed that the first click on 'Stop' test run has no effect in this project. The tests are continuing to be executed until the end without stopping in between. I debugged also this use case, until the point when the stop run is passed to the NUnit framework. So I assume it's not a TestCentric issue.
