### PR TITLE
Add NUnitTree grouping 

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -52,7 +52,7 @@ namespace TestCentric.Gui.Presenters
             _view.EnableTestFilter(true);
         }
 
-        protected override VisualState CreateVisualState() => new VisualState("NUNIT_TREE", _settings.Gui.TestTree.ShowNamespace).LoadFrom(_view.TreeView);
+        protected override VisualState CreateVisualState() => new VisualState("NUNIT_TREE", _settings.Gui.TestTree.NUnitGroupBy, _settings.Gui.TestTree.ShowNamespace).LoadFrom(_view.TreeView);
 
         protected override string GetTreeNodeName(TestNode testNode)
         {

--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -239,6 +239,9 @@ namespace TestCentric.Gui.Presenters
                         UpdateTreeDisplayMenuItem();
                         UpdateViewCommands();
                         break;
+                    case "TestCentric.Gui.TestTree.NUnitGroupBy":
+                        _view.NUnitGroupBy.SelectedItem = _settings.Gui.TestTree.NUnitGroupBy;
+                        break;
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                         _view.TestListGroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
                         break;
@@ -463,6 +466,11 @@ namespace TestCentric.Gui.Presenters
             _view.ShowHideFilterButton.CheckedChanged += () =>
             {
                 _settings.Gui.TestTree.ShowFilter = _view.ShowHideFilterButton.Checked;
+            };
+
+            _view.NUnitGroupBy.SelectionChanged += () =>
+            {
+                _settings.Gui.TestTree.NUnitGroupBy = _view.NUnitGroupBy.SelectedItem;
             };
 
             _view.TestListGroupBy.SelectionChanged += () =>
@@ -916,6 +924,9 @@ namespace TestCentric.Gui.Presenters
 
             switch (displayFormat)
             {
+                case "NUNIT_TREE":
+                    _view.NUnitGroupBy.SelectedItem = _settings.Gui.TestTree.NUnitGroupBy;
+                    break;
                 case "TEST_LIST":
                     _view.TestListGroupBy.SelectedItem = _settings.Gui.TestTree.TestList.GroupBy;
                     break;

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -133,6 +133,7 @@ namespace TestCentric.Gui.Presenters
                         Strategy.Reload();
                         break;
 
+                    case "TestCentric.Gui.TestTree.NUnitGroupBy":
                     case "TestCentric.Gui.TestTree.TestList.GroupBy":
                     case "TestCentric.Gui.TestTree.FixtureList.GroupBy":
                     case "TestCentric.Gui.TestTree.ShowNamespace":
@@ -338,7 +339,11 @@ namespace TestCentric.Gui.Presenters
         private void UpdateTreeSettingsFromVisualState(VisualState visualState)
         {
             _treeSettings.DisplayFormat = visualState.DisplayStrategy;
-            if (visualState.DisplayStrategy == "TEST_LIST")
+            if (visualState.DisplayStrategy == "NUNIT_TREE")
+            {
+                _treeSettings.NUnitGroupBy = visualState.GroupBy;
+            }
+            else if (visualState.DisplayStrategy == "TEST_LIST")
             {
                 _treeSettings.TestList.GroupBy = visualState.GroupBy;
             }

--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -76,7 +76,7 @@ namespace TestCentric.Gui.Views
         IViewElement DisplayFormatButton { get; }
         ISelection DisplayFormat { get; }
         ISelection TestListGroupBy { get; }
-
+        ISelection NUnitGroupBy { get; }
         ISelection FixtureListGroupBy { get; }
 
         IChecked ShowNamespace { get; }

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -88,6 +88,11 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem fixtureListMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespaceMenuItem;
+        private ToolStripSeparator nunitTreeSeparator;
+        private ToolStripMenuItem nunitTreeUngroupedMenuItem;
+        private ToolStripMenuItem nunitTreeByCategoryMenuItem;
+        private ToolStripMenuItem nunitTreeByOutcomeMenuItem;
+        private ToolStripMenuItem nunitTreeByDurationMenuItem;
         private ToolStripMenuItem textListUngroupedMenuItem;
         private ToolStripMenuItem textListByAssemblyMenuItem;
         private ToolStripMenuItem textListByFixtureMenuItem;
@@ -176,6 +181,9 @@ namespace TestCentric.Gui.Views
             DisplayFormat = new CheckedToolStripMenuGroup(
                 "displayFormat",
                 nunitTreeMenuItem, fixtureListMenuItem, testListMenuItem);
+            NUnitGroupBy = new CheckedToolStripMenuGroup(
+                "NUnitGroupBy",
+                nunitTreeUngroupedMenuItem, nunitTreeByCategoryMenuItem, nunitTreeByOutcomeMenuItem, nunitTreeByDurationMenuItem);
             TestListGroupBy = new CheckedToolStripMenuGroup(
                 "TestListGroupBy",
                 textListUngroupedMenuItem, textListByAssemblyMenuItem, textListByFixtureMenuItem, textListByCategoryMenuItem, textListByOutcomeMenuItem, textListByDurationMenuItem);
@@ -224,6 +232,11 @@ namespace TestCentric.Gui.Views
             this.fixtureListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespaceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.nunitTreeUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeByCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeByOutcomeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeByDurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.textListUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fixtureListUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.textListByAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -412,21 +425,13 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton.ToolTipText = "Tree Display Format";
             this.displayFormatButton.DropDown.Closing += DisplayFormatDropDown_Closing;
             // 
-            // nunitTreeShowNamespaceMenuItem
-            // 
-            this.nunitTreeShowNamespaceMenuItem.Name = "nunitTreeShowNamespaceMenuItem";
-            this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
-            this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
-            this.nunitTreeShowNamespaceMenuItem.Visible = false;
-            // 
             // nunitTreeMenuItem
             // 
             this.nunitTreeMenuItem.Name = "nunitTreeMenuItem";
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(141, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
             this.nunitTreeMenuItem.Text = "NUnit Tree";
-            this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem });
+            this.nunitTreeMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nunitTreeShowNamespaceMenuItem, nunitTreeSeparator, nunitTreeUngroupedMenuItem, nunitTreeByCategoryMenuItem, nunitTreeByOutcomeMenuItem, nunitTreeByDurationMenuItem });
             this.nunitTreeMenuItem.CheckedChanged += DisplayFormatNUnitTreeChanged;
             // 
             // fixtureListMenuItem
