### PR TITLE
Enable 'Select agent' menu item when using NUnit agents

### DIFF
--- a/src/GuiRunner/TestModel/TestServices.cs
+++ b/src/GuiRunner/TestModel/TestServices.cs
@@ -24,7 +24,7 @@ namespace TestCentric.Gui.Model
 
             ExtensionService = GetService<IExtensionService>();
             ResultService = GetService<IResultService>();
-            TestAgentService = new TestAgentService();
+            TestAgentService = GetService<TestAgentService>();
         }
 
         #region ITestServices Implementation

--- a/src/TestEngine/testcentric.engine/Services/TestAgency.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestAgency.cs
@@ -59,12 +59,12 @@ namespace TestCentric.Engine.Services
 
             foreach (var node in _launcherNodes)
             {
-                var runtimes = node.GetValues("TargetFramework");
+                var runtimes = node.GetValues("TargetFramework").ToList();
                 if (runtimes.Count() > 0)
                     agents.Add(new NUnit.Engine.TestAgentInfo(
                         GetAgentName(node),
                         NUnit.Engine.TestAgentType.LocalProcess,
-                        RuntimeFramework.Parse(runtimes.First()).FrameworkName));
+                        RuntimeFramework.FromFrameworkName(runtimes.First()).FrameworkName));
             }
 
             return agents;


### PR DESCRIPTION
This PR (re-)enables the 'Select agent' menu item after switching to the NUnit agents and NUnit extensibility.
Here's a screenshot:
<img width="547" height="149" alt="image" src="https://github.com/user-attachments/assets/27ab4a19-ce38-49b7-abdf-bc59420d745d" />

Some comments about the actual code changes:

- Instead of creating a new instance of the `TestAgentService`, I propose to retrieve an instance using a `GetService `call. The existing code which creates a new instance missed to start the service. So, it was not initialized and contains no provides.
Using the GetService call we retrieve an initialized service. One drawback might be that we use a concrete class in the GetService call instead of an interface, but I copied this call from the AssemblyRunner class - so, I assume it's OK for now.

- After this change the method `RuntimeFramework.Parse` thrown an exception, because the input doesn't have the expected format. Luckily I spotted another existing method (`RuntimeFramework.FromFrameworkName`) which is capable to process the input and provide the FrameworkName. So, I switched to use this method.
Here's a screenshot of the runtime name:
<img width="730" height="265" alt="image" src="https://github.com/user-attachments/assets/e2da5535-dbbe-4dc0-975d-b021d9d0cdf7" />

