### PR TITLE
NUnit tree grouping improvement: Prefer usage of TestGroup instead of TreeNode

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/DisplayStrategy.cs
@@ -141,6 +141,7 @@ namespace TestCentric.Gui.Presenters
         {
             TreeNode treeNode = new TreeNode(GroupDisplayName(group), group.ImageIndex, group.ImageIndex);
             treeNode.Tag = group;
+            group.TreeNode = treeNode;
 
             if (recursive)
                 foreach (TestNode test in group)
@@ -229,10 +230,10 @@ namespace TestCentric.Gui.Presenters
             _view.TreeView.EndUpdate();
         }
 
-        public void UpdateTreeNodeNames(IEnumerable<TreeNode> treeNodes)
+        public void UpdateTreeNodeNames(IEnumerable<TestGroup> groups)
         {
-            foreach (TreeNode treeNode in treeNodes)
-                UpdateTreeNodeName(treeNode);
+            foreach (TestGroup group in groups)
+                UpdateTreeNodeName(group.TreeNode);
         }
 
         private void UpdateTreeNodeName(TreeNode treeNode)
@@ -303,7 +304,11 @@ namespace TestCentric.Gui.Presenters
                 if (anyChildNodeRunning || treeNode.Tag is TestNode testNode && _model.IsInTestRun(testNode))
                     imageIndex = TestTreeView.RunningIndex;
                 else
+                {
                     imageIndex = UpdateTreeIconToPreviousRun(treeNode.ImageIndex);
+                    if (treeNode.Tag is TestGroup testGroup)
+                        testGroup.ImageIndex = imageIndex;
+                }
 
                 _view.SetImageIndex(treeNode, imageIndex);
             }

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/INUnitGrouping.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/INUnitGrouping.cs
@@ -28,6 +28,12 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         IList<TreeNode> CreateTreeNodes(TestNode testNode, string groupName);
 
         /// <summary>
+        /// Remove test from TestGroup.
+        /// If no test remains in group, the group and the associated tree node is deleted
+        /// </summary>
+        void RemoveTestFromGroup(TestGroup testGroup, TestNode testNode);
+
+        /// <summary>
         /// Called when one test case is finished
         /// </summary>
         void OnTestFinished(ResultNode result);

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/INUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/INUnitTreeDisplayStrategy.cs
@@ -17,9 +17,9 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         TreeNode MakeTreeNode(TestNode testNode);
 
         /// <summary>
-        /// Creates a new tree node for a TestGroup which is associated to a TestNode
+        /// Creates a new tree node for a TestGroup
         /// </summary>
-        TreeNode MakeTreeNode(TestGroup testGroup, TestNode testNode);
+        TreeNode MakeTreeNode(TestGroup testGroup);
 
         /// <summary>
         /// Removes one tree node from the tree
@@ -38,9 +38,15 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
         /// </summary>
         List<TreeNode> GetTreeNodesForTest(TestNode testNode);
 
+        /// <summary>
+        /// Update the name of all tree nodes
+        /// </summary>
         void UpdateTreeNodeNames();
 
