### PR TITLE
NUnit tree display: add option to show/hide assemblies and fixtures nodes

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
@@ -432,6 +432,34 @@ namespace TestCentric.Gui.Presenters.Main
 
         [TestCase(true)]
         [TestCase(false)]
+        public void ShowAssembliesChanged_Changes_TreeConfiguration(bool showAssemblies)
+        {
+            // Arrange
+            _view.ShowAssemblies.Checked.Returns(showAssemblies);
+
+            // Act
+            _view.ShowAssemblies.CheckedChanged += Raise.Event<CommandHandler>();
+
+            // Assert
+            Assert.That(_model.TreeConfiguration.ShowAssemblies, Is.EqualTo(showAssemblies));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowFixturesChanged_Changes_TreeConfiguration(bool showFixtures)
+        {
+            // Arrange
+            _view.ShowFixtures.Checked.Returns(showFixtures);
+
+            // Act
+            _view.ShowFixtures.CheckedChanged += Raise.Event<CommandHandler>();
+
+            // Assert
+            Assert.That(_model.TreeConfiguration.ShowFixtures, Is.EqualTo(showFixtures));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
         public void ShowFilterChanged_ChangesModelSetting(bool show)
         {
             // Arrange

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenSettingsChanged.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenSettingsChanged.cs
@@ -59,6 +59,34 @@ namespace TestCentric.Gui.Presenters.Main
             Assert.That(_view.ShowNamespaces.Checked, Is.EqualTo(showNamespace));
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowAssemblies_TreeConfigurationChanged_MenuItemIsUpdated(bool showAssemblies)
+        {
+            // 1. Arrange
+            _model.TreeConfiguration.ShowAssemblies.Returns(showAssemblies);
+
+            // 2. Act
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(null, new SettingsEventArgs(nameof(TreeConfiguration.ShowAssemblies)));
+
+            // 2. Assert
+            Assert.That(_view.ShowAssemblies.Checked, Is.EqualTo(showAssemblies));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowFixtures_TreeConfigurationChanged_MenuItemIsUpdated(bool showFixtures)
+        {
+            // 1. Arrange
+            _model.TreeConfiguration.ShowFixtures.Returns(showFixtures);
+
+            // 2. Act
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(null, new SettingsEventArgs(nameof(TreeConfiguration.ShowFixtures)));
+
+            // 2. Assert
+            Assert.That(_view.ShowFixtures.Checked, Is.EqualTo(showFixtures));
+        }
+
         [TestCase("NUNIT_TREE", true)]
         [TestCase("TEST_LIST", false)]
         public void DisplayFormat_TreeConfigurationChanged_ShowHideFilterButton_IsUpdated(string displayFormat, bool expectedState)

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -25,6 +25,9 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model = Substitute.For<ITestModel>();
             _model.TreeConfiguration.ShowNamespaces = true;
             _model.TreeConfiguration.DisplayFormat = "NUNIT_TREE";
+            _model.TreeConfiguration.ShowFixtures = true;
+            _model.TreeConfiguration.ShowNamespaces = true;
+            _model.TreeConfiguration.ShowAssemblies = true;
 
             // We can't construct a TreeNodeCollection, so we fake it
             var nodes = new TreeNode().Nodes;
@@ -121,7 +124,66 @@ namespace TestCentric.Gui.Presenters.TestTree
             _strategy.OnTestLoaded(new TestNode(xml), null);
 
             // Assert
-            _view.DidNotReceive().Add(Arg.Is<TreeNode>(tn => (tn.Tag as TestNode).Id == "1-1031"));
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1030"), Is.True);
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1031"), Is.False);
+        }
+
+        [Test]
+        public void OnTestLoaded_Assemblies_AreNotShown_AssemblyNode_IsNotCreated()
+        {
+            // Arrange
+            _model.TreeConfiguration.ShowAssemblies = false;
+            string xml =
+                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                    "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
+                    "</test-suite>" +
+                "</test-suite> </test-run>";
+
+            // Act
+            _strategy.OnTestLoaded(new TestNode(xml), null);
+
+            // Assert
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1031"), Is.True);
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1030"), Is.False);
+        }
+
+        [Test]
+        public void OnTestLoaded_Fixtures_AreNotShown_FixtureNode_IsNotCreated()
+        {
+            // Arrange
+            _model.TreeConfiguration.ShowFixtures = false;
+
+            string xml =
+                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                    "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
+                        "<test-suite type='TestFixture' id='1-1032' name='FixtureA'/>" +
+                        "<test-suite type='TestFixture' id='1-1033' name='FixtureB'/>" +
+                    "</test-suite>" +
+                "</test-suite> </test-run>";
+
+            // Act
+            _strategy.OnTestLoaded(new TestNode(xml), null);
+
+            // Assert
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1032"), Is.False);
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1033"), Is.False);
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1031"), Is.True);
+            Assert.That(NodeCollectionContainsTestNode(_view.Nodes, "1-1030"), Is.True);
+        }
+
+        private bool NodeCollectionContainsTestNode(TreeNodeCollection nodes, string testNodeId)
+        {
+            foreach (TreeNode treeNode in nodes)
+            {
+                TestNode testNode = treeNode.Tag as TestNode;
+                if (testNode != null && testNode.Id == testNodeId)
+                    return true;
+
+                if (NodeCollectionContainsTestNode(treeNode.Nodes, testNodeId))
+                    return true;
+            }
+
+            return false;
         }
 
         // TODO: FIX

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -43,6 +43,39 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.TreeConfiguration.ShowNamespaces = showNamespace;
             _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(this, new SettingsEventArgs(nameof(TreeConfiguration.ShowNamespaces)));
 
+            // Assert
+            strategy.Received(2).Reload();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void WhenTreeConfigurationIsChanged_ShowAssemblies_StrategyIsReloaded(bool showAssemblies)
+        {
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+            _model.TreeConfiguration.DisplayFormat.Returns("NUNIT_TREE");
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(this, new SettingsEventArgs(nameof(TreeConfiguration.DisplayFormat)));
+
+            // Act
+            _model.TreeConfiguration.ShowAssemblies = showAssemblies;
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(this, new SettingsEventArgs(nameof(TreeConfiguration.ShowAssemblies)));
+
+            // Assert
+            strategy.Received(2).Reload();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void WhenTreeConfigurationIsChanged_ShowFixtures_StrategyIsReloaded(bool showFixtures)
+        {
+            ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
+            _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
+            _model.TreeConfiguration.DisplayFormat.Returns("NUNIT_TREE");
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(this, new SettingsEventArgs(nameof(TreeConfiguration.DisplayFormat)));
+
+            // Act
+            _model.TreeConfiguration.ShowFixtures = showFixtures;
+            _model.TreeConfiguration.Changed += Raise.Event<SettingsEventHandler>(this, new SettingsEventArgs(nameof(TreeConfiguration.ShowFixtures)));
 
             // Assert
             strategy.Received(2).Reload();

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -68,7 +68,11 @@ namespace TestCentric.Gui.Presenters.TestTree
             Assert.That(_presenter.TreeConfiguration.DisplayFormat, Is.EqualTo(displayFormat));
             Assert.That(_presenter.Strategy, Is.TypeOf(expectedStrategy));
             if (displayFormat == "NUnit_TREE")
+            {
                 Assert.That(_presenter.TreeConfiguration.ShowNamespaces, Is.True);
+                Assert.That(_presenter.TreeConfiguration.ShowFixtures, Is.True);
+                Assert.That(_presenter.TreeConfiguration.ShowAssemblies, Is.True);
+            }
         }
 
         [TestCase(true)]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Views/TestCentricMainViewTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Views/TestCentricMainViewTests.cs
@@ -49,6 +49,12 @@ namespace TestCentric.Gui.Views
             menuItem.Checked = checkState;
             var subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "nunitTreeShowNamespacesMenuItem");
             Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "nunitTreeShowFixturesMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
+
+            subMenuItem = GetDropDownItem<ToolStripMenuItem>(menuItem, "nunitTreeShowAssembliesMenuItem");
+            Assert.That(subMenuItem, Is.Not.Null);
         }
 
         [TestCase(true)]

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -198,8 +198,12 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         protected bool ShowTreeNodeType(TestNode testNode)
         {
+            if (testNode.IsAssembly)
+                return TreeConfiguration.ShowAssemblies;
             if (testNode.IsNamespace)
                 return TreeConfiguration.ShowNamespaces;
+            if (testNode.IsFixture)
+                return TreeConfiguration.ShowFixtures;
 
             return true;
         }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -69,7 +69,7 @@ namespace TestCentric.Gui.Presenters
 
             _view.InvokeIfRequired(() =>
             {
-                visualState = new VisualState("NUNIT_TREE", null, _model.TreeConfiguration.ShowNamespaces).LoadFrom(_view.TreeView);
+                visualState = new VisualState("NUNIT_TREE", null, _model.TreeConfiguration).LoadFrom(_view.TreeView);
             });
 
             return visualState;

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
@@ -270,6 +270,8 @@ namespace TestCentric.Gui.Presenters
                         UpdateTreeDisplayMenuItem();
                         break;
                     case nameof(Model.TreeConfiguration.ShowNamespaces):
+                    case nameof(Model.TreeConfiguration.ShowAssemblies):
+                    case nameof(Model.TreeConfiguration.ShowFixtures):
                         UpdateTreeDisplayMenuItem();
                         break;
                 }
@@ -505,6 +507,16 @@ namespace TestCentric.Gui.Presenters
             _view.ShowNamespaces.CheckedChanged += () =>
             {
                 TreeConfiguration.ShowNamespaces = _view.ShowNamespaces.Checked;
+            };
+
+            _view.ShowAssemblies.CheckedChanged += () =>
+            {
+                TreeConfiguration.ShowAssemblies = _view.ShowAssemblies.Checked;
+            };
+
+            _view.ShowFixtures.CheckedChanged += () =>
+            {
+                TreeConfiguration.ShowFixtures = _view.ShowFixtures.Checked;
             };
 
             _view.ShowHideFilterButton.CheckedChanged += () =>
@@ -931,7 +943,10 @@ namespace TestCentric.Gui.Presenters
                 _view.TestListGroupBy.SelectedItem = TreeConfiguration.TestListGroupBy;
 
             _view.ShowNamespaces.Checked = TreeConfiguration.ShowNamespaces;
-            _view.ShowNamespaces.Enabled = displayFormat == "NUNIT_TREE";
+            _view.ShowAssemblies.Checked = TreeConfiguration.ShowAssemblies;
+            _view.ShowFixtures.Checked = TreeConfiguration.ShowFixtures;
+            _view.ShowNamespaces.Enabled = _view.ShowAssemblies.Enabled = _view.ShowFixtures.Enabled =
+                displayFormat == "NUNIT_TREE";
         }
 
         private void RunAllTests()

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
@@ -324,6 +324,8 @@ namespace TestCentric.Gui.Presenters
                     break;
                 case nameof(TreeConfiguration.TestListGroupBy):
                 case nameof(TreeConfiguration.ShowNamespaces):
