### PR TITLE
Remove 'Automatic reload' options: no reload and reload on test run

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestCentricPresenter.cs
@@ -15,12 +15,13 @@ using TestCentric.Common;
 
 namespace TestCentric.Gui.Presenters
 {
+    using Dialogs;
     using Model;
     using Model.Services;
     using Model.Settings;
-    using Views;
-    using Dialogs;
+    using TestCentric.Gui.Controls;
     using TestCentric.Gui.Elements;
+    using Views;
 
     /// <summary>
     /// TestCentricPresenter does all file opening and closing that
@@ -183,8 +184,7 @@ namespace TestCentric.Gui.Presenters
 
             _model.Events.TestChanged += (e) =>
             {
-                if (_settings.Engine.ReloadOnChange)
-                    _model.ReloadTests();
+                _model.ReloadTests();
             };
 
             _model.Events.RunStarting += (RunStartingEventArgs e) =>
@@ -904,7 +904,7 @@ namespace TestCentric.Gui.Presenters
         private void BeginLongRunningOperation(string text)
         {
             _longRunningOperation = new LongRunningOperationDisplay();
-            _longRunningOperation.Display(text);
+            _view.ResultTabs.InvokeIfRequired(() => _longRunningOperation.Display(text));
         }
 
         private void UpdateLongRunningOperation(string text)

--- a/src/TestCentric/testcentric.gui/SettingsPages/AssemblyReloadSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AssemblyReloadSettingsPage.cs
@@ -12,12 +12,10 @@ namespace TestCentric.Gui.SettingsPages
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox rerunOnChangeCheckBox;
-        private System.Windows.Forms.RadioButton reloadOnRunRadioButton;
-        private System.Windows.Forms.RadioButton reloadOnChangeRadioButton;
-        private System.Windows.Forms.RadioButton noAutoReloadRadioButton;
         private System.Windows.Forms.HelpProvider helpProvider1;
         private CheckBox clearResultsCheckBox;
         private Label label2;
+        private Label label3;
         private System.ComponentModel.IContainer components = null;
 
         public AssemblyReloadSettingsPage(string key) : base(key)
@@ -53,12 +51,10 @@ namespace TestCentric.Gui.SettingsPages
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.rerunOnChangeCheckBox = new System.Windows.Forms.CheckBox();
-            this.reloadOnRunRadioButton = new System.Windows.Forms.RadioButton();
-            this.reloadOnChangeRadioButton = new System.Windows.Forms.RadioButton();
-            this.noAutoReloadRadioButton = new System.Windows.Forms.RadioButton();
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.clearResultsCheckBox = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label1
@@ -83,57 +79,21 @@ namespace TestCentric.Gui.SettingsPages
             // rerunOnChangeCheckBox
             // 
             this.rerunOnChangeCheckBox.AutoSize = true;
-            this.rerunOnChangeCheckBox.Enabled = false;
             this.helpProvider1.SetHelpString(this.rerunOnChangeCheckBox, "If checked, the last tests run will be re-run automatically whenever the assembly" +
         " changes.");
-            this.rerunOnChangeCheckBox.Location = new System.Drawing.Point(48, 84);
+            this.rerunOnChangeCheckBox.Location = new System.Drawing.Point(25, 62);
             this.rerunOnChangeCheckBox.Name = "rerunOnChangeCheckBox";
             this.helpProvider1.SetShowHelp(this.rerunOnChangeCheckBox, true);
-            this.rerunOnChangeCheckBox.Size = new System.Drawing.Size(120, 17);
+            this.rerunOnChangeCheckBox.Size = new System.Drawing.Size(239, 24);
             this.rerunOnChangeCheckBox.TabIndex = 13;
-            this.rerunOnChangeCheckBox.Text = "Re-run last tests run";
-            // 
-            // reloadOnRunRadioButton
-            // 
-            this.reloadOnRunRadioButton.AutoSize = true;
-            this.helpProvider1.SetHelpString(this.reloadOnRunRadioButton, "If checked, the assembly is reloaded before each run");
-            this.reloadOnRunRadioButton.Location = new System.Drawing.Point(24, 32);
-            this.reloadOnRunRadioButton.Name = "reloadOnRunRadioButton";
-            this.helpProvider1.SetShowHelp(this.reloadOnRunRadioButton, true);
-            this.reloadOnRunRadioButton.Size = new System.Drawing.Size(157, 17);
-            this.reloadOnRunRadioButton.TabIndex = 11;
-            this.reloadOnRunRadioButton.Text = "Reload before each test run";
-            // 
-            // reloadOnChangeRadioButton
-            // 
-            this.reloadOnChangeRadioButton.AutoSize = true;
-            this.helpProvider1.SetHelpString(this.reloadOnChangeRadioButton, "If checked, the assembly is reloaded whenever it changes. Changes to this setting" +
-        " do not take effect until the next time an assembly is loaded.");
-            this.reloadOnChangeRadioButton.Location = new System.Drawing.Point(24, 60);
-            this.reloadOnChangeRadioButton.Name = "reloadOnChangeRadioButton";
-            this.helpProvider1.SetShowHelp(this.reloadOnChangeRadioButton, true);
-            this.reloadOnChangeRadioButton.Size = new System.Drawing.Size(198, 17);
-            this.reloadOnChangeRadioButton.TabIndex = 12;
-            this.reloadOnChangeRadioButton.Text = "Reload when test assembly changes";
-            this.reloadOnChangeRadioButton.CheckedChanged += new System.EventHandler(this.reloadOnChangeRadioButton_CheckedChanged);
-            // 
-            // noAutoReloadRadioButton
-            // 
-            this.noAutoReloadRadioButton.AutoSize = true;
-            this.helpProvider1.SetHelpString(this.noAutoReloadRadioButton, "If checked, the assembly is never reloaded automatically");
-            this.noAutoReloadRadioButton.Location = new System.Drawing.Point(24, 107);
-            this.noAutoReloadRadioButton.Name = "noAutoReloadRadioButton";
-            this.helpProvider1.SetShowHelp(this.noAutoReloadRadioButton, true);
-            this.noAutoReloadRadioButton.Size = new System.Drawing.Size(120, 17);
-            this.noAutoReloadRadioButton.TabIndex = 13;
-            this.noAutoReloadRadioButton.Text = "No automatic reload";
+            this.rerunOnChangeCheckBox.Text = "Re-run last tests run when reloading";
             // 
             // clearResultsCheckBox
             // 
             this.clearResultsCheckBox.AutoSize = true;
             this.clearResultsCheckBox.Enabled = false;
             this.helpProvider1.SetHelpString(this.clearResultsCheckBox, "If checked, any prior results are cleared when reloading");
-            this.clearResultsCheckBox.Location = new System.Drawing.Point(24, 151);
+            this.clearResultsCheckBox.Location = new System.Drawing.Point(25, 91);
             this.clearResultsCheckBox.Name = "clearResultsCheckBox";
             this.helpProvider1.SetShowHelp(this.clearResultsCheckBox, true);
             this.clearResultsCheckBox.Size = new System.Drawing.Size(161, 17);
@@ -142,21 +102,27 @@ namespace TestCentric.Gui.SettingsPages
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(21, 176);
+            this.label2.Location = new System.Drawing.Point(21, 121);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(336, 33);
             this.label2.TabIndex = 36;
             this.label2.Text = "This setting is currently disabled. Results are aloways cleared due to  a problem" +
     " in the engine Reload function.";
             // 
+            // label3
+            // 
+            this.label3.Location = new System.Drawing.Point(21, 35);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(652, 28);
+            this.label3.TabIndex = 37;
+            this.label3.Text = "The test assembly is automatically reloaded when changes are made:";
+            // 
             // AssemblyReloadSettingsPage
             // 
+            this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
-            this.Controls.Add(this.noAutoReloadRadioButton);
             this.Controls.Add(this.clearResultsCheckBox);
             this.Controls.Add(this.rerunOnChangeCheckBox);
-            this.Controls.Add(this.reloadOnRunRadioButton);
-            this.Controls.Add(this.reloadOnChangeRadioButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.groupBox1);
             this.Name = "AssemblyReloadSettingsPage";
@@ -168,38 +134,20 @@ namespace TestCentric.Gui.SettingsPages
 
         public override void LoadSettings()
         {
-            if (Settings.Engine.ReloadOnChange)
-                reloadOnChangeRadioButton.Checked = true;
-            else if (Settings.Engine.ReloadOnRun)
-                reloadOnRunRadioButton.Checked = true;
-            else
-                noAutoReloadRadioButton.Checked = true;
-
             rerunOnChangeCheckBox.Checked = Settings.Engine.RerunOnChange;
             clearResultsCheckBox.Checked = Settings.Gui.ClearResultsOnReload;
         }
 
         public override void ApplySettings()
         {
-            Settings.Engine.ReloadOnChange = reloadOnChangeRadioButton.Checked;
-            Settings.Engine.ReloadOnRun = reloadOnRunRadioButton.Checked;
-
             Settings.Engine.RerunOnChange = rerunOnChangeCheckBox.Checked;
             Settings.Gui.ClearResultsOnReload = clearResultsCheckBox.Checked;
-        }
-
-
-
-        private void reloadOnChangeRadioButton_CheckedChanged(object sender, System.EventArgs e)
-        {
-            rerunOnChangeCheckBox.Enabled = reloadOnChangeRadioButton.Checked;
         }
 
         protected override void OnHelpRequested(HelpEventArgs hevent)
         {
             System.Diagnostics.Process.Start("http://nunit.com/?p=optionsDialog&r=2.4.5");
         }
-
     }
 }
 

