### PR TITLE
Fix crash when debugging tests

### DIFF
--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -768,9 +768,10 @@ namespace TestCentric.Gui.Model
             {
                 foreach (var subPackage in TestCentricProject.SubPackages)
                 {
-                    subPackage.AddSetting(SettingDefinitions.DebugTests.WithValue(runSpec.DebuggingRequested));
+                    subPackage.Settings.Set(SettingDefinitions.DebugTests.WithValue(runSpec.DebuggingRequested));
                 }
 
+                Runner?.Dispose();
                 Runner = TestEngine.GetRunner(TestCentricProject);
 
                 // It is not strictly necessary to load the tests


### PR DESCRIPTION
This PR fixes #1383:

Instead of using the statement 
`subPackage.AddSetting(...)`
I'm using this statement now:
`subPackage.Settings.Set(...)`
This way, we can also overwrite an existing setting.

As mentioned in the issue itself, I decided to fix another observation right away. We are always creating new Runner objects in this use case, but miss to dispose the old instance. So, the agent processes don't get terminated so far.