### PR TITLE
Statusbar initalization: fix visibility of status bar items

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/StatusBarPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/StatusBarPresenter.cs
@@ -28,7 +28,6 @@ namespace TestCentric.Gui.Presenters
         private int _inconclusiveCount;
         private int _skippedCount;
         private int _ignoredCount;
-        private int _explicitCount;
 
         private Dictionary<string, TreeNode> _nodeIndex = new Dictionary<string, TreeNode>();
 
@@ -113,13 +112,12 @@ namespace TestCentric.Gui.Presenters
 
         private void ClearCounters()
         {
-            _passedCount = 
-            _failedCount = 
-            _warningCount = 
-            _inconclusiveCount = 
-            _skippedCount = 
-            _ignoredCount =
-            _explicitCount = 0;
+            _passedCount =
+            _failedCount =
+            _warningCount =
+            _inconclusiveCount =
+            _skippedCount =
+            _ignoredCount = 0;
         }
     }
 }

--- a/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
+++ b/src/TestCentric/testcentric.gui/Views/StatusBarView.cs
@@ -23,8 +23,9 @@ namespace TestCentric.Gui.Views
         {
             InvokeIfRequired(() =>
             {
-                foreach (ToolStripStatusLabel panel in statusStrip1.Controls)
-                    panel.Visible = false;
+                foreach (ToolStripStatusLabel panel in statusStrip1.Items)
+                    if (panel != StatusLabel)
+                        panel.Visible = false;
             });
         }
 


### PR DESCRIPTION
The root cause of this issue was that the elements no longer became invisible once they became visible. 

The method `StatusbarView.Initialize()` should actually ensure that they become invisible - but there was a small flaw in the implementation. Unfortunately the property `Controls` of a StatusStrip contains no items at all, but instead it's the property `Items`. So using this property already fix this issue - as the StatusLabel should be kept always visible, it's neglected here.

The adaptation in the `StatusBarPresenter` is only to fix a compiler warning about an unsed member `_explicitCount`.


This PR closes #1229 