### PR TITLE
Fix crash in settings dialog if no project is loaded

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Dialogs/SettingsDialogBaseTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Dialogs/SettingsDialogBaseTests.cs
@@ -1,0 +1,54 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Gui.Dialogs
+{
+    using NSubstitute;
+    using NUnit.Common;
+    using NUnit.Engine;
+    using NUnit.Framework;
+    using TestCentric.Gui.Model;
+
+    [TestFixture]
+    internal class SettingsDialogBaseTests
+    {
+        [Test]
+        public void ApplySettings_IsAppliedToProject()
+        {
+            // 1. Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            TestCentricProject project = new TestCentricProject(model);
+            model.TestCentricProject.Returns(project);
+
+            SettingsDialogBase settingsDialog = new SettingsDialogBase(null, model);
+            settingsDialog.PackageSettingChanges.Add(SettingDefinitions.DebugTests.Name, true);
+
+            // 2. Act
+            settingsDialog.ApplySettings();
+
+            // 3. Assert
+            Assert.That(project.Settings.HasSetting(SettingDefinitions.DebugTests.Name), Is.True);
+        }
+
+
+        [Test]
+        public void ApplySettings_ProjectIsNull_SettingIsNotApplied()
+        {
+            // 1. Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            model.TestCentricProject.Returns((TestCentricProject)null);
+
+            SettingsDialogBase settingsDialog = new SettingsDialogBase(null, model);
+            settingsDialog.PackageSettingChanges.Add(SettingDefinitions.DebugTests.Name, true);
+
+            // 2. Act
+            settingsDialog.ApplySettings();
+
+            // 3. Assert
+            // No crash occurred
+            Assert.Pass("ApplySettings worked successfully even if no project is loaded.");
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui/Dialogs/SettingsDialogBase.cs
+++ b/src/GuiRunner/TestCentric.Gui/Dialogs/SettingsDialogBase.cs
@@ -161,7 +161,7 @@ namespace TestCentric.Gui.Dialogs
 
             foreach(var entry in PackageSettingChanges)
             {
-                Model.TestCentricProject.AddSetting(entry.Key, entry.Value);
+                Model.TestCentricProject?.AddSetting(entry.Key, entry.Value);
             }
         }
         #endregion

--- a/src/GuiRunner/TestCentric.Gui/SettingsPages/AdvancedLoaderSettingsPage.cs
+++ b/src/GuiRunner/TestCentric.Gui/SettingsPages/AdvancedLoaderSettingsPage.cs
@@ -203,7 +203,7 @@ namespace TestCentric.Gui.SettingsPages
             this.numberOfAgentsCheckBox.Name = "numberOfAgentsCheckBox";
             this.numberOfAgentsCheckBox.Size = new System.Drawing.Size(205, 17);
             this.numberOfAgentsCheckBox.TabIndex = 44;
-            this.numberOfAgentsCheckBox.Text = "LImit simultaneous agent processes to";
+            this.numberOfAgentsCheckBox.Text = "Limit simultaneous agent processes to";
             this.numberOfAgentsCheckBox.UseVisualStyleBackColor = true;
             this.numberOfAgentsCheckBox.CheckedChanged += new System.EventHandler(this.numberOfAgentsCheckBox_CheckedChanged);
             // 


### PR DESCRIPTION
This PR fixes one issue mentioned in #1396:
>Changing a package related setting in the Settings dialog but no project is loaded results into a crash

This one is solved by simply adding a null check.