### PR TITLE
Fix crash when double-clicking treenode and a test is already running

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -195,7 +195,7 @@ namespace TestCentric.Gui.Presenters
             _view.TreeNodeDoubleClick += (treeNode) =>
             {
                 var testNode = treeNode.Tag as TestNode;
-                if (testNode != null && testNode.Type == "TestCase")
+                if (testNode != null && testNode.Type == "TestCase" && !_model.IsTestRunning)
                     _model.RunTests(testNode);
             };
 

--- a/src/TestCentric/tests/Presenters/TestTree/TestExecutionTests.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TestExecutionTests.cs
@@ -63,6 +63,14 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
+        public void DoubleClickOnTestCase_ATestIsRunning_DoesNotRunTest()
+        {
+            _model.IsTestRunning.Returns(true);
+            _view.TreeNodeDoubleClick += Raise.Event<TreeNodeActionHandler>(TEST_CASE_TREE_NODE);
+            _model.DidNotReceive().RunTests(Arg.Is(TEST_CASE_NODE));
+        }
+
+        [Test]
         public void DoubleClickOnTestSuiteDoesNotRunTest()
         {
             _view.TreeNodeDoubleClick += Raise.Event<TreeNodeActionHandler>(TEST_SUITE_TREE_NODE);


### PR DESCRIPTION
This PR closes #1231.
I simply add an additional check `_model.IsTestRunning` in the double-click tree node handler, before starting a new test run.