### PR TITLE
Restore VisualState when reloading tests

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -78,7 +78,8 @@ namespace TestCentric.Gui.Presenters
                 _view.CategoryFilter.Close();
                 _view.CategoryFilter.Init(_model);
 
-                Strategy.OnTestLoaded(ea.Test, null);
+                TryLoadVisualState(out VisualState visualState);
+                Strategy.OnTestLoaded(ea.Test, visualState);
                 _view.CheckBoxes = _view.ShowCheckBoxes.Checked; // TODO: View should handle this
             };
 

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -56,6 +56,45 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.CategoryFilter.Received().Init(_model);
         }
 
+        [Test]
+        public void VisualState_IsAppliedToTree()
+        {
+            // Arrange
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+
+            var project = new TestCentricProject(_model, "dummy.dll");
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            _model.TestCentricProject.Returns(project);
+
+            // Act
+            FireTestReloadedEvent(testNode);
+
+            // Assert
+            strategy.Received().OnTestLoaded(testNode, null);
+        }
+
+        [Test]
+        public void Reloading_VisualState_IsSaved()
+        {
+            // Arrange
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+
+            var project = new TestCentricProject(_model, "dummy.dll");
+            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            _model.LoadedTests.Returns(testNode);
+            _model.TestCentricProject.Returns(project);
+            FireTestLoadedEvent(testNode);
+
+            // Act
+            FireTestsReloadingEvent();
+
+            // Assert
+            strategy.Received().SaveVisualState();
+        }
+
 #if NYI // Add after implementation of project or package saving
         [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]


### PR DESCRIPTION
This PR resolves #1248 by restoring the visual state of the tree when reloading a test.

Almost everything was already in place to solve this requirement:

- the VisualState file stores all the required information
- the file is created using the current visual state of the tree when starting the reload operation
- when building up a tree there is an optional parameter to apply a VisualState to the new tree

The only missing part was to pass in the correct VisualState, so that it can be applied to the tree