### PR TITLE
Add missing event handler for 'TestAssemblyChanged' event

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -181,6 +181,12 @@ namespace TestCentric.Gui.Presenters
                 }
             };
 
+            _model.Events.TestChanged += (e) =>
+            {
+                if (_settings.Engine.ReloadOnChange)
+                    _model.ReloadTests();
+            };
+
             _model.Events.RunStarting += (RunStartingEventArgs e) =>
             {
                 _stopRequested = _forcedStopRequested = false;

--- a/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
@@ -53,5 +53,31 @@ namespace TestCentric.Gui.Presenters.Main
             _model.Received().SaveProject("TestCentric.tcproj");
             _view.Received().Title = "TestCentric - TestCentric.tcproj";
         }
+
+        [Test]
+        public void WhenTestAssemblyChanged_ReloadOnChangeEnabled_ReloadTests()
+        {
+            // Arrange
+            _settings.Engine.ReloadOnChange = true;
+
+            // Act
+            FireTestAssemblyChangedEvent();
+
+            // Assert
+            _model.Received().ReloadTests();
+        }
+
+        [Test]
+        public void WhenTestAssemblyChanged_ReloadOnChangeDisabled_NotReloadTests()
+        {
+            // Arrange
+            _settings.Engine.ReloadOnChange = false;
+
+            // Act
+            FireTestAssemblyChangedEvent();
+
+            // Assert
+            _model.DidNotReceive().ReloadTests();
+        }
     }
 }

--- a/src/TestCentric/tests/Presenters/PresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/PresenterTestBase.cs
@@ -89,6 +89,11 @@ namespace TestCentric.Gui.Presenters
             _model.Events.TestsUnloading += Raise.Event<TestEventHandler>(new TestEventArgs());
         }
 
+        protected void FireTestAssemblyChangedEvent()
+        {
+            _model.Events.TestChanged += Raise.Event<TestEventHandler>(new TestEventArgs());
+        }
+
         protected void FireRunStartingEvent(int testCount)
         {
             _model.Events.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(testCount));


### PR DESCRIPTION
This PR resolves #1245 by adding an event handler for the 'TestAssemblyChanged' event.

I managed to solve this issue quickly be comparing/debugging this use case in TestCentric 1.7.1
For some reason, the event handler for this event has been lost, so no action was performed on this event.

But I was able to restore this easily and now the reload works again as usual.

I believe this fix does not make any harm, even if we decide to solve issue [56](https://github.com/TestCentric/TestCentric.Agent.Core/issues/56) in the TestCentric.Agent.Core somehow differently. Without that fix in the Agent.Core the test assembly is kept blocked and cannot be changed at all, so the event won't be triggered.