-        void UpdateTreeNodeNames(IEnumerable<TreeNode> treeNodes);
+        /// <summary>
+        /// Update the name of all groups
+        /// </summary>
+        void UpdateTreeNodeNames(IEnumerable<TestGroup> groups);
 
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/TreeNodeDurationHandler.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/TreeNodeDurationHandler.cs
@@ -17,51 +17,28 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
     /// </summary>
     public class TreeNodeDurationHandler
     {
-        public static void ClearGroupDurations(IEnumerable<TreeNode> treeNodes)
+        public static void ClearGroupDurations(IEnumerable<TestGroup> groups)
         {
-            foreach (TreeNode treeNode in treeNodes)
-            {
-                ClearGroupDuration(treeNode);
-                ClearGroupDurations(treeNode.Nodes.OfType<TreeNode>());
-            }
+            foreach (TestGroup group in groups)
+                group.Duration = null;
         }
 
-        private static void ClearGroupDuration(TreeNode treeNode)
+        public static void SetGroupDurations(ITestModel model, IList<TestGroup> groups)
         {
-            if (treeNode.Tag is TestGroup testGroup)
-                testGroup.Duration = null;
-
-        }
-
-        public static void SetGroupDurations(ITestModel model, IEnumerable<TreeNode> treeNodes)
-        {
-            foreach (TreeNode treeNode in treeNodes)
+            foreach (TestGroup group in groups)
             {
-                SetGroupDurations(model, treeNode.Nodes.OfType<TreeNode>());
-                SetGroupDuration(model, treeNode);
-            }
-        }
-
-        private static void SetGroupDuration(ITestModel model, TreeNode treeNode)
-        {
-            TestGroup testGroup = treeNode.Tag as TestGroup;
-            if (testGroup == null)
-                return;
-
-            double duration = 0;
-            bool childHasResult = false;
-            foreach (TestNode testNode in testGroup)
-            {
-                ResultNode childResult = model.GetResultForTest(testNode.Id);
-                if (childResult != null)
+                foreach (TestNode testNode in group)
                 {
-                    duration += childResult.Duration;
-                    childHasResult = true;
+                    ResultNode result = model.GetResultForTest(testNode.Id);
+                    if (result == null)
+                        continue;
+
+                    if (!group.Duration.HasValue)
+                        group.Duration = 0;
+
+                    group.Duration += result.Duration;
                 }
             }
-
-            if (childHasResult)
-                testGroup.Duration = duration;
         }
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/TreeNodeImageHandler.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitGrouping/TreeNodeImageHandler.cs
@@ -7,6 +7,8 @@ using System.Windows.Forms;
 using System;
 using TestCentric.Gui.Views;
 using System.Collections.Generic;
+using System.Linq;
+using TestCentric.Gui.Model;
 
 namespace TestCentric.Gui.Presenters.NUnitGrouping
 {
@@ -15,28 +17,23 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
     /// </summary>
     public class TreeNodeImageHandler
     {
-        public static void SetTreeNodeImages(ITestTreeView treeView, IEnumerable<TreeNode> treeNodes, bool recursive)
+        public static void SetTreeNodeImages(ITestTreeView treeView, IEnumerable<TestGroup> groups)
         {
-            foreach (TreeNode treeNode in treeNodes)
-            {
-                SetTreeNodeImage(treeView, treeNode, recursive);
-            }
+            foreach (TestGroup group in groups)
+                treeView.SetImageIndex(group.TreeNode, group.ImageIndex);
         }
 
-        private static void SetTreeNodeImage(ITestTreeView treeView, TreeNode treeNode, bool recursive)
+        public static void OnTestFinished(ResultNode result, IList<TestGroup> groups, ITestTreeView treeView)
         {
-            int imageIndex = TestTreeView.InitIndex;
-            foreach (TreeNode childNode in treeNode.Nodes)
+            if (!result.IsSuite)
             {
-                if (recursive && childNode.ImageIndex <= TestTreeView.InitIndex)
-                    SetTreeNodeImage(treeView, childNode, recursive);
-
-                // Ignore index is set to a TreeNode when created => don't propagate up automatically on loading tree
-                if (!recursive || childNode.ImageIndex != TestTreeView.IgnoredIndex)
-                    imageIndex = Math.Max(imageIndex, childNode.ImageIndex);
-            }
-
-            treeView.SetImageIndex(treeNode, imageIndex);
+                int imageIndex = DisplayStrategy.CalcImageIndex(result);
+                foreach (TestGroup group in groups)
+                    group.ImageIndex = Math.Max(imageIndex, group.ImageIndex);
+            } 
+            else
+                foreach (TestGroup group in groups)
+                    treeView.SetImageIndex(group.TreeNode, group.ImageIndex);
         }
     }
 }

--- a/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -153,15 +153,11 @@ namespace TestCentric.Gui.Presenters
         }
 
         /// <summary>
-        /// Creates a new tree node for a TestGroup which is associated to a TestNode
+        /// Creates a new tree node for a TestGroup
         /// </summary>
-        public TreeNode MakeTreeNode(TestGroup testGroup, TestNode testNode)
+        public TreeNode MakeTreeNode(TestGroup testGroup)
         {
-            TreeNode treeNode = MakeTreeNode(testGroup, false);
-            if (testNode != null)
-                AddTestNodeMapping(testNode, treeNode);
-
-            return treeNode;
+            return MakeTreeNode(testGroup, false);
         }
 
         private void SetDefaultInitialExpansion()

