### PR TITLE
Simplify file menu: combine 'new' and 'open' items into one single 'open' item

### DIFF
--- a/src/TestCentric/testcentric.gui/Views/IMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/IMainView.cs
@@ -29,7 +29,6 @@ namespace TestCentric.Gui.Views
 
         // File Menu Items
         IPopup FileMenu { get; }
-        ICommand NewProjectCommand { get; }
         ICommand OpenProjectCommand { get; }
         ICommand SaveProjectCommand { get; }
 

--- a/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
+++ b/src/TestCentric/testcentric.gui/Views/TestCentricMainView.cs
@@ -112,7 +112,6 @@ namespace TestCentric.Gui.Views
         private ToolStripButton runFailedButton;
         private ToolStripSeparator toolStripSeparator5;
         private ToolStripButton rerunButton;
-        private ToolStripMenuItem newProjectMenuItem;
         private ToolStripMenuItem openProjectMenuItem;
         private ToolStripMenuItem saveProjectMenuItem;
         private ToolStripSeparator toolStripSeparator6;
@@ -136,7 +135,6 @@ namespace TestCentric.Gui.Views
 
             // Initialize File Menu Commands
             FileMenu = new PopupMenuElement(fileMenu);
-            NewProjectCommand = new CommandMenuElement(newProjectMenuItem);
             OpenProjectCommand = new CommandMenuElement(openProjectMenuItem);
             SaveProjectCommand = new CommandMenuElement(saveProjectMenuItem);
             CloseProjectCommand = new CommandMenuElement(closeMenuItem);
@@ -251,7 +249,6 @@ namespace TestCentric.Gui.Views
             this.runParametersButton = new System.Windows.Forms.ToolStripButton();
             this.mainMenu = new System.Windows.Forms.MenuStrip();
             this.fileMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.newProjectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openProjectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveProjectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.closeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -617,7 +614,6 @@ namespace TestCentric.Gui.Views
             // fileMenu
             // 
             this.fileMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newProjectMenuItem,
             this.openProjectMenuItem,
             this.saveProjectMenuItem,
             this.closeMenuItem,
@@ -636,29 +632,23 @@ namespace TestCentric.Gui.Views
             this.fileMenu.Size = new System.Drawing.Size(37, 20);
             this.fileMenu.Text = "&File";
             // 
-            // newProjectMenuItem
-            // 
-            this.newProjectMenuItem.Name = "newProjectMenuItem";
-            this.newProjectMenuItem.Size = new System.Drawing.Size(187, 22);
-            this.newProjectMenuItem.Text = "Create &New Project";
-            // 
             // openProjectMenuItem
             // 
             this.openProjectMenuItem.Name = "openProjectMenuItem";
             this.openProjectMenuItem.Size = new System.Drawing.Size(187, 22);
-            this.openProjectMenuItem.Text = "&Open Existing Project";
+            this.openProjectMenuItem.Text = "&Open";
             // 
             // saveProjectMenuItem
             // 
             this.saveProjectMenuItem.Name = "saveProjectMenuItem";
             this.saveProjectMenuItem.Size = new System.Drawing.Size(187, 22);
-            this.saveProjectMenuItem.Text = "&Save Project";
+            this.saveProjectMenuItem.Text = "&Save";
             // 
             // closeMenuItem
             // 
             this.closeMenuItem.Name = "closeMenuItem";
             this.closeMenuItem.Size = new System.Drawing.Size(187, 22);
-            this.closeMenuItem.Text = "&Close Project";
+            this.closeMenuItem.Text = "&Close";
             // 
             // toolStripSeparator6
             // 
@@ -1200,7 +1190,6 @@ namespace TestCentric.Gui.Views
 
         // File Menu Items
         public IPopup FileMenu { get; }
-        public ICommand NewProjectCommand { get; }
         public ICommand OpenProjectCommand { get; }
         public ICommand SaveProjectCommand { get; }
         public ICommand CloseProjectCommand { get; }

--- a/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -11,14 +11,6 @@ namespace TestCentric.Gui.Presenters.Main
 {
     public class WhenPresenterIsCreated : MainPresenterTestBase
     {
-#if NYI // Add after implementation of project or package saving
-        [TestCase("NewProjectCommand", true)]
-        [TestCase("OpenProjectCommand", true)]
-		[TestCase("SaveCommand", false)]
-        [TestCase("SaveAsCommand", false)]
-#endif
-
-        [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]
         [TestCase("SaveProjectCommand", false)]
         [TestCase("CloseProjectCommand", false)]

--- a/src/TestCentric/tests/Presenters/Main/WhenTestRunBegins.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestRunBegins.cs
@@ -21,7 +21,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireRunStartingEvent(1234);
         }
 
-        [TestCase("NewProjectCommand", false)]
         [TestCase("OpenProjectCommand", false)]
         [TestCase("SaveProjectCommand", false)]
         [TestCase("CloseProjectCommand", false)]

--- a/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -29,7 +29,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireRunFinishedEvent(resultNode);
         }
 
-        [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]
         [TestCase("SaveProjectCommand", true)]
         [TestCase("CloseProjectCommand", true)]

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -31,7 +31,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireTestLoadedEvent(testNode);
         }
 
-        [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]
         [TestCase("SaveProjectCommand", true)]
 

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoading.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreLoading.cs
@@ -18,7 +18,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireTestsLoadingEvent(new[] { "test.dll" });
         }
 
-        [TestCase("NewProjectCommand", false)]
         [TestCase("OpenProjectCommand", false)]
         [TestCase("SaveProjectCommand", false)]
 

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -27,7 +27,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireTestReloadedEvent(testNode);
         }
 
-        [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]
         [TestCase("SaveProjectCommand", true)]
 

--- a/src/TestCentric/tests/Presenters/Main/WhenTestsAreUnloaded.cs
+++ b/src/TestCentric/tests/Presenters/Main/WhenTestsAreUnloaded.cs
@@ -20,7 +20,6 @@ namespace TestCentric.Gui.Presenters.Main
             FireTestUnloadedEvent();
         }
 
-        [TestCase("NewProjectCommand", true)]
         [TestCase("OpenProjectCommand", true)]
         [TestCase("SaveProjectCommand", false)]
 

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -94,12 +94,5 @@ namespace TestCentric.Gui.Presenters.TestTree
             // Assert
             strategy.Received().SaveVisualState();
         }
-
-#if NYI // Add after implementation of project or package saving
-        [TestCase("NewProjectCommand", true)]
-        [TestCase("OpenProjectCommand", true)]
-        [TestCase("SaveCommand", true)]
-        [TestCase("SaveAsCommand", true)
-#endif
     }
 }

--- a/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreUnloaded.cs
+++ b/src/TestCentric/tests/Presenters/TestTree/WhenTestsAreUnloaded.cs
@@ -44,12 +44,5 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.OutcomeFilter.ReceivedWithAnyArgs().SelectedItems = null;
             _view.CategoryFilter.ReceivedWithAnyArgs().SelectedItems = null;
         }
-
-#if NYI // Add after implementation of project or package saving
-        [TestCase("NewProjectCommand", true)]
-        [TestCase("OpenProjectCommand", true)]
-        [TestCase("SaveCommand", true)]
-        [TestCase("SaveAsCommand", true)
-#endif
     }
 }


### PR DESCRIPTION
This PR resolves #1263.

As described in the issue itself, there's now only one single menu item to open either a tcproj or a dll/exe. The file dialog provides the different filter options accordingly.