### PR TITLE
Fix exception using SelectAgent menu

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/AgentSelectionController.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/AgentSelectionController.cs
@@ -84,13 +84,11 @@ namespace TestCentric.Gui.Presenters
                 EnsureSingleItemChecked(item);
 
                 // TODO: We currently need to use both settings. Investigate.
+                _model.TestCentricProject.RemoveSetting(SettingDefinitions.SelectedAgentName);
+                _model.TestCentricProject.RemoveSetting(SettingDefinitions.RequestedAgentName);
+
                 string itemTag = item.Tag as string;
-                if (itemTag == null || itemTag == "DEFAULT")
-                {
-                    _model.TestCentricProject.RemoveSetting(SettingDefinitions.SelectedAgentName);
-                    _model.TestCentricProject.RemoveSetting(SettingDefinitions.RequestedAgentName);
-                }
-                else
+                if (itemTag is not null && itemTag != "DEFAULT")
                 {
                     _model.TestCentricProject.AddSetting(SettingDefinitions.SelectedAgentName.WithValue(itemTag));
                     _model.TestCentricProject.AddSetting(SettingDefinitions.RequestedAgentName.WithValue(itemTag));


### PR DESCRIPTION
Fixes #1354 

This actually fixes the original problem and two additional related problems that were hidden behind it. All of them relate to the use of the full name of the extension Type.

The basic problem is that `NUnit.Engine.TestAgentInfo` provides an `AgentName field` intended as a display name for the agent. We were using that value as the tag for each menu item, rather than the full name of the type, which is contained in the `ExtensionNode`. The key to this fix is that we are now ignoring the display name provided by the agent, which is OK for our existing agents but not a good recipe for the future.

Complicating matters, we are in the process of switching to use NUnit services in place of our own, so any changes we make will need to be ported to NUnit.    

@rowo360 In reviewing this, please try to suggest any longer term improvements. We may even want to implement a better solution on the TestCentric side now, for later porting to NUnit.