+                case nameof(TreeConfiguration.ShowAssemblies):
+                case nameof(TreeConfiguration.ShowFixtures):
                     Strategy?.Reload();
                     break;
                 case nameof(TreeConfiguration.ShowCheckBoxes):
@@ -370,6 +372,8 @@ namespace TestCentric.Gui.Presenters
                 TreeConfiguration.ShowCheckBoxes = visualState.ShowCheckBoxes;
                 TreeConfiguration.DisplayFormat = visualState.DisplayStrategy;
                 TreeConfiguration.ShowNamespaces = visualState.ShowNamespaces;
+                TreeConfiguration.ShowAssemblies = visualState.ShowAssemblies;
+                TreeConfiguration.ShowFixtures = visualState.ShowFixtures;
                 TreeConfiguration.TestListGroupBy = TreeConfiguration.DisplayFormat == "TEST_LIST" ? visualState.GroupBy : "UNGROUPED";
             }
             else
@@ -380,6 +384,8 @@ namespace TestCentric.Gui.Presenters
                 TreeConfiguration.DisplayFormat = treeSettings.DisplayFormat;
                 TreeConfiguration.TestListGroupBy = "UNGROUPED";
                 TreeConfiguration.ShowNamespaces = true;
+                TreeConfiguration.ShowAssemblies = true;
+                TreeConfiguration.ShowFixtures = true;
                 TreeConfiguration.ShowTestDuration = false;
             }
 