--- a/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
+++ b/src/TestCentric/tests/Presenters/Main/ProjectEventTests.cs
@@ -55,29 +55,13 @@ namespace TestCentric.Gui.Presenters.Main
         }
 
         [Test]
-        public void WhenTestAssemblyChanged_ReloadOnChangeEnabled_ReloadTests()
+        public void WhenTestAssemblyChanged_ReloadTests()
         {
-            // Arrange
-            _settings.Engine.ReloadOnChange = true;
-
             // Act
             FireTestAssemblyChangedEvent();
 
             // Assert
             _model.Received().ReloadTests();
-        }
-
-        [Test]
-        public void WhenTestAssemblyChanged_ReloadOnChangeDisabled_NotReloadTests()
-        {
-            // Arrange
-            _settings.Engine.ReloadOnChange = false;
-
-            // Act
-            FireTestAssemblyChangedEvent();
-
-            // Assert
-            _model.DidNotReceive().ReloadTests();
         }
     }
 }

--- a/src/TestModel/model/Settings/EngineSettings.cs
+++ b/src/TestModel/model/Settings/EngineSettings.cs
@@ -27,22 +27,10 @@ namespace TestCentric.Gui.Model.Settings
             set { SaveSetting(nameof(Agents), value); }
         }
 
-        public bool ReloadOnChange
-        {
-            get { return GetSetting(nameof(ReloadOnChange), true); }
-            set { SaveSetting(nameof(ReloadOnChange), value); }
-        }
-
         public bool RerunOnChange
         {
             get { return GetSetting(nameof(RerunOnChange), false); }
             set { SaveSetting(nameof(RerunOnChange), value); }
-        }
-
-        public bool ReloadOnRun
-        {
-            get { return GetSetting(nameof(ReloadOnRun), false); }
-            set { SaveSetting(nameof(ReloadOnRun), value); }
         }
 
         public bool SetPrincipalPolicy

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -829,17 +829,6 @@ namespace TestCentric.Gui.Model
             foreach (ResultNode resultNode in this.Results.Values)
                 resultNode.IsLatestRun = false;
 