@@ -446,6 +451,50 @@ namespace TestCentric.Gui.Views
             this.testListMenuItem.Text = "Test List";
             this.testListMenuItem.DropDownItems.AddRange(new ToolStripItem[] { textListUngroupedMenuItem, textListByAssemblyMenuItem, textListByFixtureMenuItem, textListByCategoryMenuItem, textListByOutcomeMenuItem, textListByDurationMenuItem });
             this.testListMenuItem.CheckedChanged += DisplayFormatTestListChanged;
+            // nunitTreeShowNamespaceMenuItem
+            // 
+            this.nunitTreeShowNamespaceMenuItem.Name = "nunitTreeShowNamespaceMenuItem";
+            this.nunitTreeShowNamespaceMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeShowNamespaceMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
+            this.nunitTreeShowNamespaceMenuItem.Text = "Show Namespace";
+            this.nunitTreeShowNamespaceMenuItem.Visible = false;
+            // 
+            // nunitTreeSeparator
+            // 
+            this.nunitTreeSeparator.Name = "nunitTreeSeparator";
+            this.nunitTreeSeparator.Size = new System.Drawing.Size(184, 6);
+            //
+            // nunitTreeUngroupedMenuItem
+            //
+            this.nunitTreeUngroupedMenuItem.Name = "nunitTreeUngroupedMenuItem";
+            this.nunitTreeUngroupedMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeUngroupedMenuItem.Tag = "UNGROUPED";
+            this.nunitTreeUngroupedMenuItem.Text = "No grouping";
+            this.nunitTreeUngroupedMenuItem.Visible = false;
+            //
+            // nunitTreeByCategoryMenuItem
+            //
+            this.nunitTreeByCategoryMenuItem.Name = "nunitTreeByCategoryMenuItem";
+            this.nunitTreeByCategoryMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeByCategoryMenuItem.Tag = "CATEGORY";
+            this.nunitTreeByCategoryMenuItem.Text = "By Category";
+            this.nunitTreeByCategoryMenuItem.Visible = false;
+            //
+            // nunitTreeByOutcomeMenuItem
+            //
+            this.nunitTreeByOutcomeMenuItem.Name = "nunitTreeByOutcomeMenuItem";
+            this.nunitTreeByOutcomeMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeByOutcomeMenuItem.Tag = "OUTCOME";
+            this.nunitTreeByOutcomeMenuItem.Text = "By Outcome";
+            this.nunitTreeByOutcomeMenuItem.Visible = false;
+            //
+            // nunitTreeByDurationMenuItem
+            //
+            this.nunitTreeByDurationMenuItem.Name = "nunitTreeByDurationMenuItem";
+            this.nunitTreeByDurationMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.nunitTreeByDurationMenuItem.Tag = "DURATION";
+            this.nunitTreeByDurationMenuItem.Text = "By Duration";
+            this.nunitTreeByDurationMenuItem.Visible = false;
             //
             // textListUngroupedMenuItem
             //
