### PR TITLE
Fix bug when loading tcproj files

### DIFF
--- a/src/GuiRunner/TestModel/TestCentricProject.cs
+++ b/src/GuiRunner/TestModel/TestCentricProject.cs
@@ -98,26 +98,21 @@ namespace TestCentric.Gui.Model
         {
             ProjectPath = path;
 
-            using (StreamReader reader = new StreamReader(ProjectPath))
+            try
             {
-                XmlSerializer serializer = new XmlSerializer(typeof(NUnit.Engine.TestPackage));
+                string fileContent = File.ReadAllText(ProjectPath);
+                TestPackage newPackage = PackageHelper.FromXml(fileContent);
 
-                try
-                {
-                    var newPackage = (NUnit.Engine.TestPackage)serializer.Deserialize(reader);
+                foreach (var subPackage in newPackage.SubPackages)
+                    AddSubPackage(subPackage.FullName);
 
-                    foreach (var subPackage in newPackage.SubPackages)
-                    {
-                        AddSubPackage(subPackage.FullName);
-                    }
-
-                    LoadTests();
-                }
-                catch (Exception ex)
-                {
-                    throw new Exception("Unable to deserialize TestProject.", ex);
-                }
+                LoadTests();
             }
+            catch (Exception ex)
+            {
+                throw new Exception($"Unable to load TestProject from {path}", ex);
+            }
+
 
             IsDirty = false;
         }
@@ -133,22 +128,6 @@ namespace TestCentric.Gui.Model
             using (StreamWriter writer = new StreamWriter(ProjectPath))
                 writer.Write(this.ToXml());
         }
-
-        //public void Save(TextWriter writer)
-        //{
-        //    XmlSerializer serializer = new XmlSerializer(typeof(NUnit.Engine.TestPackage));
-
-        //    try
-        //    {
-        //        serializer.Serialize(writer, this);
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        throw new Exception("Unable to serialize TestProject.", ex);
-        //    }
-
-        //    IsDirty = false;
-        //}
 
         public void LoadTests()
         {


### PR DESCRIPTION
Fixes #1403 

This PR fixes #1403  (first mentioned in #1396 ([link](https://github.com/TestCentric/TestCentricRunner/issues/1396#issuecomment-3678559987) to comment):

It's not possible to load a tcproj file: instead there's an error message box:
<img width="300" src="https://github.com/user-attachments/assets/d2749af0-5b98-4219-ba44-533541b26f97" />


@CharliePoole:
I'm not entirely sure about this fix, because it's based on searching through the commit history and looking on that changes. But in doing so, I came to realize that serializing/deserializing a TestPackage seems not be supported anymore or that we should not use it anymore. Instead there are two new methods in the `NUnit.Engine`: ToXml() and FromXml().

Saving a TestCentric project already used the ToXml(), but loading still uses the deserializing approach. Switching to helper method FromXml() solves this issue.



