### PR TITLE
Load TestCentricProject: restore list of test files

### DIFF
--- a/src/GuiRunner/TestModel.Tests/TestCentricProjectTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestCentricProjectTests.cs
@@ -493,6 +493,24 @@ namespace TestCentric.Gui.Model
             Assert.That(loadedProject.ProjectPath, Is.EqualTo("TestCentricTestProject.tcproj"));
         }
 
+        [Test]
+        public void Load_SetsTestFiles()
+        {
+            // 1. Arrange
+            TestCentricProject project = new TestCentricProject(new GuiOptions("Test1.dll", "Test2.dll"));
+            project.SaveAs("TestCentricTestProject.tcproj");
+
+            TestCentricProject loadedProject = new TestCentricProject();
+
+            // 2. Act
+            loadedProject.Load("TestCentricTestProject.tcproj");
+
+            // 3. Assert
+            Assert.That(loadedProject.TestFiles.Count, Is.EqualTo(2));
+            Assert.That(loadedProject.TestFiles[0], Does.EndWith("Test1.dll"));
+            Assert.That(loadedProject.TestFiles[1], Does.Contain("Test2.dll"));
+        }
+
         #endregion
 
         #region FileName and ProjectPath Tests

--- a/src/GuiRunner/TestModel/TestCentricProject.cs
+++ b/src/GuiRunner/TestModel/TestCentricProject.cs
@@ -100,6 +100,11 @@ namespace TestCentric.Gui.Model
                     }
                 }
 
+                // Update the list of test files
+                TestFiles.Clear();
+                foreach (TestPackage subPackage in TopLevelPackage.SubPackages)
+                    TestFiles.Add(subPackage.FullName);
+
                 bool FindTestCentricProjectElement()
                 {
                     while (xmlReader.Read())


### PR DESCRIPTION
This is a fix caused by latest changes for issue https://github.com/TestCentric/TestCentricRunner/issues/1414.

When loading a TestCentricProject file we missed to properly restore the member which contains the list of files. So, the list remains empty after loading. Now, the list of files is updated from the subpackages.