@@ -1085,7 +1134,12 @@ namespace TestCentric.Gui.Views
 
         private void DisplayFormatNUnitTreeChanged(object sender, EventArgs e)
         {
-            nunitTreeShowNamespaceMenuItem.Visible = nunitTreeMenuItem.Checked;
+            nunitTreeShowNamespaceMenuItem.Visible =
+            nunitTreeSeparator.Visible =
+            nunitTreeUngroupedMenuItem.Visible =
+            nunitTreeByCategoryMenuItem.Visible =
+            nunitTreeByOutcomeMenuItem.Visible =
+            nunitTreeByDurationMenuItem.Visible = nunitTreeMenuItem.Checked;
             if (nunitTreeMenuItem.Checked && nunitTreeMenuItem.Visible)
                 this.nunitTreeMenuItem.DropDown.Show();
         }
@@ -1191,8 +1245,8 @@ namespace TestCentric.Gui.Views
 
         public IViewElement DisplayFormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
+        public ISelection NUnitGroupBy { get; private set; }
         public ISelection TestListGroupBy { get; private set; }
-
         public ISelection FixtureListGroupBy { get; private set; }
 
         public IChecked ShowNamespace { get; private set; }

--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -30,9 +30,10 @@ namespace TestCentric.Gui
             DisplayStrategy = strategyID;
         }
 
-        public VisualState(string strategyID, bool showNamespace)
+        public VisualState(string strategyID, string groupID, bool showNamespace)
         {
             DisplayStrategy = strategyID;
+            GroupBy = groupID;
             ShowNamespace = showNamespace;
         }
 

--- a/src/TestCentric/tests/Presenters/Main/CommandTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/CommandTests.cs
@@ -270,17 +270,16 @@ namespace TestCentric.Gui.Presenters.Main
             _model.Received().RunTests(Arg.Any<TestSelection>());
         }
 
-        //// TODO: No longer a setting, replace with change to VisualState
-        //[Test]
-        //public void DisplayFormatChange_ChangesModelSetting()
-        //{
-        //    _view.DisplayFormat.SelectedItem.Returns("TEST_LIST");
-        //    _view.DisplayFormat.SelectionChanged += Raise.Event<CommandHandler>();
+        [Test]
+        public void DisplayFormatChange_ChangesModelSetting()
+        {
+            _view.DisplayFormat.SelectedItem.Returns("TEST_LIST");
+            _view.DisplayFormat.SelectionChanged += Raise.Event<CommandHandler>();
 
-        //    // FakeSettings saves the setting so we can check if it was set
-        //    var setting = (string)_model.Settings.GetSetting("Gui.TestTree.DisplayFormat");
-        //    Assert.That(setting, Is.EqualTo("TEST_LIST"));
-        //}
+            // FakeSettings saves the setting so we can check if it was set
+            var setting = (string)_model.Settings.GetSetting("Gui.TestTree.DisplayFormat");
+            Assert.That(setting, Is.EqualTo("TEST_LIST"));
+        }
 
         [Test]
         public void TestListGroupByChange_ChangesModelSetting()
@@ -303,6 +302,18 @@ namespace TestCentric.Gui.Presenters.Main
 
             // FakeSettings saves the setting so we can check if it was set
             var setting = (string)_model.Settings.GetSetting("Gui.TestTree.FixtureList.GroupBy");
+            Assert.That(setting, Is.EqualTo("CATEGORY"));
+        }
+
+        [Test]
+        public void NUnitTreeGroupByChange_ChangesModelSetting()
+        {
+            _view.DisplayFormat.SelectedItem.Returns("NUNIT_TREE");
+            _view.NUnitGroupBy.SelectedItem.Returns("CATEGORY");
+            _view.NUnitGroupBy.SelectionChanged += Raise.Event<CommandHandler>();
+
+            // FakeSettings saves the setting so we can check if it was set
+            var setting = (string)_model.Settings.GetSetting("Gui.TestTree.NUnitGroupBy");
             Assert.That(setting, Is.EqualTo("CATEGORY"));
         }
 

--- a/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -62,6 +62,23 @@ namespace TestCentric.Gui.Presenters.Main
             _view.DisplayFormat.Received().SelectedItem = displayFormat;
         }
 
