### PR TITLE
Enable debugging of tests for TestGroups

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
@@ -56,6 +56,22 @@ namespace TestCentric.Gui.Presenters.TestTree
         }
 
         [Test]
+        public void DebugContextCommand_TestGroup_DebugsTest()
+        {
+            // Arrange
+            TestGroup testGroup = new TestGroup("TestGroup");
+            var treeNode = new TreeNode() { Tag = testGroup };
+
+            _view.ContextNode.Returns(treeNode);
+
+            // Act
+            _view.DebugContextCommand.Execute += Raise.Event<CommandHandler>();
+
+            // Assert
+            _model.Received().DebugTests(Arg.Is(testGroup));
+        }
+
+        [Test]
         public void DoubleClickOnTestCaseRunsTest()
         {
             _view.TreeNodeDoubleClick += Raise.Event<TreeNodeActionHandler>(TEST_CASE_TREE_NODE);

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
@@ -206,9 +206,10 @@ namespace TestCentric.Gui.Presenters
             {
                 if (_view.ContextNode != null)
                 {
-                    var testNode = _view.ContextNode.Tag as TestNode;
-                    if (testNode != null)
+                    if (_view.ContextNode.Tag is TestNode testNode)
                         _model.DebugTests(testNode);
+                    else if (_view.ContextNode.Tag is TestGroup groupNode)
+                        _model.DebugTests(groupNode);
                 }
             };
 

--- a/src/GuiRunner/TestModel/ITestModel.cs
+++ b/src/GuiRunner/TestModel/ITestModel.cs
@@ -143,6 +143,8 @@ namespace TestCentric.Gui.Model
         void RunTests(TestSelection testSelection);
         void RepeatLastRun();
         void DebugTests(TestNode testNode);
+        void DebugTests(TestSelection testSelection);
+
         void StopTestRun(bool force);
 
         #endregion

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -571,6 +571,15 @@ namespace TestCentric.Gui.Model
             RunTests(new TestRunSpecification(testNode, CategoryFilter, true));
         }
 
+        public void DebugTests(TestSelection tests)
+        {
+            if (tests == null)
+                throw new ArgumentNullException(nameof(tests));
+
+            log.Info($"Debugging test: {string.Join(", ", tests.Select(node => node.GetAttribute("name").ToArray()))}");
+            RunTests(new TestRunSpecification(tests, CategoryFilter, true));
+        }
+
         public void StopTestRun(bool force)
         {
             // Async to avoid blocking the main thread for incoming test events in between


### PR DESCRIPTION
This PR fixes #1375.

The TreeNodes might either be bound to a TestNode or a TestGroup. Therefore, we must always consider both cases if a user event regarding a TreeNode occurs. We actually do that everywhere, but this distinction was missing in the ‘Debug’ action. So, this PR adds the handling for a TestGroup.