### PR TITLE
Fix resize of extension dialog

### DIFF
--- a/src/TestCentric/testcentric.gui/Dialogs/ExtensionDialog.cs
+++ b/src/TestCentric/testcentric.gui/Dialogs/ExtensionDialog.cs
@@ -53,11 +53,6 @@ namespace TestCentric.Gui.Dialogs
             // Required for Windows Form Designer support
             //
             InitializeComponent();
-
-            //
-            // TODO: Add any constructor code after InitializeComponent call
-            //
-            extensionListView.Resize += (s, e) => { extensionListView.Columns[0].Width = extensionListView.Width - 75; };
         }
 
         /// <summary>
@@ -327,6 +322,7 @@ namespace TestCentric.Gui.Dialogs
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Engine Extensions";
             this.Load += new System.EventHandler(this.ExtensionDialog_Load);
+            this.ResizeEnd += ExtensionDialog_ResizeEnd;
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.groupBox2.ResumeLayout(false);
@@ -349,6 +345,11 @@ namespace TestCentric.Gui.Dialogs
                 if (extensionPointsListBox.Items.Count > 0)
                     extensionPointsListBox.SelectedIndex = 0;
             }
+        }
+
+        private void ExtensionDialog_ResizeEnd(object sender, EventArgs e)
+        {
+            extensionNameColumn.Width = extensionListView.Width - 75;
         }
 
         private void button1_Click(object sender, System.EventArgs e)


### PR DESCRIPTION
This PR resolves #1259.
The extension dialog displays the list of extensions in two columns: extension name and extension state. When resizing the extension dialog the width of the name column should be adapted while the width of the state column remain fix.

So far this was realized by handling the `Resize` event of the listview. Actually there's nothing wrong with that besides that this event is invoked multiple times while resizing. Which means that multiple times the column width is adapted. Finally WinForms get out-of-sync and cannot draw the listview content anymore. Another indication is that the listview is flickering during resizing.

I propose to replace the `resize` event with the dialog `ResizeEnd` event. That event is invoked only a single time, when the operation is finished. And thus avoiding the out-of-sync state.
One visual drawback of that approach: the column width is not updated while resizing, but only once at the end - but I think that's acceptable.

