### PR TITLE
Fix display of previous test results

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestGroupTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestGroupTests.cs
@@ -57,24 +57,24 @@ namespace TestCentric.Gui.Presenters
             Assert.That(ids, Is.EqualTo(new string[] { "1", "3" }));
         }
 
-        [TestCase(TestTreeView.InitIndex, "Passed", TestTreeView.SuccessIndex)]
-        [TestCase(TestTreeView.InitIndex, "Failed", TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.SkippedIndex, "Warning", TestTreeView.WarningIndex)]
-        [TestCase(TestTreeView.SuccessIndex, "Failed", TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.SuccessIndex, "Warning", TestTreeView.WarningIndex)]
-        [TestCase(TestTreeView.WarningIndex, "Failed", TestTreeView.FailureIndex)]
-        [TestCase(TestTreeView.InconclusiveIndex, "Passed", TestTreeView.SuccessIndex)]
-        [TestCase(TestTreeView.IgnoredIndex, "Passed", TestTreeView.IgnoredIndex)]
-        [TestCase(TestTreeView.FailureIndex, "Passed", TestTreeView.FailureIndex)]
-        public void AddTestWithResult(int imageIndex, string outcome, int expectedImageIndex)
+        [TestCase("Skipped", "Ignored", "Warning", TestTreeView.WarningIndex)]
+        [TestCase("Passed", "Ignored", "Failed", TestTreeView.FailureIndex)]
+        [TestCase("Passed", "Ignored", "Warning", TestTreeView.WarningIndex)]
+        [TestCase("Warning", "Ignored", "Failed", TestTreeView.FailureIndex)]
+        [TestCase("Inconclusive", "Ignored", "Passed", TestTreeView.SuccessIndex)]
+        [TestCase("Skipped", "Ignored", "Passed", TestTreeView.IgnoredIndex)]
+        [TestCase("Failed", "Ignored", "Passed", TestTreeView.FailureIndex)]
+        public void AddTestsWithResults_CheckImageIndex(string outcome1, string label1, string outcome2, int expectedImageIndex)
         {
             // Arrange
-            var group = new TestGroup("TestGroup", imageIndex);
+            var group = new TestGroup("TestGroup");
             var testNode = MakeTestNode("1", "Tom", "Runnable");
-            var resultNode = new ResultNode($"<test-case id='1' result='{outcome}'/>");
+            var resultNode1 = new ResultNode($"<test-case id='1' result='{outcome1}' label='{label1}'/>");
+            var resultNode2 = new ResultNode($"<test-case id='1' result='{outcome2}'/>");
 
             // Act
-            group.Add(testNode, resultNode);
+            group.Add(testNode, resultNode1);
+            group.Add(testNode, resultNode2);
 
             // Assert
             Assert.That(group.ImageIndex, Is.EqualTo(expectedImageIndex));

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -257,7 +257,12 @@ namespace TestCentric.Gui.Presenters
 
         public static int CalcImageIndex(ResultNode resultNode, bool latestRun)
         {
-            switch (resultNode.Outcome.Status)
+            return CalcImageIndex(resultNode.Outcome, latestRun);
+        }
+
+        public static int CalcImageIndex(ResultState resultState, bool latestRun)
+        {
+            switch (resultState.Status)
             {
                 case TestStatus.Inconclusive:
                     return latestRun ? TestTreeView.InconclusiveIndex : TestTreeView.InconclusiveIndex_NotLatestRun;
@@ -269,7 +274,7 @@ namespace TestCentric.Gui.Presenters
                     return latestRun ? TestTreeView.WarningIndex : TestTreeView.WarningIndex_NotLatestRun;
                 case TestStatus.Skipped:
                 default:
-                    return resultNode.Outcome.Label == "Ignored"
+                    return resultState.Label == "Ignored"
                         ? latestRun ? TestTreeView.IgnoredIndex : TestTreeView.IgnoredIndex_NotLatestRun
                         : TestTreeView.SkippedIndex;
             }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestGroup.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestGroup.cs
@@ -3,12 +3,10 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using System.Text;
-using System.Windows.Forms;
 
 namespace TestCentric.Gui.Presenters
 {
-    using System;
+    using System.Windows.Forms;
     using Model;
     using TestCentric.Gui.Model.Filter;
 
@@ -21,6 +19,10 @@ namespace TestCentric.Gui.Presenters
     /// </summary>
     public class TestGroup : TestSelection, ITestItem
     {
+        private ResultState _groupResultState;
+        private bool _isResultFromLatestRun;
+
+
         #region Constructors
 
         public TestGroup(string name) : this(name, -1) { }
@@ -64,8 +66,12 @@ namespace TestCentric.Gui.Presenters
             Add(testNode);
             if (resultNode != null)
             {
-                int imageIndex = DisplayStrategy.CalcImageIndex(resultNode);
-                ImageIndex = Math.Max(imageIndex, ImageIndex);
+                if (_groupResultState == null || TestResultManager.GetOutcome(_groupResultState) < TestResultManager.GetOutcome(resultNode.Outcome))
+                    _groupResultState = resultNode.Outcome;
+
+                _isResultFromLatestRun = _isResultFromLatestRun || resultNode.IsLatestRun;
+
+                ImageIndex = DisplayStrategy.CalcImageIndex(_groupResultState, _isResultFromLatestRun);
             }
         }
     }

--- a/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
+++ b/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace TestCentric.Gui.Model
@@ -34,6 +35,50 @@ namespace TestCentric.Gui.Model
             Assert.That(newResultNode.Id, Is.EqualTo("100"));
             Assert.That(newResultNode.FullName, Is.EqualTo(resultNode.FullName));
             Assert.That(newResultNode.Status, Is.EqualTo(resultNode.Status));
+            Assert.That(newResultNode.IsLatestRun, Is.EqualTo(false));
+        }
+
+        private static object[] ReplaceResultStateTestCases =
+        {
+                new object[] { ResultState.Success, TestStatus.Passed },
+                new object[] { ResultState.Failure, TestStatus.Failed },
+                new object[] { ResultState.Error, TestStatus.Failed },
+                new object[] { ResultState.Skipped, TestStatus.Skipped },
+                new object[] { ResultState.Ignored, TestStatus.Skipped },
+                new object[] { ResultState.Inconclusive, TestStatus.Inconclusive },
+                new object[] { ResultState.Explicit, TestStatus.Skipped },
+        };
+
+        [Test]
+        [TestCaseSource(nameof(ReplaceResultStateTestCases))]
+        public void CreateResultNode_FromOldResult_ReplaceResultState(ResultState resultState, TestStatus expectedTestStatus)
+        {
+            // Act
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Passed'/>");
+
+            // Arrange
+            ResultNode newResultNode = ResultNode.Create(resultNode.Xml, resultState);
+
+            // Assert
+            Assert.That(newResultNode.Id, Is.EqualTo("1"));
+            Assert.That(newResultNode.FullName, Is.EqualTo(resultNode.FullName));
+            Assert.That(newResultNode.Status, Is.EqualTo(expectedTestStatus));
+            Assert.That(newResultNode.IsLatestRun, Is.EqualTo(false));
+        }
+
+        [TestCaseSource(nameof(ReplaceResultStateTestCases))]
+        public void CreateResultNode_FromOldResult_ReplaceResultState2(ResultState resultState, TestStatus expectedTestStatus)
+        {
+            // Act
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Skipped' label='Ignored' />");
+
+            // Arrange
+            ResultNode newResultNode = ResultNode.Create(resultNode.Xml, resultState);
+
+            // Assert
+            Assert.That(newResultNode.Id, Is.EqualTo("1"));
+            Assert.That(newResultNode.FullName, Is.EqualTo(resultNode.FullName));
+            Assert.That(newResultNode.Status, Is.EqualTo(expectedTestStatus));
             Assert.That(newResultNode.IsLatestRun, Is.EqualTo(false));
         }
 

--- a/src/GuiRunner/TestModel/ResultNode.cs
+++ b/src/GuiRunner/TestModel/ResultNode.cs
@@ -54,7 +54,10 @@ namespace TestCentric.Gui.Model
             if (!string.IsNullOrEmpty(resultState.Label))
             {
                 attribute = xmlNode.Attributes["label"];
-                attribute.Value = resultState.Label;
+                if (attribute == null)
+                    xmlNode.AddAttribute("label", resultState.Label);
+                else
+                    attribute.Value = resultState.Label;
             }
 
             return new ResultNode(xmlNode) { IsLatestRun = false };


### PR DESCRIPTION
This PR fixes #1328.

The TestGroup logic to calculate the groups ImageIndex is improved. It's not sufficient to use the max value, but instead it must be taken additional into account if a test result was from a previous or current run.