### PR TITLE
Show error message box when loading a tcproj failed (instead of crash)

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
@@ -11,6 +11,8 @@ using NUnit.Framework;
 
 namespace TestCentric.Gui.Presenters.Main
 {
+    using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
     using Elements;
     using Model;
     using NUnit.Common;
@@ -93,6 +95,17 @@ namespace TestCentric.Gui.Presenters.Main
             _view.OpenTestCentricProjectCommand.Execute += Raise.Event<CommandHandler>();
 
             _model.DidNotReceiveWithAnyArgs().OpenExistingProject(null);
+        }
+
+        [Test]
+        public void OpenTestCentricProjectCommand_ThrowsException_ErrorMessage_IsDisplayed()
+        {
+            _view.DialogManager.GetFileOpenPath(null, null).ReturnsForAnyArgs("Test.dll");
+            _model.When(m => m.OpenExistingProject("Test.dll")).Do(x => throw new IOException("Disk error"));
+
+            _view.OpenTestCentricProjectCommand.Execute += Raise.Event<CommandHandler>();
+
+            _view.MessageDisplay.Received().Error(Arg.Any<string>());
         }
 
         [Test]

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
@@ -589,8 +589,16 @@ namespace TestCentric.Gui.Presenters
             var filter = "TestCentric Projects (*.tcproj)|*.tcproj";
 
             string file = _view.DialogManager.GetFileOpenPath("Existing Project", filter);
-            if (!string.IsNullOrEmpty(file))
-                _model.OpenExistingProject(file);
+
+            try
+            {
+                if (!string.IsNullOrEmpty(file))
+                    _model.OpenExistingProject(file);
+            }
+            catch (Exception exception)
+            {
+                _view.MessageDisplay.Error("Unable to open project\n\n" + MessageBuilder.FromException(exception));
+            }
         }
 
         private void OpenTestAssembly()


### PR DESCRIPTION
This is a fix caused by latest changes for issue https://github.com/TestCentric/TestCentricRunner/issues/1414.

There was a crash in case the loading of a tcproj file failed with an exception. Now, this exception is cought, an error message box is shown and the user can continue to work.