### PR TITLE
Fixing the automatic opening of the menu

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Elements/ToolStripElements/DisplayFormatButton.cs
+++ b/src/GuiRunner/TestCentric.Gui/Elements/ToolStripElements/DisplayFormatButton.cs
@@ -21,7 +21,7 @@ namespace TestCentric.Gui.Elements.ToolStripElements
                 item.DropDown.Opening += (s, e) => e.Cancel = !item.Checked;
                 item.CheckedChanged += (s, e) =>
                 {
-                    if (item.Checked)
+                    if (item.Checked && item.Visible)
                         item.DropDown.Show();
                 };
             }


### PR DESCRIPTION
This fix closes #1443.

I simply applied the previous solution to the new class `DisplayFormatButton`. Somehow it get lost during commit #1443. If the menu item is not open and the checked state is changed, we won't open any submenu.