--- a/src/GuiRunner/TestCentric.Gui/Views/IMainView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/IMainView.cs
@@ -86,6 +86,9 @@ namespace TestCentric.Gui.Views
         ISelection DisplayFormat { get; }
         ISelection TestListGroupBy { get; }
         IChecked ShowNamespaces { get; }
+        IChecked ShowAssemblies { get; }
+        IChecked ShowFixtures { get; }
+
         IChecked ShowHideFilterButton { get; }
         ICommand RunParametersButton { get; }
 

--- a/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.Designer.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.Designer.cs
@@ -48,6 +48,8 @@ namespace TestCentric.Gui.Views
             this.displayFormatButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.nunitTreeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nunitTreeShowNamespacesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeShowAssembliesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nunitTreeShowFixturesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListUngroupedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testListByAssemblyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -242,7 +244,7 @@ namespace TestCentric.Gui.Views
             // nunitTreeMenuItem
             // 
             this.nunitTreeMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.nunitTreeShowNamespacesMenuItem});
+                this.nunitTreeShowAssembliesMenuItem, this.nunitTreeShowNamespacesMenuItem, this.nunitTreeShowFixturesMenuItem});
             this.nunitTreeMenuItem.Name = "nunitTreeMenuItem";
             this.nunitTreeMenuItem.Size = new System.Drawing.Size(129, 22);
             this.nunitTreeMenuItem.Tag = "NUNIT_TREE";