+        [TestCase("UNGROUPED")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        [TestCase("DURATION")]
+        public void CheckMenu_NUnitTreeGroupBy_SelectedItem_IsInitializedFromSettings(string groupBy)
+        {
+            // 1. Arrange
+            _settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
+            _settings.Gui.TestTree.NUnitGroupBy = groupBy;
+
+            // 2. Act
+            _presenter = new TestCentricPresenter(_view, _model, new CommandLineOptions());
+
+            // 3. Assert
+            _view.NUnitGroupBy.Received().SelectedItem = groupBy;
+        }
+
         [TestCase("ASSEMBLY")]
         [TestCase("CATEGORY")]
         [TestCase("OUTCOME")]

--- a/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenSettingsChanged.cs
@@ -23,6 +23,19 @@ namespace TestCentric.Gui.Presenters.Main
             Assert.That(_view.DisplayFormat.SelectedItem, Is.EqualTo(displayFormat));
         }
 
+        [TestCase("UNGROUPED")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        [TestCase("DURATION")]
+        public void NUnitTreeGroupBy_SettingChanged_MenuItemIsUpdated(string groupBy)
+        {
+            // 1. Act
+            _settings.Gui.TestTree.NUnitGroupBy = groupBy;
+
+            // 2. Assert
+            Assert.That(_view.NUnitGroupBy.SelectedItem, Is.EqualTo(groupBy));
+        }
+
         [TestCase("ASSEMBLY")]
         [TestCase("CATEGORY")]
         [TestCase("OUTCOME")]

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -126,6 +126,34 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(visualState.GroupBy, Is.EqualTo(groupBy));
         }
 
+        [TestCase("UNGROUPED")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        [TestCase("DURATION")]
+        public void WhenTestRunStarts_NUnitTree_CurrentGroupBy_IsSaved_InVisualFile(string groupBy)
+        {
+            // Arrange
+            _settings.Gui.TestTree.DisplayFormat = "NUNIT_TREE";
+            _settings.Gui.TestTree.NUnitGroupBy = groupBy;
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            var project = new TestCentricProject(_model, TestFileName);
+            _model.TestCentricProject.Returns(project);
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireRunStartingEvent(1234);
+
+            // Assert
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            VisualState visualState = VisualState.LoadFrom(fileName);
+            Assert.That(visualState.GroupBy, Is.EqualTo(groupBy));
+        }
+
         // TODO: Version 1 Test - Make it work if needed.
         //[Test]
         //public void WhenTestRunStarts_ResultsAreCleared()

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -190,6 +190,34 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_model.Settings.Gui.TestTree.DisplayFormat, Is.EqualTo(displayFormat));
         }
 
+        [TestCase("UNGROUPED")]
+        [TestCase("CATEGORY")]
+        [TestCase("OUTCOME")]
+        [TestCase("DURATION")]
+        public void TestLoaded_WithVisualState_NUnitTreeGroupBySetting_IsUpdatedFromVisualState(string groupBy)
+        {
+            // Arrange: Create and save VisualState file
+            VisualState visualState = new VisualState();
+            visualState.DisplayStrategy = "NUNIT_TREE";
+            visualState.GroupBy = groupBy;
+            string fileName = VisualState.GetVisualStateFileName(TestFileName);
+            visualState.Save(fileName);
+
+            _model.Settings.Gui.TestTree.TestList.GroupBy = "DURATION";
+
+            var tv = new TreeView();
+            _view.TreeView.Returns(tv);
+
+            // Act: Load tests
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            FireTestLoadedEvent(testNode);
+
+            // Assert
+            Assert.That(_model.Settings.Gui.TestTree.NUnitGroupBy, Is.EqualTo(groupBy));
+            Assert.That(_model.Settings.Gui.TestTree.TestList.GroupBy, Is.EqualTo("DURATION"));     // Assert that testList groupBy was not changed accidently
+        }
+
         [TestCase("ASSEMBLY")]
         [TestCase("CATEGORY")]
         [TestCase("OUTCOME")]

--- a/src/TestModel/model/Settings/TestTreeSettings.cs
+++ b/src/TestModel/model/Settings/TestTreeSettings.cs
@@ -56,6 +56,12 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(ShowNamespace), value); }
         }
 
+        public string NUnitGroupBy
+        {
+            get { return GetSetting(nameof(NUnitGroupBy), "UNGROUPED"); }
+            set { SaveSetting(nameof(NUnitGroupBy), value); }
+        }
+
         public bool ShowFilter
         {
             get { return GetSetting(nameof(ShowFilter), true); }


### PR DESCRIPTION
This PR closes #1226 by providing grouping functionality to the NUnit tree display strategy.

I plan to implement the functionality incrementally and provide separate commits for indivdual parts. So it's easier to review and comment on that parts. Here's an overview of the individual steps:

1. Extend UI + save grouping in VisualState + Setting
2. Implement grouping
3. Support folding of namespaces
4. Update tree nodes icons during/after a test run
5. Improve performance for regrouping