--- a/src/TestCentric/testcentric.gui/Presenters/TestGroup.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestGroup.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Presenters
 {
+    using System;
     using Model;
 
     /// <summary>
@@ -54,6 +55,19 @@ namespace TestCentric.Gui.Presenters
             sb.Append("</or></filter>");
 
             return new TestFilter(sb.ToString());
+        }
+
+        /// <summary>
+        /// Add a testNode to the TestGroup and apply the testNode result to the result state of the group
+        /// </summary>
+        public void Add(TestNode testNode, ResultNode resultNode)
+        {
+            Add(testNode);
+            if (resultNode != null)
+            {
+                int imageIndex = DisplayStrategy.CalcImageIndex(resultNode);
+                ImageIndex = Math.Max(imageIndex, ImageIndex);
+            }
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/NUnitGrouping/CategoryGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitGrouping/CategoryGroupingTests.cs
@@ -36,8 +36,13 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
             // We can't construct a TreeNodeCollection, so we need to fake it
             _createNodes = new TreeNode().Nodes;
-            _strategy.MakeTreeNode(null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
-            _strategy.MakeTreeNode(null, null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestGroup>(0).Name) { Tag = x.ArgAt<TestGroup>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestNode>()).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestGroup>()).ReturnsForAnyArgs(x => {
+                var testGroup = x.ArgAt<TestGroup>(0);
+                var treeNode = new TreeNode(testGroup.Name) { Tag = testGroup };
+                testGroup.TreeNode = treeNode;
+                return treeNode;
+            });
             _view.When(t => t.Add(Arg.Any<TreeNode>())).Do(x => _createNodes.Add(x.ArgAt<TreeNode>(0)));
             _view.Nodes.Returns(x => _createNodes);
         }

--- a/src/TestCentric/tests/Presenters/NUnitGrouping/DurationGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitGrouping/DurationGroupingTests.cs
@@ -38,8 +38,13 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
             // We can't construct a TreeNodeCollection, so we need to fake it
             _createNodes = new TreeNode().Nodes;
-            _strategy.MakeTreeNode(null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
-            _strategy.MakeTreeNode(null, null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestGroup>(0).Name) { Tag = x.ArgAt<TestGroup>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestNode>()).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestGroup>()).ReturnsForAnyArgs(x => {
+                var testGroup = x.ArgAt<TestGroup>(0);
+                var treeNode = new TreeNode(testGroup.Name) { Tag = testGroup };
+                testGroup.TreeNode = treeNode;
+                return treeNode;
+            });
             _view.When(t => t.Add(Arg.Any<TreeNode>())).Do(x => _createNodes.Add(x.ArgAt<TreeNode>(0)));
             _view.Nodes.Returns(x => _createNodes);
         }

--- a/src/TestCentric/tests/Presenters/NUnitGrouping/OutcomeGroupingTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitGrouping/OutcomeGroupingTests.cs
@@ -39,8 +39,13 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
 
             // We can't construct a TreeNodeCollection, so we need to fake it
             _createNodes = new TreeNode().Nodes;
-            _strategy.MakeTreeNode(null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
-            _strategy.MakeTreeNode(null, null).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestGroup>(0).Name) { Tag = x.ArgAt<TestGroup>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestNode>()).ReturnsForAnyArgs(x => new TreeNode(x.ArgAt<TestNode>(0).Name) { Tag = x.ArgAt<TestNode>(0) });
+            _strategy.MakeTreeNode(Arg.Any<TestGroup>()).ReturnsForAnyArgs(x => {
+                var testGroup = x.ArgAt<TestGroup>(0);
+                var treeNode = new TreeNode(testGroup.Name) { Tag = testGroup };
+                testGroup.TreeNode = treeNode;
+                return treeNode;
+            });
             _view.When(t => t.Add(Arg.Any<TreeNode>())).Do(x => _createNodes.Add(x.ArgAt<TreeNode>(0)));
             _view.Nodes.Returns(x => _createNodes);
         }

