### PR TITLE
Extension dialog: fix resize; harmonize and align UI elements

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Dialogs/ExtensionDialog.cs
+++ b/src/GuiRunner/TestCentric.Gui/Dialogs/ExtensionDialog.cs
@@ -7,8 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Windows.Forms;
-using TestCentric.Engine.Services;
 using NUnit.Extensibility;
+using TestCentric.Engine.Services;
 
 namespace TestCentric.Gui.Dialogs
 {
@@ -26,7 +26,6 @@ namespace TestCentric.Gui.Dialogs
         private System.Windows.Forms.ColumnHeader extensionStatusColumn;
         private ColumnHeader extensionEnabledColumn;
         private TextBox extensionDescription2;
-        private Label descriptionLabel;
         private Label label3;
         private TextBox extensionProperties2;
 
@@ -61,7 +60,7 @@ namespace TestCentric.Gui.Dialogs
         private Label assemblyVersion1;
         private Label label13;
         private Label label12;
-        private TextBox extensionPointPath;
+        private Label extensionPointPath;
         private IExtensionService _extensionService;
 
         public ExtensionDialog(IExtensionService extensionService)
@@ -109,7 +108,6 @@ namespace TestCentric.Gui.Dialogs
             this.extensionProperties2 = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.extensionDescription2 = new System.Windows.Forms.TextBox();
-            this.descriptionLabel = new System.Windows.Forms.Label();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.assemblyVersion1 = new System.Windows.Forms.Label();
@@ -133,7 +131,7 @@ namespace TestCentric.Gui.Dialogs
             this.assemblyPath2 = new TestCentric.Gui.Controls.ExpandingLabel();
             this.extensionPointsListBox = new System.Windows.Forms.ListBox();
             this.label12 = new System.Windows.Forms.Label();
-            this.extensionPointPath = new System.Windows.Forms.TextBox();
+            this.extensionPointPath = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
@@ -152,11 +150,11 @@ namespace TestCentric.Gui.Dialogs
             this.extensionListView2.FullRowSelect = true;
             this.extensionListView2.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
             this.extensionListView2.HideSelection = false;
-            this.extensionListView2.Location = new System.Drawing.Point(9, 199);
+            this.extensionListView2.Location = new System.Drawing.Point(3, 199);
             this.extensionListView2.MultiSelect = false;
             this.extensionListView2.Name = "extensionListView2";
             this.extensionListView2.ShowItemToolTips = true;
-            this.extensionListView2.Size = new System.Drawing.Size(443, 99);
+            this.extensionListView2.Size = new System.Drawing.Size(449, 99);
             this.extensionListView2.TabIndex = 0;
             this.extensionListView2.UseCompatibleStateImageBehavior = false;
             this.extensionListView2.View = System.Windows.Forms.View.Details;
@@ -205,7 +203,7 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(7, 504);
+            this.label6.Location = new System.Drawing.Point(7, 508);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(53, 13);
             this.label6.TabIndex = 11;
@@ -217,7 +215,7 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(7, 473);
+            this.label5.Location = new System.Drawing.Point(7, 475);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(37, 13);
             this.label5.TabIndex = 10;
@@ -229,21 +227,23 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(6, 450);
+            this.label4.Location = new System.Drawing.Point(0, 450);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(118, 13);
             this.label4.TabIndex = 8;
-            this.label4.Text = "Extension Assembly";
+            this.label4.Text = "Extension Assembly:";
             // 
             // extensionProperties2
             // 
             this.extensionProperties2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.extensionProperties2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.extensionProperties2.Location = new System.Drawing.Point(10, 394);
+            this.extensionProperties2.Location = new System.Drawing.Point(3, 394);
             this.extensionProperties2.Multiline = true;
+            this.extensionProperties2.ReadOnly = true;
+            this.extensionProperties2.BackColor = System.Drawing.SystemColors.Window;
             this.extensionProperties2.Name = "extensionProperties2";
-            this.extensionProperties2.Size = new System.Drawing.Size(442, 41);
+            this.extensionProperties2.Size = new System.Drawing.Size(449, 41);
             this.extensionProperties2.TabIndex = 6;
             // 
             // label3
@@ -252,32 +252,24 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(7, 378);
+            this.label3.Location = new System.Drawing.Point(0, 378);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(123, 13);
             this.label3.TabIndex = 5;
-            this.label3.Text = "Extension Properties";
+            this.label3.Text = "Extension Properties:";
             // 
             // extensionDescription2
             // 
             this.extensionDescription2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.extensionDescription2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.extensionDescription2.Location = new System.Drawing.Point(10, 333);
+            this.extensionDescription2.Location = new System.Drawing.Point(3, 333);
             this.extensionDescription2.Multiline = true;
+            this.extensionDescription2.ReadOnly = true;
+            this.extensionDescription2.BackColor = System.Drawing.SystemColors.Window;
             this.extensionDescription2.Name = "extensionDescription2";
-            this.extensionDescription2.Size = new System.Drawing.Size(442, 31);
+            this.extensionDescription2.Size = new System.Drawing.Size(449, 31);
             this.extensionDescription2.TabIndex = 4;
-            // 
-            // descriptionLabel
-            // 
-            this.descriptionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.descriptionLabel.Location = new System.Drawing.Point(7, 314);
-            this.descriptionLabel.Name = "descriptionLabel";
-            this.descriptionLabel.Size = new System.Drawing.Size(0, 16);
-            this.descriptionLabel.TabIndex = 3;
-            this.descriptionLabel.Text = "Description:";
             // 
             // tabControl1
             // 
@@ -331,7 +323,7 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label13.AutoSize = true;
             this.label13.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label13.Location = new System.Drawing.Point(10, 405);
+            this.label13.Location = new System.Drawing.Point(10, 410);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(53, 13);
             this.label13.TabIndex = 13;
@@ -343,7 +335,7 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(10, 375);
+            this.label8.Location = new System.Drawing.Point(10, 378);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(37, 13);
             this.label8.TabIndex = 10;
@@ -366,7 +358,7 @@ namespace TestCentric.Gui.Dialogs
             this.extensionListView1.MultiSelect = false;
             this.extensionListView1.Name = "extensionListView1";
             this.extensionListView1.ShowItemToolTips = true;
-            this.extensionListView1.Size = new System.Drawing.Size(443, 182);
+            this.extensionListView1.Size = new System.Drawing.Size(449, 182);
             this.extensionListView1.TabIndex = 11;
             this.extensionListView1.UseCompatibleStateImageBehavior = false;
             this.extensionListView1.View = System.Windows.Forms.View.Details;
@@ -397,7 +389,7 @@ namespace TestCentric.Gui.Dialogs
             this.assemblyPath1.Location = new System.Drawing.Point(62, 374);
             this.assemblyPath1.Name = "assemblyPath1";
             this.assemblyPath1.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
-            this.assemblyPath1.Size = new System.Drawing.Size(384, 21);
+            this.assemblyPath1.Size = new System.Drawing.Size(389, 21);
             this.assemblyPath1.TabIndex = 9;
             // 
             // label9
@@ -406,11 +398,11 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(4, 340);
+            this.label9.Location = new System.Drawing.Point(0, 350);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(118, 13);
             this.label9.TabIndex = 8;
-            this.label9.Text = "Extension Assembly";
+            this.label9.Text = "Extension Assembly:";
             // 
             // extensionProperties1
             // 
@@ -419,8 +411,10 @@ namespace TestCentric.Gui.Dialogs
             this.extensionProperties1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.extensionProperties1.Location = new System.Drawing.Point(3, 279);
             this.extensionProperties1.Multiline = true;
+            this.extensionProperties1.ReadOnly = true;
+            this.extensionProperties1.BackColor = System.Drawing.SystemColors.Window;
             this.extensionProperties1.Name = "extensionProperties1";
-            this.extensionProperties1.Size = new System.Drawing.Size(443, 41);
+            this.extensionProperties1.Size = new System.Drawing.Size(449, 55);
             this.extensionProperties1.TabIndex = 6;
             // 
             // label11
@@ -439,11 +433,11 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label10.AutoSize = true;
             this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label10.Location = new System.Drawing.Point(4, 263);
+            this.label10.Location = new System.Drawing.Point(0, 263);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(64, 13);
             this.label10.TabIndex = 5;
-            this.label10.Text = "Properties";
+            this.label10.Text = "Properties:";
             // 
             // extensionDescription1
             // 
@@ -452,8 +446,10 @@ namespace TestCentric.Gui.Dialogs
             this.extensionDescription1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.extensionDescription1.Location = new System.Drawing.Point(3, 218);
             this.extensionDescription1.Multiline = true;
+            this.extensionDescription1.ReadOnly = true;
+            this.extensionDescription1.BackColor = System.Drawing.SystemColors.Window;
             this.extensionDescription1.Name = "extensionDescription1";
-            this.extensionDescription1.Size = new System.Drawing.Size(443, 31);
+            this.extensionDescription1.Size = new System.Drawing.Size(449, 31);
             this.extensionDescription1.TabIndex = 4;
             // 
             // tabPage2
@@ -470,7 +466,6 @@ namespace TestCentric.Gui.Dialogs
             this.tabPage2.Controls.Add(this.label4);
             this.tabPage2.Controls.Add(this.extensionListView2);
             this.tabPage2.Controls.Add(this.extensionProperties2);
-            this.tabPage2.Controls.Add(this.descriptionLabel);
             this.tabPage2.Controls.Add(this.label3);
             this.tabPage2.Controls.Add(this.extensionDescription2);
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
@@ -483,28 +478,30 @@ namespace TestCentric.Gui.Dialogs
             // 
             // label7
             // 
+            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(6, 308);
+            this.label7.Location = new System.Drawing.Point(0, 315);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(130, 13);
             this.label7.TabIndex = 14;
-            this.label7.Text = "Extension Description";
+            this.label7.Text = "Extension Description:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(9, 183);
+            this.label2.Location = new System.Drawing.Point(0, 180);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(191, 13);
             this.label2.TabIndex = 13;
-            this.label2.Text = "Extensions at this ExensionPoint";
+            this.label2.Text = "Extensions at this ExensionPoint:";
             // 
             // label1
             // 
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(6, 113);
+            this.label1.Location = new System.Drawing.Point(0, 113);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(211, 16);
             this.label1.TabIndex = 2;
@@ -515,10 +512,10 @@ namespace TestCentric.Gui.Dialogs
             this.extensionPointDescriptionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.extensionPointDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.extensionPointDescriptionTextBox.Location = new System.Drawing.Point(7, 132);
+            this.extensionPointDescriptionTextBox.Location = new System.Drawing.Point(3, 132);
             this.extensionPointDescriptionTextBox.Multiline = true;
             this.extensionPointDescriptionTextBox.Name = "extensionPointDescriptionTextBox";
-            this.extensionPointDescriptionTextBox.Size = new System.Drawing.Size(445, 31);
+            this.extensionPointDescriptionTextBox.Size = new System.Drawing.Size(448, 31);
             this.extensionPointDescriptionTextBox.TabIndex = 1;
             // 
             // assemblyPath2
@@ -539,27 +536,32 @@ namespace TestCentric.Gui.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.extensionPointsListBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.extensionPointsListBox.FormattingEnabled = true;
-            this.extensionPointsListBox.Location = new System.Drawing.Point(6, 6);
+            this.extensionPointsListBox.Location = new System.Drawing.Point(3, 6);
             this.extensionPointsListBox.Name = "extensionPointsListBox";
-            this.extensionPointsListBox.Size = new System.Drawing.Size(446, 93);
+            this.extensionPointsListBox.Size = new System.Drawing.Size(449, 93);
             this.extensionPointsListBox.TabIndex = 6;
             this.extensionPointsListBox.SelectedIndexChanged += new System.EventHandler(this.Tab2_SelectedExtensionPointChanged);
             // 
             // label12
             // 
+            this.label12.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label12.AutoSize = true;
             this.label12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label12.Location = new System.Drawing.Point(4, 442);
+            this.label12.Location = new System.Drawing.Point(0, 442);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(121, 13);
             this.label12.TabIndex = 15;
-            this.label12.Text = "ExtensionPoint Path";
+            this.label12.Text = "ExtensionPoint Path:";
             // 
             // extensionPointPath
             // 
+            this.extensionPointPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.extensionPointPath.BackColor = System.Drawing.SystemColors.Window;
+            this.extensionPointPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.extensionPointPath.Location = new System.Drawing.Point(3, 462);
             this.extensionPointPath.Name = "extensionPointPath";
-            this.extensionPointPath.Size = new System.Drawing.Size(443, 20);
+            this.extensionPointPath.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.extensionPointPath.Size = new System.Drawing.Size(449, 21);
             this.extensionPointPath.TabIndex = 16;
             // 
             // ExtensionDialog
@@ -637,7 +639,8 @@ namespace TestCentric.Gui.Dialogs
 
                     extensionProperties1.AppendText(sb.ToString() + Environment.NewLine);
                 }
-
+                extensionProperties1.Select(0, 0);
+                extensionProperties1.ScrollToCaret();
                 assemblyPath1.Text = extension.AssemblyPath;
                 assemblyVersion1.Text = extension.AssemblyVersion.ToString();
 


### PR DESCRIPTION
This PR fixes #1351 by adapting some UI elements in the extension dialog:

- set anchor property so that UI elements are placed/sized properly while resizing
- harmonize header texts (by adding':' to all headers)
- harmonize position/size of headers to get some alignment