### PR TITLE
Fix sporadic crash of statusbar view

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
@@ -4,10 +4,8 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Reflection;
 using System.Windows.Forms;
 
 namespace TestCentric.Gui.Views
@@ -32,7 +30,7 @@ namespace TestCentric.Gui.Views
 
         public override string Text
         {
-            set { StatusLabel.Text = value; }
+            set { InvokeIfRequired(() => StatusLabel.Text = value); }
         }
 
         public int Passed


### PR DESCRIPTION
This PR closes #1230.

At least it's an attempt to close the issue. As I said, this crash doesn't occur regularly, so I can't say 100% that it's fixed. But at least with this code change it didn't occur anymore yet.

And that code change make sense: the statusbar view is triggered from a test event, so a sync to the main/UI thread is required to update the UI.