### PR TITLE
Improve message when start logging without sufficient rights

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/AppEntry.cs
+++ b/src/GuiRunner/TestCentric.Gui/AppEntry.cs
@@ -52,6 +52,12 @@ namespace TestCentric.Gui
                 return 2;
             }
 
+            if (!ValidateLoggingOption(options))
+            {
+                MessageDisplay.Error($"Failed to enable logging. Might be due to missing access rights in folder {Environment.CurrentDirectory}. Please consider to start with admin rights.");
+                return 2;
+            }
+
             log.Info("Instantiating TestModel");
             ITestModel model = null;
             try
@@ -111,6 +117,17 @@ namespace TestCentric.Gui
             }
 
             return 0;
+        }
+
+        private static bool ValidateLoggingOption(GuiOptions options)
+        {
+            if (string.IsNullOrEmpty(options.InternalTraceLevel))
+                return true;
+
+            if (options.InternalTraceLevel.Equals("off", StringComparison.CurrentCultureIgnoreCase))
+                return true;
+
+            return InternalTraceWriter.CanCreateLogFile();
         }
 
         private static string GetHelpText(GuiOptions options)

--- a/src/GuiRunner/TestModel/InternalTrace.cs
+++ b/src/GuiRunner/TestModel/InternalTrace.cs
@@ -30,8 +30,7 @@ namespace TestCentric.Gui
             set { logName = value; }
         }
 
-        public static 
-            InternalTraceLevel Level
+        public static InternalTraceLevel Level
         {
             get { return level; }
             set

--- a/src/GuiRunner/TestModel/InternalTraceWriter.cs
+++ b/src/GuiRunner/TestModel/InternalTraceWriter.cs
@@ -35,6 +35,26 @@ namespace TestCentric.Gui
             this.writer.AutoFlush = true;
         }
 
+        /// <summary>
+        /// Check if a log file can be created in general
+        /// (Access rights or readonly access...)
+        /// </summary>
+        public static bool CanCreateLogFile()
+        {
+            try
+            {
+                string logDirectory = Path.Combine(Environment.CurrentDirectory, Path.GetRandomFileName());
+                using (FileStream fs = File.Create(logDirectory, 1, FileOptions.DeleteOnClose))
+                {
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         public override System.Text.Encoding Encoding
         {
             get { return writer.Encoding; }

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -85,9 +85,8 @@ namespace TestCentric.Gui.Model
             // We can't use user settings to provide a default because the settings
             // are an engine service and the engine have the internal trace level
             // set as part of its initialization.
-            var traceLevel = options.InternalTraceLevel != null
-                ? (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel)
-                : InternalTraceLevel.Off;
+            if (!Enum.TryParse(options.InternalTraceLevel, out InternalTraceLevel traceLevel))
+                traceLevel = InternalTraceLevel.Off;
 
             var logFile = $"InternalTrace.{Process.GetCurrentProcess().Id}.gui.log";
             if (options.WorkDirectory != null)


### PR DESCRIPTION
This PR fixes #1358. The application checks on start-up if the user has sufficient rights to create a log file whenever logging was enabled. If not this new message box is shown, informing the user about the problem. Afterwards TestCentric is getting closed. 

<img width="400" src="https://github.com/user-attachments/assets/41811150-4460-4420-a9a1-6576ef58ab98" />

So, overall instead of a message box with some internal info a more user friendly message box is shown
