### PR TITLE
Fix crash when opening menu without any project loaded

### DIFF
--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -455,7 +455,11 @@ namespace TestCentric.Gui.Model
 
         public IList<string> GetAgentsForPackage(TestPackage package = null)
         {
-            if (package == null) package = TestCentricProject;
+            if (package == null)
+                package = TestCentricProject;
+
+            if (package == null)                // no project is loaded
+                return new List<string>();
 
             return new List<string>(
                 Services.GetService<TestAgentService>().GetAgentsForPackage(package).Select(a => a.AgentName));


### PR DESCRIPTION
This PR fixes a crash when opening the menu but no project is loaded. It's caused by our latest changes regarding the 'agent selection menu item'. We want to update this menu item whenever the menu is opened, which also happens when no project is loaded.

I fixed this crash by  extending method `TestModel.GetAgentsForPackage()`, Instead of throwing an exception I defined that this method returns an empty list when the input is null and no project is loaded.