@@ -254,6 +256,20 @@ namespace TestCentric.Gui.Views
             this.nunitTreeShowNamespacesMenuItem.Size = new System.Drawing.Size(173, 22);
             this.nunitTreeShowNamespacesMenuItem.Tag = "NUNIT_TREE_SHOW_NAMESPACE";
             this.nunitTreeShowNamespacesMenuItem.Text = "Show Namespaces";
+            // 
+            // nunitTreeShowAssembliesMenuItem
+            // 
+            this.nunitTreeShowAssembliesMenuItem.Name = "nunitTreeShowAssembliesMenuItem";
+            this.nunitTreeShowAssembliesMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.nunitTreeShowAssembliesMenuItem.Tag = "NUNIT_TREE_SHOW_ASSEMBLIES";
+            this.nunitTreeShowAssembliesMenuItem.Text = "Show Assemblies";
+            // 
+            // nunitTreeShowFixturesMenuItem
+            // 
+            this.nunitTreeShowFixturesMenuItem.Name = "nunitTreeShowFixturesMenuItem";
+            this.nunitTreeShowFixturesMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.nunitTreeShowFixturesMenuItem.Tag = "NUNIT_TREE_SHOW_FIXTURES";
+            this.nunitTreeShowFixturesMenuItem.Text = "Show Fixtures";
             // 
             // testListMenuItem
             // 
@@ -994,6 +1010,8 @@ namespace TestCentric.Gui.Views
         private ToolStripMenuItem nunitTreeMenuItem;
         private ToolStripMenuItem testListMenuItem;
         private ToolStripMenuItem nunitTreeShowNamespacesMenuItem;
+        private ToolStripMenuItem nunitTreeShowAssembliesMenuItem;
+        private ToolStripMenuItem nunitTreeShowFixturesMenuItem;
         private ToolStripMenuItem testListUngroupedMenuItem;
         private ToolStripMenuItem testListByAssemblyMenuItem;
         private ToolStripMenuItem testListByFixtureMenuItem;

--- a/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.cs
@@ -88,6 +88,8 @@ namespace TestCentric.Gui.Views
                 "TestListGroupBy",
                 testListUngroupedMenuItem, testListByAssemblyMenuItem, testListByFixtureMenuItem, testListByCategoryMenuItem, testListByOutcomeMenuItem, testListByDurationMenuItem);
             ShowNamespaces = new CheckedMenuElement(nunitTreeShowNamespacesMenuItem);
+            ShowAssemblies = new CheckedMenuElement(nunitTreeShowAssembliesMenuItem);
+            ShowFixtures = new CheckedMenuElement(nunitTreeShowFixturesMenuItem);
             ShowHideFilterButton = new ToolStripButtonElement(showFilterButton);
             RunParametersButton = new ToolStripButtonElement(runParametersButton);
 
