### PR TITLE
Fix serialization of ShowNamespace attribute in VisualState file

### DIFF
--- a/src/TestCentric/testcentric.gui/VisualState.cs
+++ b/src/TestCentric/testcentric.gui/VisualState.cs
@@ -266,7 +266,7 @@ namespace TestCentric.Gui
             // GroupBy is null for NUnitTree strategy, otherwise required
             if (GroupBy == null && strategy != "NUNIT_TREE") GroupBy = "ASSEMBLY";
             ShowCheckBoxes = reader.GetAttribute("ShowCheckBoxes") == "True";
-            ShowNamespace = reader.GetAttribute("ShowNamespace") == "True";
+            ShowNamespace = reader.GetAttribute("ShowNamespace") != "False";
 
             while (reader.Read())
             {
@@ -381,8 +381,8 @@ namespace TestCentric.Gui
                 writer.WriteAttributeString("GroupBy", GroupBy);
             if (ShowCheckBoxes)
                 writer.WriteAttributeString("ShowCheckBoxes", "True");
-            if (ShowNamespace)
-                writer.WriteAttributeString("ShowNamespace", "True");
+            if (!ShowNamespace)
+                writer.WriteAttributeString("ShowNamespace", "False");
 
             WriteVisualTreeNodes(Nodes);
 

--- a/src/TestCentric/tests/VisualStateSerializationTests.cs
+++ b/src/TestCentric/tests/VisualStateSerializationTests.cs
@@ -37,7 +37,7 @@ namespace TestCentric.Gui
                 "</Nodes>\r\n" +
             "</VisualState>";
 
-        //[Test]
+        [Test]
         public void CanDeserializeVersion1VisualState()
         {
             var reader = new StringReader(V1_XML);
@@ -45,6 +45,8 @@ namespace TestCentric.Gui
             var vs = VisualState.LoadFrom(reader);
 
             Assert.That(vs.DisplayStrategy, Is.EqualTo("NUNIT_TREE"));
+            Assert.That(vs.ShowCheckBoxes, Is.EqualTo(false));
+            Assert.That(vs.ShowNamespace, Is.EqualTo(true));
         }
 
         [TestCaseSource(typeof(VisualStateSerializationData))]
@@ -68,7 +70,7 @@ namespace TestCentric.Gui
                 Assert.That(docElement.Name, Is.EqualTo("VisualState"));
                 Assert.That(docElement.GetAttribute("DisplayStrategy"), Is.EqualTo(vs.DisplayStrategy));
                 Assert.That(docElement.GetAttribute("ShowCheckBoxes"), Is.EqualTo(vs.ShowCheckBoxes ? "True" : ""));
-                Assert.That(docElement.GetAttribute("ShowNamespace"), Is.EqualTo(vs.ShowNamespace ? "True" : ""));
+                Assert.That(docElement.GetAttribute("ShowNamespace"), Is.EqualTo(!vs.ShowNamespace ? "False" : ""));
                 Assert.That(firstChild.Name, Is.EqualTo("Nodes"));
                 Assert.That(topNodes.Count, Is.EqualTo(vs.Nodes.Count));
                 for (int i = 0; i < topNodes.Count; i++)
@@ -154,7 +156,15 @@ namespace TestCentric.Gui
                         null,
                         checkBoxes: true,
                         showNamespace: true))
-                    .SetName("NUnitTree_EmptyWithTwoAttributes)");
+                    .SetName("NUnitTree_Empty_ShowNamespaceIsTrue)");
+
+                yield return new TestCaseData(
+                    VisualStateTestData.CreateVisualState(
+                        "NUNIT_TREE",
+                        null,
+                        checkBoxes: true,
+                        showNamespace: false))
+                    .SetName("NUnitTree_Empty_ShowNamespaceIsFalse)");
 
                 yield return new TestCaseData(
                     VisualStateTestData.CreateVisualState(


### PR DESCRIPTION
This PR resolves #1266 by fixing the default value handling of the ShowNamespace attribute.

Actually, it was always intended that the default value of the ShowNamespace attribute should be set to true. That works fine even in case there's no VisualState file or no TestCentric setting file. However it breaks in case there's a VisualState file from a previous TestCentric version (1.X or 2.X). Of course, these older files cannot yet contain the ShowNamespace attribute, so some default value handling must be applied. Unfortunately, the default value handling had been implemented exactly the other way around: if there's no value present, the ShowNamespace attribute was set to false. This behavior doesn't fit to this use case and therefore needs to be adjusted.

The ShowNamespace attribute is serialized into the VisualState file only in case it's set to false now. If the attribute is not present in the file, the default value 'true' is applied.