--- a/src/TestCentric/tests/Presenters/NUnitGrouping/TreeNodeDurationHandlerTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitGrouping/TreeNodeDurationHandlerTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using System.Windows.Forms;
 using NSubstitute;
 using NUnit.Framework;
 using TestCentric.Gui.Model;
@@ -20,13 +19,8 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             TestGroup testGroup2 = new TestGroup("Group_2") { Duration = 0.5 };
             TestGroup testGroup3 = new TestGroup("Group_3") { Duration = 0.5 };
 
-            TreeNode treeNode1 = new TreeNode() { Tag = testGroup1 };
-            TreeNode treeNode2 = new TreeNode() { Tag = testGroup2 };
-            TreeNode treeNode3 = new TreeNode() { Tag = testGroup3 };
-            treeNode2.Nodes.Add(treeNode3);
-
             // Act
-            TreeNodeDurationHandler.ClearGroupDurations(new[] { treeNode1, treeNode2 });
+            TreeNodeDurationHandler.ClearGroupDurations(new[] { testGroup1, testGroup2, testGroup3 });
 
             // Assert
 
@@ -41,6 +35,7 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             ITestModel model = Substitute.For<ITestModel>();
             TestNode testNode1 = new TestNode($"<test-start id='1'/>");
             TestNode testNode2 = new TestNode($"<test-start id='2'/>");
+            TestNode testNode3 = new TestNode($"<test-start id='3'/>");
             var resultNode1 = new ResultNode($"<test-case id='1' duration='1'/>");
             var resultNode2 = new ResultNode($"<test-case id='2' duration='2'/>");
             model.GetResultForTest("1").Returns(resultNode1);
@@ -54,14 +49,10 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
             testGroup2.Add(testNode2);
             testGroup3.Add(testNode1);
             testGroup3.Add(testNode2);
-
-            TreeNode treeNode1 = new TreeNode() { Tag = testGroup1 };
-            TreeNode treeNode2 = new TreeNode() { Tag = testGroup2 };
-            TreeNode treeNode3 = new TreeNode() { Tag = testGroup3 };
-            treeNode2.Nodes.Add(treeNode3);
+            testGroup3.Add(testNode3);
 
             // Act
-            TreeNodeDurationHandler.SetGroupDurations(model, new[] { treeNode1, treeNode2 });
+            TreeNodeDurationHandler.SetGroupDurations(model, new[] { testGroup1, testGroup2, testGroup3 });
 
             // Assert
 

--- a/src/TestCentric/tests/Presenters/NUnitGrouping/TreeNodeImageHandlerTests.cs
+++ b/src/TestCentric/tests/Presenters/NUnitGrouping/TreeNodeImageHandlerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using NSubstitute;
 using NUnit.Framework;
+using TestCentric.Gui.Model;
 using TestCentric.Gui.Views;
 
 namespace TestCentric.Gui.Presenters.NUnitGrouping