@@ -184,6 +186,8 @@ namespace TestCentric.Gui.Views
         public ISelection TestListGroupBy { get; private set; }
 
         public IChecked ShowNamespaces { get; private set; }
+        public IChecked ShowAssemblies { get; private set; }
+        public IChecked ShowFixtures { get; private set; }
 
         public IChecked ShowHideFilterButton { get; private set; }
         public ICommand RunParametersButton { get; private set; }

--- a/src/GuiRunner/TestModel.Tests/VisualStateSerializationTests.cs
+++ b/src/GuiRunner/TestModel.Tests/VisualStateSerializationTests.cs
@@ -40,6 +40,8 @@ namespace TestCentric.Gui.Model
             Assert.That(vs.DisplayStrategy, Is.EqualTo("NUNIT_TREE"));
             Assert.That(vs.ShowCheckBoxes, Is.EqualTo(false));
             Assert.That(vs.ShowNamespaces, Is.EqualTo(true));
+            Assert.That(vs.ShowAssemblies, Is.EqualTo(true));
+            Assert.That(vs.ShowFixtures, Is.EqualTo(true));
         }
 
         [TestCaseSource(typeof(VisualStateSerializationData))]
@@ -64,6 +66,8 @@ namespace TestCentric.Gui.Model
                 Assert.That(docElement.GetAttribute("DisplayStrategy"), Is.EqualTo(vs.DisplayStrategy));
                 Assert.That(docElement.GetAttribute("ShowCheckBoxes"), Is.EqualTo(vs.ShowCheckBoxes ? "True" : ""));
                 Assert.That(docElement.GetAttribute("ShowNamespaces"), Is.EqualTo(!vs.ShowNamespaces ? "False" : ""));
+                Assert.That(docElement.GetAttribute("ShowFixtures"), Is.EqualTo(!vs.ShowFixtures ? "False" : ""));
+                Assert.That(docElement.GetAttribute("ShowAssemblies"), Is.EqualTo(!vs.ShowAssemblies ? "False" : ""));
                 Assert.That(firstChild.Name, Is.EqualTo("Nodes"));
                 Assert.That(topNodes.Count, Is.EqualTo(vs.Nodes.Count));
                 for (int i = 0; i < topNodes.Count; i++)

--- a/src/GuiRunner/TestModel.Tests/VisualStateTests.cs
+++ b/src/GuiRunner/TestModel.Tests/VisualStateTests.cs
@@ -141,6 +141,8 @@ namespace TestCentric.Gui.Model
             {
                 Assert.That(restoredState.ShowCheckBoxes, Is.EqualTo(visualState.ShowCheckBoxes));
                 Assert.That(restoredState.ShowNamespaces, Is.EqualTo(visualState.ShowNamespaces));
+                Assert.That(restoredState.ShowAssemblies, Is.EqualTo(visualState.ShowAssemblies));
+                Assert.That(restoredState.ShowFixtures, Is.EqualTo(visualState.ShowFixtures));
                 // TODO: Categories not yet supported
                 //Assert.AreEqual(ExpectedVisualState.SelectedCategories, restoredState.SelectedCategories);
                 //Assert.AreEqual(ExpectedVisualState.ExcludeCategories, restoredState.ExcludeCategories);

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -69,6 +69,9 @@ namespace TestCentric.Gui.Model
         public bool IsProject => Type == "Project";
         public bool IsNamespace =>
             IsSuite && (Type == "TestSuite" || Type == "SetUpFixture");
+        public bool IsFixture => IsSuite && 
+            (Type == "TestFixture" || Type == "GenericFixture" || Type == "ParameterizedFixture" || Type == "Theory");
+
 
         /// <summary>
         /// Controls if the TestNode should be visible or hidden in the TestTree

--- a/src/GuiRunner/TestModel/TreeConfiguration.cs
+++ b/src/GuiRunner/TestModel/TreeConfiguration.cs
@@ -15,6 +15,10 @@ namespace TestCentric.Gui.Model
 
         bool ShowNamespaces {  get; set; }
 
+        bool ShowAssemblies { get; set; }
+
+        bool ShowFixtures { get; set; }
+
         bool ShowTestDuration { get; set; }
 
         string DisplayFormat { get; set; }
@@ -30,6 +34,8 @@ namespace TestCentric.Gui.Model
         public event SettingsEventHandler Changed;
         private bool _showCheckBoxes = false;
         private bool _showNamespaces = true;
+        private bool _showAssemblies = true;
+        private bool _showFixtures = true;
         private bool _showTestDuration = false;
         private string _displayFormat = "NUNIT_TREE";
         private string _testListGroupBy = "UNGROUPED";
@@ -51,6 +57,26 @@ namespace TestCentric.Gui.Model
             {
                 _showNamespaces = value;
                 OnPropertyChanged(nameof(ShowNamespaces));
+            }
+        }
+
+        public bool ShowAssemblies
+        {
+            get => _showAssemblies;
+            set
+            {
+                _showAssemblies = value;
+                OnPropertyChanged(nameof(ShowAssemblies));
+            }
+        }
+
+        public bool ShowFixtures
+        {
+            get => _showFixtures;
+            set
+            {
+                _showFixtures = value;
+                OnPropertyChanged(nameof(ShowFixtures));
             }
         }
 

