### PR TITLE
Extend VisualState to use TestNode/TestGroup name

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestPropertiesPresenter.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Presenters
         private void WireUpEvents()
         {
             _model.Events.TestLoaded += (ea) => _view.Visible = true;
-            _model.Events.TestReloaded += (ea) => _view.Visible = true;
+            _model.Events.TestReloaded += (ea) => _view.TestPackageSubView.InvokeIfRequired(() => _view.Visible = true);
             _model.Events.TestUnloaded += (ea) => _view.Visible = false;
             _model.Events.RunFinished += (ea) => DisplaySelectedItem();
             _model.Events.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);

--- a/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TreeViewPresenter.cs
@@ -71,16 +71,19 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.TestReloaded += (ea) =>
             {
-                EnsureNonRunnableFilesAreVisible(ea.Test);
+                _view.InvokeIfRequired(() =>
+                {
+                    EnsureNonRunnableFilesAreVisible(ea.Test);
 
-                // Handle category filter identically to close/load project
-                ResetTestFilterUIElements();
-                _view.CategoryFilter.Close();
-                _view.CategoryFilter.Init(_model);
+                    // Handle category filter identically to close/load project
+                    ResetTestFilterUIElements();
+                    _view.CategoryFilter.Close();
+                    _view.CategoryFilter.Init(_model);
 
-                TryLoadVisualState(out VisualState visualState);
-                Strategy.OnTestLoaded(ea.Test, visualState);
-                _view.CheckBoxes = _view.ShowCheckBoxes.Checked; // TODO: View should handle this
+                    TryLoadVisualState(out VisualState visualState);
+                    Strategy.OnTestLoaded(ea.Test, visualState);
+                    _view.CheckBoxes = _view.ShowCheckBoxes.Checked; // TODO: View should handle this
+                });
             };
 
             _model.Events.TestUnloaded += (ea) =>

--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -13,6 +13,8 @@ using System.Xml.Schema;
 using System.Xml;
 using System.Xml.Linq;
 using TestCentric.Gui.Controls;
+using TestCentric.Gui.Model;
+using TestCentric.Gui.Presenters;
 
 namespace TestCentric.Gui
 {
@@ -103,7 +105,7 @@ namespace TestCentric.Gui
 
                 var visualNode = new VisualTreeNode()
                 {
-                    Name = treeNode.Text,
+                    Name = GetName(treeNode),
                     Expanded = treeNode.IsExpanded,
                     Checked = treeNode.Checked,
                     Selected = isSelectedNode,
@@ -151,7 +153,8 @@ namespace TestCentric.Gui
             {
                 foreach (TreeNode treeNode in treeNodes)
                 {
-                    if (treeNode.Text == visualNode.Name || treeNode.Text == "Not Run")
+                    string name = GetName(treeNode);
+                    if (name == visualNode.Name || treeNode.Text == "Not Run")
                     {
                         ApplyVisualNodeToTreeNode(visualNode, treeNode);
                         break;
@@ -415,6 +418,16 @@ namespace TestCentric.Gui
         }
 
         #endregion
+
+        private static string GetName(TreeNode treeNode)
+        {
+            if (treeNode.Tag is TestNode testNode)
+                return testNode.Name;
+            else if (treeNode.Tag is TestGroup testGroup)
+                return testGroup.Name;
+
+            return treeNode.Text;
+        }
 
         #endregion
     }

--- a/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTestBase.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/TreeViewPresenterTestBase.cs
@@ -28,6 +28,7 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             // Make it look like the view loaded
             _view.Load += Raise.Event<System.EventHandler>(_view, new System.EventArgs());
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
             // We can't construct a TreeNodeCollection, so we fake it
             var nodes = new TreeNode().Nodes;


### PR DESCRIPTION
This PR solves #1250 by adapting the VisualState class.

So far the VisualState class uses the TreeNode name as an identifier. However this name is not constant which causes the effect as explained in the issue.
Therefore the associated TestNode or TestGroup name is used instead.

Besides this change I noticed two exceptions ('UI update called from wrong thread') which I decided to fix along by adding an _InvokeIfRequired()_ statement.