### PR TITLE
Fix crash opening File menu when no project is loaded

### DIFF
--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -159,7 +159,7 @@ namespace TestCentric.Gui.Model
         /// </summary>
         public TestCentricProject TestCentricProject { get; set; }
 
-        public TestPackage TopLevelPackage => TestCentricProject.TopLevelPackage;
+        public TestPackage TopLevelPackage => TestCentricProject?.TopLevelPackage;
 
         public bool IsProjectLoaded => TestCentricProject != null;
 


### PR DESCRIPTION
This is a tiny fix caused by latest changes for issue #1414.

FYI:
If no project is loaded and the File menu is opened, there's a NullReference exception.
In detail: the AgentSelectionController tries to update his menu items and requests the Model.TopLevelPackage property. However, the TestCentricProject is null in this state.