### PR TITLE
Handle exceptions thrown while writing VisualState file

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/VisualState.cs
+++ b/src/GuiRunner/TestCentric.Gui/VisualState.cs
@@ -210,9 +210,16 @@ namespace TestCentric.Gui
             if (!string.IsNullOrEmpty(path) && !Directory.Exists(path))
                 return;
 
-            using (StreamWriter writer = new StreamWriter(fileName))
+            try
             {
+                using StreamWriter writer = new StreamWriter(fileName);
                 Save(writer);
+            }
+            catch (Exception e)
+            {
+                // Catch all kind of exceptions while writing file (Security, IO-Exception, ...)
+                Logger log = InternalTrace.GetLogger(nameof(VisualState));
+                log.Error($"Failed to write VisualState file: {fileName}; {e.Message}");
             }
         }
 
@@ -226,8 +233,7 @@ namespace TestCentric.Gui
             }
             catch(InvalidOperationException ex)
             {
-                throw new Exception(
-                    "Unable to serialize VisualState. This may be due to duplicate node names in the tree.", ex);
+                throw new Exception("Unable to serialize VisualState. This may be due to duplicate node names in the tree.", ex);
             }
         }
 


### PR DESCRIPTION
This PR fixes #1359 . 

From technical point of view I just handle all exceptions while writing the VisualState file, add a log message and continue the workflow afterwards. A VisualState file is not created in this case. 
As we are writing the VisualState file already **before** test execution, the user is currently blocked and cannot execute tests at all.  He only get a non helpful error message box (see #1359 description).

So, with this change the user can execute tests again. The only drawback is that no VisualState file is created and any visual setting applied by him will not be persisted. But I think this behavior is OK. Of course we didn't have VisualState files with TestCentric 1.X, so there were no write access at all, but overall it was possible to execute tests with 1.X in such a use case.
