### PR TITLE
Fix crash when applying setting

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Dialogs/SettingsDialogBaseTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Dialogs/SettingsDialogBaseTests.cs
@@ -33,6 +33,25 @@ namespace TestCentric.Gui.Dialogs
         }
 
         [Test]
+        public void ApplySettings_SettingValueIsChanged_IsAppliedToProject()
+        {
+            // 1. Arrange
+            ITestModel model = Substitute.For<ITestModel>();
+            TestCentricProject project = new TestCentricProject();
+            project.AddSetting(SettingDefinitions.DebugTests.WithValue(false));
+            model.TestCentricProject.Returns(project);
+
+            SettingsDialogBase settingsDialog = new SettingsDialogBase(null, model);
+            settingsDialog.SubPackageSettingChanges.Add(SettingDefinitions.DebugTests.WithValue(true));
+
+            // 2. Act
+            settingsDialog.ApplySettings();
+
+            // 3. Assert
+            Assert.That(project.TopLevelPackage.Settings.HasSetting(SettingDefinitions.DebugTests.Name), Is.True);
+        }
+
+        [Test]
         public void ApplySettings_TopLevelPackageChanges_AreAppliedToProject()
         {
             // 1. Arrange

--- a/src/GuiRunner/TestCentric.Gui/Dialogs/SettingsDialogBase.cs
+++ b/src/GuiRunner/TestCentric.Gui/Dialogs/SettingsDialogBase.cs
@@ -165,7 +165,7 @@ namespace TestCentric.Gui.Dialogs
                     page.ApplySettings();
 
             foreach(PackageSetting setting in SubPackageSettingChanges)
-                Model.TestCentricProject?.AddSetting(setting);
+                Model.TestCentricProject?.ApplySetting(setting);
 
             foreach (PackageSetting setting in TopLevelPackageSettingChanges)
                 Model.TestCentricProject?.SetTopLevelSetting(setting);

--- a/src/GuiRunner/TestModel.Tests/TestCentricProjectTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestCentricProjectTests.cs
@@ -8,6 +8,7 @@ namespace TestCentric.Gui.Model
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Security.Principal;
     using NSubstitute;
     using NUnit.Common;
     using NUnit.Framework;
@@ -308,31 +309,30 @@ namespace TestCentric.Gui.Model
         }
 
         [Test]
-        public void AddSetting_InvokedTwice_StoresCorrectly()
+        public void ApplySetting_Setting_IsStore()
         {
             // 1. Arrange
             TestCentricProject project = new TestCentricProject();
 
             // 2. Act
-            project.AddSetting("BoolSetting", true);
-            project.AddSetting("BoolSetting", true);
+            project.ApplySetting(SettingDefinitions.PrincipalPolicy.WithValue(PrincipalPolicy.WindowsPrincipal.ToString()));
 
             // 3. Assert
-            Assert.That(project.TopLevelPackage.Settings.GetSetting("BoolSetting"), Is.EqualTo(true));
+            Assert.That(project.TopLevelPackage.Settings.GetSetting(SettingDefinitions.PrincipalPolicy.Name), Is.EqualTo(PrincipalPolicy.WindowsPrincipal.ToString()));
         }
 
         [Test]
-        public void AddSetting_InvokedTwice2_StoresCorrectly()
+        public void ApplySetting_SettingWasSetPreviouslySet_SettingsIsUpdated()
         {
             // 1. Arrange
             TestCentricProject project = new TestCentricProject();
 
             // 2. Act
-            project.AddSetting(SettingDefinitions.DebugTests.WithValue(true));
-            project.AddSetting(SettingDefinitions.DebugTests.WithValue(true));
+            project.ApplySetting(SettingDefinitions.DebugTests.WithValue(true));
+            project.ApplySetting(SettingDefinitions.DebugTests.WithValue(false));
 
             // 3. Assert
-            Assert.That(project.TopLevelPackage.Settings.GetSetting(SettingDefinitions.DebugTests.Name), Is.EqualTo(true));
+            Assert.That(project.TopLevelPackage.Settings.GetSetting(SettingDefinitions.DebugTests.Name), Is.EqualTo(false));
         }
 
         [Test]

--- a/src/GuiRunner/TestModel/TestCentricProject.cs
+++ b/src/GuiRunner/TestModel/TestCentricProject.cs
@@ -169,29 +169,32 @@ namespace TestCentric.Gui.Model
 
         public void AddSetting(PackageSetting setting)
         {
-            RemoveSetting(setting.Name);
             TopLevelPackage.AddSetting(setting);
             IsDirty = true;
         }
 
         public void AddSetting(string key, string value)
         {
-            RemoveSetting(key);
             TopLevelPackage.AddSetting(key, value);
             IsDirty = true;
         }
 
         public void AddSetting(string key, bool value)
         {
-            RemoveSetting(key);
             TopLevelPackage.AddSetting(key, value);
             IsDirty = true;
         }
 
         public void AddSetting(string key, int value)
         {
-            RemoveSetting(key);
             TopLevelPackage.AddSetting(key, value);
+            IsDirty = true;
+        }
+
+        public void ApplySetting(PackageSetting setting)
+        {
+            RemoveSetting(setting.Name);
+            TopLevelPackage.AddSetting(setting);
             IsDirty = true;
         }
 


### PR DESCRIPTION
This PR fixes #1428:

If a setting already exists, we must first remove it before we can set it. There exists already a method `TestCentricProject.RemoveSetting()` for this purpose. It removes the setting from the top level package itself and all subpackages. So, we invoke this method in all `TestCentricProject.AddSetting(...)` methods now.

The method `RemoveSetting()` succeeds even in case the setting is not present.