@@ -16,77 +17,77 @@ namespace TestCentric.Gui.Presenters.NUnitGrouping
     internal class TreeNodeImageHandlerTests
     {
         [Test]
-        public void SetTreeNodeImages_NoChildNodes_Set_InitIndex()
+        public void SetTreeNodeImages_AllImagesAreSet()
         {
             // Arrange
-            TreeNode treeNode = new TreeNode();
-            var treeNodes = new List<TreeNode>() { treeNode };
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
 
+            TestGroup testGroup1 = new TestGroup("Group_1") { ImageIndex = 10 };
+            TestGroup testGroup2 = new TestGroup("Group_2") { ImageIndex = 20 };
+            TestGroup testGroup3 = new TestGroup("Group_3") { ImageIndex = 30 };
+
             // Act
-            TreeNodeImageHandler.SetTreeNodeImages(treeView, treeNodes, false);
+            TreeNodeImageHandler.SetTreeNodeImages(treeView, new[] { testGroup1, testGroup2, testGroup3});
 
             // Assert
-            treeView.Received().SetImageIndex(treeNode, TestTreeView.InitIndex);
+            treeView.Received().SetImageIndex(testGroup1.TreeNode, testGroup1.ImageIndex);
+            treeView.Received().SetImageIndex(testGroup2.TreeNode, testGroup2.ImageIndex);
+            treeView.Received().SetImageIndex(testGroup3.TreeNode, testGroup3.ImageIndex);
+
         }
 
-        [TestCase(TestTreeView.FailureIndex, TestTreeView.FailureIndex, TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.FailureIndex, TestTreeView.SuccessIndex, TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.InitIndex, TestTreeView.SuccessIndex, TestTreeView.SuccessIndex)]
-        [TestCase(TestTreeView.InconclusiveIndex, TestTreeView.SuccessIndex, TestTreeView.SuccessIndex)]
-        [TestCase(TestTreeView.IgnoredIndex, TestTreeView.SuccessIndex, TestTreeView.IgnoredIndex)]
-        public void SetTreeNodeImages_WithChildNodes_Set_InitIndex(int childImageIndex1, int childImageIndex2, int expectedImageIndex)
+        [TestCase(TestTreeView.InitIndex, "Passed", TestTreeView.SuccessIndex)]
+        [TestCase(TestTreeView.InitIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Warning", TestTreeView.WarningIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Passed", TestTreeView.SuccessIndex)]
+        [TestCase(TestTreeView.InconclusiveIndex, "Warning", TestTreeView.WarningIndex)]
+        [TestCase(TestTreeView.WarningIndex, "Passed", TestTreeView.WarningIndex)]
+        [TestCase(TestTreeView.FailureIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.FailureIndex, "Passed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.FailureIndex, "Warning", TestTreeView.FailureIndex)]
+        public void OnTestFinished_TestCase_GroupIndexIsUpdated(int groupIndex, string outcome, int expectedGroupIndex)
         {
             // Arrange
-            TreeNode treeNode = new TreeNode();
-
-            CreateChildNode(treeNode, childImageIndex1);
-            CreateChildNode(treeNode, childImageIndex2);
-
-            var treeNodes = new List<TreeNode>() { treeNode };
-
-
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
 
+            TestGroup testGroup1 = new TestGroup("Group_1") { ImageIndex = groupIndex };
+            TestGroup testGroup2 = new TestGroup("Group_2") { ImageIndex = groupIndex };
+            TestGroup testGroup3 = new TestGroup("Group_3") { ImageIndex = groupIndex };
+
+            var resultNode = new ResultNode($"<test-case id='1' result='{outcome}' />");
+
             // Act
-            TreeNodeImageHandler.SetTreeNodeImages(treeView, treeNodes, false);
+            TreeNodeImageHandler.OnTestFinished(resultNode, new[] { testGroup1, testGroup2, testGroup3 }, treeView);
 
             // Assert
-            treeView.Received().SetImageIndex(treeNode, expectedImageIndex);
+            Assert.That(testGroup1.ImageIndex, Is.EqualTo(expectedGroupIndex));
+            Assert.That(testGroup2.ImageIndex, Is.EqualTo(expectedGroupIndex));
+            Assert.That(testGroup3.ImageIndex, Is.EqualTo(expectedGroupIndex));
         }
 
-        [TestCase(TestTreeView.FailureIndex, TestTreeView.FailureIndex, TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.FailureIndex, TestTreeView.SuccessIndex, TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.InitIndex, TestTreeView.SuccessIndex, TestTreeView.SuccessIndex)]
-        [TestCase(TestTreeView.InconclusiveIndex, TestTreeView.SuccessIndex, TestTreeView.SuccessIndex)]
-        public void SetTreeNodeImagesRecursive_WithChildNodes_Set_InitIndex(int childImageIndex1, int childImageIndex2, int expectedImageIndex)
+        [TestCase(TestTreeView.InitIndex)]
+        [TestCase(TestTreeView.SuccessIndex)]
+        [TestCase(TestTreeView.FailureIndex)]
+        public void OnTestFinished_TestFixture_TreeviewImageIndex_IsSet(int groupIndex)
         {
             // Arrange
-            TreeNode treeNode = new TreeNode();
-            TreeNode childNode = CreateChildNode(treeNode, TestTreeView.InitIndex);
-
-            CreateChildNode(childNode, childImageIndex1);
-            CreateChildNode(childNode, childImageIndex2);
-
-            var treeNodes = new List<TreeNode>() { treeNode };
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
-            treeView.When(t => t.SetImageIndex(Arg.Any<TreeNode>(), Arg.Any<int>())).Do(x => x.ArgAt<TreeNode>(0).ImageIndex = x.ArgAt<int>(1));
+
+            TestGroup testGroup1 = new TestGroup("Group_1") { ImageIndex = groupIndex };
+            TestGroup testGroup2 = new TestGroup("Group_2") { ImageIndex = groupIndex };
+            TestGroup testGroup3 = new TestGroup("Group_3") { ImageIndex = groupIndex };
+
+            var resultNode = new ResultNode($"<test-suite id='1' result='Passed' />");
 
             // Act
-            TreeNodeImageHandler.SetTreeNodeImages(treeView, treeNodes, true);
+            TreeNodeImageHandler.OnTestFinished(resultNode, new[] { testGroup1, testGroup2, testGroup3 }, treeView);
 
             // Assert
-            treeView.Received().SetImageIndex(treeNode, expectedImageIndex);
-            treeView.Received().SetImageIndex(childNode, expectedImageIndex);
-        }
-
-        private TreeNode CreateChildNode(TreeNode treeNode, int imageIndex)
-        {
-            TreeNode childNode = new TreeNode();
-            childNode.ImageIndex = imageIndex;
-            treeNode.Nodes.Add(childNode);
-
-            return childNode;
+            treeView.Received().SetImageIndex(testGroup1.TreeNode, testGroup1.ImageIndex);
+            treeView.Received().SetImageIndex(testGroup2.TreeNode, testGroup2.ImageIndex);
+            treeView.Received().SetImageIndex(testGroup3.TreeNode, testGroup3.ImageIndex);
         }
     }
 }

--- a/src/TestCentric/tests/Presenters/TestGroupTests.cs
+++ b/src/TestCentric/tests/Presenters/TestGroupTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace TestCentric.Gui.Presenters
 {
     using Model;
+    using TestCentric.Gui.Views;
 
     public class TestGroupTests
     {
@@ -51,6 +52,30 @@ namespace TestCentric.Gui.Presenters
             foreach (XmlNode child in filter.ChildNodes)
                 ids.Add(child.InnerText);
             Assert.That(ids, Is.EqualTo(new string[] { "1", "3" }));
+        }
+
+        [TestCase(TestTreeView.InitIndex, "Passed", TestTreeView.SuccessIndex)]
+        [TestCase(TestTreeView.InitIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.SkippedIndex, "Warning", TestTreeView.WarningIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.SuccessIndex, "Warning", TestTreeView.WarningIndex)]
+        [TestCase(TestTreeView.WarningIndex, "Failed", TestTreeView.FailureIndex)]
+        [TestCase(TestTreeView.InconclusiveIndex, "Passed", TestTreeView.SuccessIndex)]
+        [TestCase(TestTreeView.IgnoredIndex, "Passed", TestTreeView.IgnoredIndex)]
+        [TestCase(TestTreeView.FailureIndex, "Passed", TestTreeView.FailureIndex)]
+        public void AddTestWithResult(int imageIndex, string outcome, int expectedImageIndex)
+        {
+            // Arrange
+            var group = new TestGroup("TestGroup", imageIndex);
+            var testNode = MakeTestNode("1", "Tom", "Runnable");
+            var resultNode = new ResultNode($"<test-case id='1' result='{outcome}'/>");
+
+            // Act
+            group.Add(testNode, resultNode);
+
+            // Assert
+            Assert.That(group.ImageIndex, Is.EqualTo(expectedImageIndex));
+
         }
 
         private TestNode MakeTestNode(string id, string name, string runState)


### PR DESCRIPTION
This PR contributes to issue #1227 which enhance the NUnit tree with grouping functionality.
These changes are a refactoring which doesn't provide new functionality or fixes any bugs.

The refactoring is targeting to use the class `TestGroup` or `TestNode` instead of the class `TreeNode`. The later one is part of the Windows.Forms namespace and therefore part of the View logic. TestGroup and TestNode are part of the Presenter/Model logic.

When building up the grouped NUnit tree there were some code locations which uses the TreeNode to access certain information: for example child nodes or ImageIndex - however these information are also available at the associated TestGroup/TestNode. So, we should use these instead.