### PR TITLE
Update nunit engine dependency to version 4.0.0-beta.1.35

### DIFF
--- a/KnownExtensions.cake
+++ b/KnownExtensions.cake
@@ -15,7 +15,7 @@ public static class KnownExtensions
     //public static ExtensionSpecifier Net20PluggableAgent = new ExtensionSpecifier(
     //    "NUnit.Extension.Net20PluggableAgent", "nunit-extension-net20-pluggable-agent", "2.1.1");
     public static ExtensionSpecifier Net462PluggableAgent = new ExtensionSpecifier(
-        "NUnit.Extension.Net462PluggableAgent", "nunit-extension-net462-pluggable-agent", "4.1.0-alpha.3");
+        "NUnit.Extension.Net462PluggableAgent", "nunit-extension-net462-pluggable-agent", "4.1.0-alpha.5");
     //public static ExtensionSpecifier NetCore21PluggableAgent = new ExtensionSpecifier(
     //    "NUnit.Extension.NetCore21PluggableAgent", "nunit-extension-netcore21-pluggable-agent", "2.1.1");
     //public static ExtensionSpecifier NetCore31PluggableAgent = new ExtensionSpecifier(

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,7 +53,7 @@
 	<PropertyGroup>
 		<NUnitVersion Condition="'$(NUnitVersion)'==''">4.1.0</NUnitVersion>
 		<NSubstituteVersion Condition="'$(NSubstituteVersion)'==''">5.3.0</NSubstituteVersion>
-		<NUnitEngineVersion Condition="'$(NUnitEngineVersion)'==''">4.0.0-beta.1.29</NUnitEngineVersion>
+		<NUnitEngineVersion Condition="'$(NUnitEngineVersion)'==''">4.0.0-beta.1.35</NUnitEngineVersion>
 	</PropertyGroup>
 
 	<!-- Common package metadata, may be overridden in individual projects -->


### PR DESCRIPTION
This is the latest nunit engine that actually works for us at this point. Later versions require updated agents to work.