### PR TITLE
Fix crash: UI access from wrong thread on TestFinish event

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -32,6 +32,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void Setup()
         {
             _presenter = new TreeViewPresenter(_view, _model, new TreeDisplayStrategyFactory());
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
         }
 
         [TestCaseSource("resultData")]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -21,6 +21,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void Setup()
         {
             _presenter = new TreeViewPresenter(_view, _model, new TreeDisplayStrategyFactory());
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
         }
 
         static object[] resultData = new object[] {

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -90,12 +90,15 @@ namespace TestCentric.Gui.Presenters
 
         public virtual void OnTestFinished(ResultNode result)
         {
-            int imageIndex = CalcImageIndex(result);
-            foreach (TreeNode treeNode in GetTreeNodesForTest(result))
+            _view.InvokeIfRequired(() =>
             {
-                treeNode.Text = GetTreeNodeDisplayName(result);
-                _view.SetImageIndex(treeNode, imageIndex);
-            }
+                int imageIndex = CalcImageIndex(result);
+                foreach (TreeNode treeNode in GetTreeNodesForTest(result))
+                {
+                    treeNode.Text = GetTreeNodeDisplayName(result);
+                    _view.SetImageIndex(treeNode, imageIndex);
+                }
+            });
         }
 
         public virtual void OnTestRunStarting()


### PR DESCRIPTION
This PR fixes a crash whenever tests are executed.
The UI elements are accessed from the wrong thread in the `DisplayStrategy.TestFinished` event handler.
<img width="500" src="https://github.com/user-attachments/assets/9334333b-b573-4f5f-83f6-683b98bdf08c" />

This statement was added only a few day back so that I don't create a separate issue for it. Moreover I want to fix it quickly to getting a working environment soon.