### PR TITLE
Use ConfigurationManager to store user settings

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
@@ -337,7 +337,7 @@ namespace TestCentric.Gui.Presenters
 
                 _view.ReloadTestsCommand.Enabled = isPackageLoaded && !isTestRunning;
 
-                _agentSelectionController.UpdateMenuItems();
+                // _agentSelectionController.UpdateMenuItems();
 
                 _view.RunAsX86.Enabled = isPackageLoaded && !isTestRunning;
 

--- a/src/GuiRunner/TestModel/Settings/SettingsStore.cs
+++ b/src/GuiRunner/TestModel/Settings/SettingsStore.cs
@@ -8,12 +8,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Runtime.Remoting.Contexts;
-using System.Text;
-using System.Xml;
 
 namespace TestCentric.Gui.Model.Settings
 {
+    using System.Configuration;
+
     /// <summary>
     /// SettingsStore implements the loading and saving of settings
     /// from an XML file and allows access to them via a key
@@ -25,7 +24,6 @@ namespace TestCentric.Gui.Model.Settings
 
         protected Dictionary<string, object> _settings = new Dictionary<string, object>();
 
-        private string _settingsFile;
         private bool _writeable;
         private object _myLock;
 
@@ -41,42 +39,28 @@ namespace TestCentric.Gui.Model.Settings
         /// <param name="writeable"></param>
         public SettingsStore(string settingsFile, bool writeable)
         {
-            _settingsFile = Path.GetFullPath(settingsFile);
             _writeable = writeable;
             _myLock = new object();
         }
 
         public void LoadSettings()
         {
-            FileInfo info = new FileInfo(_settingsFile);
-            if (!info.Exists || info.Length == 0)
-                return;
+            var userConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
 
             try
             {
-                XmlDocument doc = new XmlDocument();
-                using (var stream = new FileStream(_settingsFile, FileMode.Open, FileAccess.Read))
+                ExeConfigurationFileMap fileMap = new ExeConfigurationFileMap() { ExeConfigFilename = userConfigFile.FilePath };
+                Configuration configFile = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None);
+
+                var settings = configFile.AppSettings.Settings;
+                foreach (KeyValueConfigurationElement setting in settings)
                 {
-                    doc.Load(stream);
-                }
-
-                foreach (XmlElement element in doc.DocumentElement["Settings"].ChildNodes)
-                {
-                    if (element.Name != "Setting")
-                        throw new Exception("Unknown element in settings file: " + element.Name);
-
-                    if (!element.HasAttribute("name"))
-                        throw new Exception("Setting must have 'name' attribute");
-
-                    if (!element.HasAttribute("value"))
-                        throw new Exception("Setting must have 'value' attribute");
-
-                    SaveSetting(element.GetAttribute("name"), element.GetAttribute("value"));
+                    SaveSetting(setting.Key, setting.Value);
                 }
             }
             catch (Exception ex)
             {
-                string msg = string.Format("Error loading settings {0}. {1}", _settingsFile, ex.Message);
+                string msg = string.Format("Error loading settings {0}. {1}", userConfigFile.FilePath, ex.Message);
                 throw new Exception(msg, ex);
             }
         }
@@ -90,14 +74,29 @@ namespace TestCentric.Gui.Model.Settings
             {
                 try
                 {
-                    var contents = CreateSettingContents();
+                    var userConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+                    ExeConfigurationFileMap fileMap = new ExeConfigurationFileMap() { ExeConfigFilename = userConfigFile.FilePath };
+                    Configuration configFile = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None);
 
-                    // Ensure that the contents are readable before writing.
-                    // Remove comments on next two lines to debug file corruption issues.
-                    //XmlDocument doc = new XmlDocument();
-                    //doc.LoadXml(contents);
+                    var settings = configFile.AppSettings.Settings;
+                    List<string> keys = new List<string>(_settings.Keys);
+                    keys.Sort();
 
-                    WriteSettingsToFile(contents);
+                    foreach (string name in keys)
+                    {
+                        object value = GetSetting(name);
+                        string valueToWrite = TypeDescriptor.GetConverter(value).ConvertToInvariantString(value);
+                        if (settings[name] == null)
+                        {
+                            settings.Add(name, valueToWrite);
+                        }
+                        else
+                        {
+                            settings[name].Value = valueToWrite;
+                        }
+                    }
+
+                    configFile.Save(ConfigurationSaveMode.Modified);
                 }
                 catch (Exception)
                 {
@@ -106,53 +105,6 @@ namespace TestCentric.Gui.Model.Settings
                     throw;
                 }
             }