--- a/src/GuiRunner/TestModel/VisualState.cs
+++ b/src/GuiRunner/TestModel/VisualState.cs
@@ -25,11 +25,13 @@ namespace TestCentric.Gui.Model
         // Default constructor is required for serialization
         public VisualState() : this("NUNIT_TREE") { }
 
-        public VisualState(string strategyID, string groupID, bool showNamespaces)
+        public VisualState(string strategyID, string groupID, ITreeConfiguration treeConfiguration)
         {
             DisplayStrategy = strategyID;
             GroupBy = groupID;
-            ShowNamespaces = showNamespaces;
+            ShowAssemblies = treeConfiguration.ShowAssemblies;
+            ShowNamespaces = treeConfiguration.ShowNamespaces;
+            ShowFixtures = treeConfiguration.ShowFixtures;
         }
 
         public VisualState(string strategyID, string groupID = null)
@@ -50,6 +52,10 @@ namespace TestCentric.Gui.Model
         public bool ShowCheckBoxes { get; set; }
 
         public bool ShowNamespaces { get; set; }
+
+        public bool ShowAssemblies { get; set; }
+
+        public bool ShowFixtures { get; set; }
 
         // TODO: Categories not yet supported
         //public List<string> SelectedCategories;
@@ -261,7 +267,9 @@ namespace TestCentric.Gui.Model
             // GroupBy is null for NUnitTree strategy, otherwise required
             if (GroupBy == null && strategy != "NUNIT_TREE") GroupBy = "ASSEMBLY";
             ShowCheckBoxes = reader.GetAttribute("ShowCheckBoxes") == "True";
+            ShowAssemblies = reader.GetAttribute("ShowAssemblies") != "False";
             ShowNamespaces = reader.GetAttribute("ShowNamespaces") != "False";
+            ShowFixtures = reader.GetAttribute("ShowFixtures") != "False";
 
             while (reader.Read())
             {
@@ -376,9 +384,12 @@ namespace TestCentric.Gui.Model
                 writer.WriteAttributeString("GroupBy", GroupBy);
             if (ShowCheckBoxes)
                 writer.WriteAttributeString("ShowCheckBoxes", "True");
+            if (!ShowAssemblies)
+                writer.WriteAttributeString("ShowAssemblies", "False");
             if (!ShowNamespaces)
                 writer.WriteAttributeString("ShowNamespaces", "False");
-
+            if (!ShowFixtures)
+                writer.WriteAttributeString("ShowFixtures", "False");
             WriteVisualTreeNodes(Nodes);
 
             void WriteVisualTreeNodes(List<VisualTreeNode> nodes)


### PR DESCRIPTION
This PR fixes #1437 by providing additional menu items for the nunit tree display.
<img width="300" src="https://github.com/user-attachments/assets/b547d059-e97d-48a0-b5cb-18f867ea9595" />

All these options are enabled by default for new projects, so that by default the entire NUnit tree will always be displayed. 
These options are also stored in the VisualState file so when reloading a project the previous tree configuration is restored.
