### PR TITLE
Extned package tests for x86 platform

### DIFF
--- a/package-tests.cake
+++ b/package-tests.cake
@@ -62,6 +62,22 @@ public static class PackageTests
             "net9.0/mock-assembly.dll",
             MockAssemblyExpectedResult("Net90AgentLauncher")));
 
+        GuiAndEngineTests.Add(new PackageTest(1, "Net60X86Test", "Run mock-assembly-x86.dll under .NET 6.0",
+            "net6.0/mock-assembly-x86.dll",
+            MockAssemblyX86ExpectedResult("Net60AgentLauncher")));
+
+        GuiAndEngineTests.Add(new PackageTest(1, "Net70X86Test", "Run mock-assembly-x86.dll under .NET 7.0",
+            "net7.0/mock-assembly-x86.dll",
+            MockAssemblyX86ExpectedResult("Net70AgentLauncher")));
+
+        GuiAndEngineTests.Add(new PackageTest(1, "Net80X86Test", "Run mock-assembly-x86.dll under .NET 8.0",
+            "net8.0/mock-assembly-x86.dll",
+            MockAssemblyX86ExpectedResult("Net80AgentLauncher")));
+
+        GuiAndEngineTests.Add(new PackageTest(1, "Net90X86Test", "Run mock-assembly-x86.dll under .NET 9.0",
+            "net9.0/mock-assembly-x86.dll",
+            MockAssemblyX86ExpectedResult("Net90AgentLauncher")));
+
         // AspNetCore tests
 
         if (BuildSettings.IsLocalBuild)

--- a/src/TestData/mock-assembly-x86/MockAssembly.cs
+++ b/src/TestData/mock-assembly-x86/MockAssembly.cs
@@ -55,18 +55,6 @@ namespace TestCentric.Tests
             public static int Failures = MockTestFixture.Failures;
 
             public static int Categories = MockTestFixture.Categories;
-
-            public static string AssemblyPath;
-
-            static MockAssembly()
-            {
-                var assembly = typeof(MockAssembly).Assembly;
-                string codeBase = assembly.EscapedCodeBase;
-
-                AssemblyPath = codeBase.ToLower().StartsWith(Uri.UriSchemeFile)
-                    ? new Uri(codeBase).LocalPath
-                    : assembly.Location;
-            }
         }
 
         [TestFixture(Description = "Fake Test Fixture")]

--- a/src/TestData/mock-assembly-x86/mock-assembly-x86.csproj
+++ b/src/TestData/mock-assembly-x86/mock-assembly-x86.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<RootNamespace>NUnit.Tests</RootNamespace>
-		<TargetFrameworks>net35;net462</TargetFrameworks>
+		<TargetFrameworks>net35;net462;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\testcentric.snk</AssemblyOriginatorKeyFile>
 		<OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
This PR solves #1360 by adding additional target frameworks to our test assembly **mock-assembly-x86**.
These tests are executed in our build scripts.

I removed some code parts in class `MockAssembly` which set the static string `AssemblyPath`. This change was required due to compile error using .Net core which complains that `Assembly.EscapedCodeBase` is not available. I could also introduce some preprocessor directives (\#if) for that purpose, but I came to the conclusion that the `AssemblyPath` is not used at all. So, I decided to remove this part.

Additional remark:
It's currently still unclear why this kind of tests failed using TestCentric 2.0 - beta 7. However luckily they are already succeeding using our latest developer builds, in which we switched to NUnit agents in the meantime. And the tests are executed successfully in our pipeline. Here's one part of the log file:
```
----------------------------------------
Run mock-assembly-x86.dll under .NET 7.0
----------------------------------------
```