-        }
-
-        private string CreateSettingContents()
-        {
-            var stream = new MemoryStream();
-            using (var writer = new XmlTextWriter(stream, Encoding.UTF8))
-            {
-                writer.Formatting = Formatting.Indented;
-
-                writer.WriteProcessingInstruction("xml", "version=\"1.0\"");
-                writer.WriteStartElement("NUnitSettings");
-                writer.WriteStartElement("Settings");
-
-                List<string> keys = new List<string>(_settings.Keys);
-                keys.Sort();
-
-                foreach (string name in keys)
-                {
-                    object val = GetSetting(name);
-                    if (val != null)
-                    {
-                        writer.WriteStartElement("Setting");
-                        writer.WriteAttributeString("name", name);
-                        writer.WriteAttributeString("value",
-                            TypeDescriptor.GetConverter(val).ConvertToInvariantString(val));
-                        writer.WriteEndElement();
-                    }
-                }
-
-                writer.WriteEndElement();
-                writer.WriteEndElement();
-                writer.Flush();
-
-                var reader = new StreamReader(stream, Encoding.UTF8, true);
-                stream.Seek(0, SeekOrigin.Begin);
-
-                return reader.ReadToEnd();
-            }
-        }
-
-        private void WriteSettingsToFile(string contents)
-        {
-            string dirPath = Path.GetDirectoryName(_settingsFile);
-            if (!Directory.Exists(dirPath))
-                Directory.CreateDirectory(dirPath);
-
-            File.WriteAllText(_settingsFile, contents, Encoding.UTF8);
         }
 
         #region ISettings Implementation

--- a/src/GuiRunner/TestModel/TestCentric.Gui.Model.csproj
+++ b/src/GuiRunner/TestModel/TestCentric.Gui.Model.csproj
@@ -14,4 +14,7 @@
     <PackageReference Include="NUnit.Extensibility" Version="$(NUnitApiVersion)" />
     <PackageReference Include="TestCentric.InternalTrace" Version="$(InternalTraceVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is intended only as a draft for #1342 (and not the final solution). In this PR I evaluate the direct usage of the `ConfigurationManager` class to read/write user settings. 

- This approach fits well in our existing design. We just need to replace the IO-operations with the appropriate `ConfigurationManager` methods. That's all and really easy!
- The user setting file (user.config) is stored in folder AppData\Local\TestCentric\testcentric.exe_StrongName_l4olpu2u0j01dg13xxpj02ttammiohbl\2.0.0.0
This folder name looks suspicious, but it seems to be the common naming convention.

- The actual settings are stored as <key, value> pairs in the &lt;appSettings&gt; section. Here's a screenshot:
<img width="834" height="207" alt="image" src="https://github.com/user-attachments/assets/891f28f5-6982-4bb9-a7fc-a3a5c8d22945" />
When getting familiar with settings I learned there's a difference between &lt;appSettings&gt; and &lt;applicationSettings&gt; and discussions about the pro/cons of each approach. Ultimately, &lt;applicationSettings&gt; is probably the newer approach which contains also type checking. I hope it will be used when evaluating the next approach.

- It may not look like it, but these three lines were not that easy. Only a lot of googling helped here and I'm still not convinced or didn't understand the concept in total why the first line isn't sufficient.
```
Configuration userConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
ExeConfigurationFileMap fileMap = new ExeConfigurationFileMap() { ExeConfigFilename = userConfigFile.FilePath };
Configuration configFile = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None);
```

So, that's all for now - I want to keep this draft PR open to compare it with the other approaches