### PR TITLE
Add missing toolbar icon for 'reset filter' button

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.Designer.cs
@@ -1,6 +1,7 @@
 namespace TestCentric.Gui.Views
 {
     using TestCentric.Gui.Controls;
+    using TestCentric.Gui.Properties;
 
     partial class TestTreeView
     {
@@ -31,6 +32,7 @@ namespace TestCentric.Gui.Views
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TestTreeView));
             this.treeView = new System.Windows.Forms.TreeView();
             this.testTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.runMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -328,6 +330,7 @@ namespace TestCentric.Gui.Views
             // filterResetButton
             // 
             this.filterResetButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.filterResetButton.Image = ((System.Drawing.Image)(resources.GetObject("ResetFilter.Image")));
             this.filterResetButton.Name = "filterResetButton";
             this.filterResetButton.Size = new System.Drawing.Size(23, 4);
             this.filterResetButton.ToolTipText = "Reset all filters";

--- a/src/TestCentric/testcentric.gui/Views/TestTreeView.resx
+++ b/src/TestCentric/testcentric.gui/Views/TestTreeView.resx
@@ -117,16 +117,73 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="testTreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="testTreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>286, 17</value>
-  </metadata>
-  <metadata name="treeImages.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  </data>
+  <data name="treeImages.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>453, 17</value>
-  </metadata>
-  <metadata name="filterToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  </data>
+  <data name="filterToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="filterTextToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  </data>
+  <data name="filterTextToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>141, 17</value>
-  </metadata>
+  </data>
+  <data name="ResetFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAKoAAACvCAYAAABtu0UxAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAC8
+        9wAAvPcBkp5q3wAAC8lJREFUeF7tnXnsJEUZhl+Qa1dwOURAF0FMRGSVS1BZPNZgFIhBMIpEXQ+igGAE
+        wRCN5+IKasATENQAUTxQVMADF4yAsCpCVERFQUFQg4ssCgJyat5N92b49pvuqj5mpqrfJ3n+gJn+umvm
+        3f71dFVXAXHMA3AIgEsBPATgf1JG+DCAKwAcDmBTG64u2BDAcQD+5excyibeA+BEAJvYsDXllQBWODuS
+        sgtXAniNDV0MGwD4olNYyj48G8AcG8I6HgtgmVNMyj69HMDjbBjHMRfAcqeIlJPwquJEWclaAL7ibCzl
+        JP1WkcWxHO1sJOU0fKcNZ8nWAP7jbCDlNOTtq21tSMm5zpulnKbM5KPYAcAjzhulnLYLRoN6qvMGKWfB
+        U8qQrg/gLucNof4awBEAXgBgOylHZCaOBHCtk5tQmU1mFC9yXgzxAQBvq7uNIESREZ7MHnRyFOIiFlnq
+        vBDiQfZohKjhYCdHIZ7AjS90Xqjza/YIhAiE2bF5qvP73PA654U6F9q9CxHIXk6e6vwdN+QwK/tClf/W
+        daloAbMT++Od748eDP1nu2chIrnZyVWV7DHFHc4LVfL9OqOKpjA7sZlbdUa90XmhzqfZvQsRyPZOnur8
+        Cze8yHmhzs/YvQsRCHuabJ7qvJgbfsp5oc77bR+sEAEwM8yOzVOdq06Mr3BeCPG3xdMAQoTAZ/DY3W5z
+        FOIBLMBh//91XgzxNHs0QozhdCc/IbKrnvNJrOI85w2h8nFqIap4lZObUL89Wuj5zhtCvXPcSGwhiidH
+        Ym9HjcpsPoqfOm8KldO0rGMLisHzGABXOnkJlZlcg91azie1xBYUg+dQJyehMovMpMsnnA1CZWGObRWi
+        pM2AaWZxLG1uIdC/Ani8LSoGCWc8afocXtCtz2cCuM/ZONTzNRZAANjGyUaI98Z0JvERE1sgxrfbgmJw
+        cKrSJr95eF0bBadVsUVC5Rl5J1tQDI6fOdmo8hu2QAicEfgWp1iovw+Z7EpkDZ+rs7kY500ANrYFQuHN
+        1ian79Iv2IJicHzVyYX1bgC72g1j+aBTOEY9rTps1i2G9nH+fpsNytH+z7EbNYG9C5c5OwiVj7o8xRYV
+        g2OX4t4oJ+u9uvgN9JbilmhnzAfwTyeEoXJyVv7LEqJ39mtxA5d+xBYUoi/aTKbGa5S9bUEh+oDXE79y
+        QhjqbQC2tEWF6INnFLMB2xCG+gN1sYpJ8VYngDEeZQsK0RchN3LHyedgOrl3JkQd7O5it5cNYag3ANjI
+        FhWiD/Yozo42hKGeZQsK0RfvdQIY4+tsQSH6YG0AlzgBDJUDEjSXlZgITwJwuxPCUNn3u54tKkQfvLxl
+        F+vHbEHRGv61ezaA1xbz5/Mxo2mxI4DDAbynGMXPWf2mRpMJ10oZ8pfagqIxDKd3V4YPzu1r39wjvKz7
+        kXMclJ0/UxlZx/WAfukcUKjsYt3CFhXRfNz5bEflSeHddqMeeF7ALCm8ZOTZduI8veXiv5yvlX+yRDPe
+        6Hym43y/3bhDGFKu92D36fmHaf1GebNzMDG+yxYUQXDM79+cz7PKPsIaE9JSZmYqtO1i3d0WFLU0XYWx
+        y7A2CSm9wBaaFJzT8k/OAYXKtQU424YI5zDncwy1i7A2DSldtZbUtOBZsclU2KVftwVFJW2CSj9gC0bQ
+        JqSU45ynynHOQcX4BltQjKXpn/5Rm5xZ24aUnmOLThr+gueqFvbAQlUXazhNfkx5xoS1i5BSPpM3dbYC
+        8A/n4EK9plyzXdTyJufza2JIWLsK6TJbeJrs07KLtXK+TPEo2jyEOWpVWLsKKXvKOH3UTHGyc6ChMuQc
+        TyDq4TNpTRYe8/R+YHUV0uuLv7YzB6+hYmd4G3UFgCfaosKlr7BmH9KSp7Zs6KXFNEOinq7DOpiQlix2
+        Dj7GSQyoyAWG9QznM2xi04XzRuU1aVIDj77kNCLUBwHsaQuKsXR5Zm1jMmfSUTh1Ng/cNiZUTjK8iS0q
+        xjLtsCYZ0hKuI9Smi7XRVNoDZlphTTqkJcc6DYvxEFtQVDLpsGYRUsIP7kKngaFykPYOtqioZFJhzSak
+        JU8A8HenoaH+BsAcW1RU0ndYswtpyaKKed5D/LQtKGrpK6zZhrSEj0zbRofKLtb9bUFRS9dhzT6khF2s
+        P3caHyrXGeBkGCKOhS2XaRr1RFs8V7Zr2U3HFVzUxRpOV92io1aNusqKVzuNj/F9tqBw6SOkpYMJ65lO
+        40NlFyv/nInx9BnS0kGEleuocj1V2/hQb53FAbkzwiRCWjqIsHJSL65UbRsf6nm2oJhoSEsHEVYuTGEb
+        HmP0+u8ZM42QlmYfVt7nO99peKg8Iz/LFh0g0wxpafZh3bzlY8DXDbyLdRZCWpp9WF/csov1NFtwIHQV
+        Uk65w8VB7P9vYva3D7nwr210jAfZgpnTVUjLbtEuu1uzPrOuA+BKp9Gh3glgG1s0U7oOaYnCGsi2ReBs
+        o0P9yQC6WLsKKf/cew/idfnAYNaXAW27WD9kC2YEx0rUTUce4riQlnQZ1qxvIX7eaXCo/FHGH2c58j2n
+        vbHaP/fj6OoygLcQs70km1v8q7eNDpVdrJvZoonDL9u2M9a6M6mlqzPrCbZwTvBGfpsu1u8UH3QucC0p
+        28YYY0Na0kVYOdVT1hzpNDrGI2zBhOGCY7Z9oTYNaUnbsHJNrKzhB8Qzo214qDl1sR7gtC/EtiEtaRNW
+        zoGbPbzW5DWnbXyo/KJ4zZs6HNbIsbi2fVV2FdKSpmH9pC2UKy9s+dwP7yLkQExIug5pSWxY+b0Nam4G
+        3h+1H0KMvD+bOhsHzunVV0hLYsK6xG6cO+xiZc+T/SBCZY8Xe75ShwH8sdO+0u9O6NYcw3p8xWAi/v+l
+        Q11S9MkAVjofSqjLi8DnwMuKsxr/8fLpXI4g4xI/k2bn4tLqhuK7+WPx3zvZNw6NA50AxvhhW1CIvuDZ
+        wwYwVP5J2tsWFKIPOKKfk6fZEIbK212cbFiI3lkA4F4nhKEeYwsK0RdtFrK9whYTok++6YQwRC6LKcTE
+        4E1wDnqwQazzLltIiL7Zq0E/uIIqpgJvNNswVqmgiqmgoIokUFBFEiioIglSCup6AHYvunJ3GcBcBGKE
+        FII6D8BJzgQSXEiDS5FvYDcQ+THrQZ0fMMs2V43RYsWZM8tB5Z/2XzjH4MlJJkTGzHJQFzv7r/IltoDI
+        h1kO6kXO/qvkqjEiU2Y5qLGPe19lC4h8mOWg2l/5dbItIlMUVJEECqpIAgVVJIGCKpJAQRVJoKCKJFBQ
+        RRIoqCIJFFSRBAqqSAIFVSSBgiqSQEEVSaCgiiRQUEUSKKgiCRRUkQQKqkgCBVUkgYIqkkBBFUmgoIok
+        UFBFEiioIgkUVJEECqpIAgVVJIGCKpJAQRVJoKCKJFBQRRIoqCIJFFSRBFc7X3iVD01wITIFVawmdkEH
+        uqst0hMKqljNl50vvM6zbJGeUFDFao51vvA6HwSwhy3UAwqqWM1znS88RK5DupMt1jH3OPut8npbQOTD
+        usUvefulh3gfgBMAbG2LdgDXNrX7q5PLUYqM+Zzzpcf4MIDLABwKYFNbvCH7O/up82JbROTFzs6X3tT7
+        AVwA4GAAc+2OIljm1K7zVFtE5Mclzhff1ruLuwr7FpcYoRzm1AqR24nM2RHAA86X35W3AzgFwEIAa9md
+        F6wN4OjiUsJuHyLbIAbASc6X34c3A/gogP0A7FbceTgKwLXOe0O90TZG5Mv6AJY7IUjB421jRN5sAeAW
+        JwizLH/AbWUbIvJnewA3OYGYVXl7TQyULQFc44Ri1lwJYHN78GJY8D4of2BxaJ8NyKz4envQYrhwAMoV
+        Tkim7Rn2QIUgvI10bs/3W0PlOFrepRBiLJsVvUCXA3jECVHf/hDAHHtQQlQxH8A7JnhpcHpkd6wQa7AA
+        wNKebm3dCuBAu0Mh2sC+/D0BfBbACid0Md4BYAmAjexOhOiSdQDsA+BMALc5QfTkoy4cW8rxrRvagkL0
+        Dc+0HPu6uHgygNeb5wA4G8DJAI4BsAjAPLuhWJP/A+4yy2+abb0+AAAAAElFTkSuQmCC
+</value>
+  </data>
 </root>


### PR DESCRIPTION
This toolbar button icon was orginally introduced with PR #1180.
But somehow it get lost in the meantime and the toolbar button remains empty - hardly to recognize.
So, I'm adding this icon properly this time.