-            // TODO: Does this belong here? Maybe need to do before creating the run specification.
-            if (Settings.Engine.ReloadOnRun)
-            {
-                // TODO: reinstate when engine Reload works. Currently
-                // we simulate it with Unload + Load, so the results
-                // are always cleared.
-                //if (Settings.Gui.ClearResultsOnReload)
-                //    ClearResults();
-                ReloadTests();
-            }
-
             log.Debug("Executing RunAsync");
             Runner.RunAsync(_events, filter.AsNUnitFilter());
         }

--- a/src/TestModel/tests/Settings/SettingsTests.cs
+++ b/src/TestModel/tests/Settings/SettingsTests.cs
@@ -63,9 +63,7 @@ namespace TestCentric.Gui.Model.Settings
         {
             new TestCaseData("ShadowCopyFiles", true, false),
             new TestCaseData("Agents", 0, 8),
-            new TestCaseData("ReloadOnChange", true, false),
             new TestCaseData("RerunOnChange", false, true),
-            new TestCaseData("ReloadOnRun", false, true),
             new TestCaseData("SetPrincipalPolicy", false, true),
             new TestCaseData("PrincipalPolicy", nameof(PrincipalPolicy.UnauthenticatedPrincipal), nameof(PrincipalPolicy.WindowsPrincipal))
         };


### PR DESCRIPTION
This PR closes issue #1252 by removing the two 'automatic reload' options:

- no reload 
- reload on test run

This means that the test assembly is always automatically reloaded whenever the assembly is changed, now.

The code changes are almost all deletion of some code parts. And also the UI is simplified - here's a screenshot from the settings dialog:
<img src="https://github.com/user-attachments/assets/14619400-ab28-4753-8e85-e7e6694e809e" width="500">
