### PR TITLE
Move VisualState back to the TestCentric.Gui assembly

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/VisualStateSerializationTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/VisualStateSerializationTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using System.Xml;
 using System.Collections;
 
-namespace TestCentric.Gui.Model
+namespace TestCentric.Gui
 {
     public class VisualStateSerializationTests : VisualStateTestBase
     {

--- a/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTestBase.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTestBase.cs
@@ -5,7 +5,7 @@
 
 using System.Windows.Forms;
 
-namespace TestCentric.Gui.Model
+namespace TestCentric.Gui
 {
     public class VisualStateTestBase
     {

--- a/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTestData.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTestData.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Windows.Forms; 
 
-namespace TestCentric.Gui.Model
+namespace TestCentric.Gui
 {
     public class VisualStateTestData
     {

--- a/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/VisualStateTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Windows.Forms;
 using NUnit.Framework;
 
-namespace TestCentric.Gui.Model
+namespace TestCentric.Gui
 {
     [TestFixtureSource(nameof(TestData))]
     public class VisualStateTests : VisualStateTestBase

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
@@ -120,11 +120,6 @@ namespace TestCentric.Gui.Presenters
             _model.Events.TestFinished += OnTestFinished;
             _model.Events.SuiteFinished += OnTestFinished;
 
-            _model.Events.VisualStateRequest += (ea) =>
-            {
-                ea.VisualState = Strategy.CreateVisualState();
-            };
-
             _model.Settings.Changed += OnSettingsChanged;
             TreeConfiguration.Changed += OnTreeConfigurationChanged;
 

--- a/src/GuiRunner/TestCentric.Gui/VisualState.cs
+++ b/src/GuiRunner/TestCentric.Gui/VisualState.cs
@@ -11,10 +11,9 @@ using System.Xml.Serialization;
 using System.Xml.Schema;
 using System.Xml;
 using NUnit;
+using TestCentric.Gui.Model;
 
-// TODO: Consider splitting this class so that the model does not deal
-// with a windows tree control.
-namespace TestCentric.Gui.Model
+namespace TestCentric.Gui
 {
     /// <summary>
     /// The VisualState class holds the latest visual state for a project.

--- a/src/GuiRunner/TestModel.Tests/TestModelTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestModelTests.cs
@@ -60,10 +60,6 @@ namespace TestCentric.Gui.Model
             var engine = new MockTestEngine();
             var options = new GuiOptions("dummy.dll");
             var model = TestModel.CreateTestModel(engine, options);
-            model.Events.VisualStateRequest += (ea) =>
-            {
-                ea.VisualState = new VisualState();
-            };
 
             // Act
             model.CreateNewProject("TestCentric");

--- a/src/GuiRunner/TestModel/ITestEvents.cs
+++ b/src/GuiRunner/TestModel/ITestEvents.cs
@@ -18,7 +18,6 @@ namespace TestCentric.Gui.Model
     public delegate void UnhandledExceptionEventHandler(UnhandledExceptionEventArgs args);
     public delegate void TestFilesLoadingEventHandler(TestFilesLoadingEventArgs args);
     public delegate void TestLoadFailureEventHandler(TestLoadFailureEventArgs args);
-    public delegate void VisualStateEventHandler(VisualStateEventArgs args);
 
     /// <summary>
     /// ITestEvents provides events for all actions in the model, both those
@@ -30,7 +29,6 @@ namespace TestCentric.Gui.Model
         // Events related to loading and unloading TestCentric projects
         event TestEventHandler TestCentricProjectLoaded;
         event TestEventHandler TestCentricProjectUnloaded;
-        event VisualStateEventHandler VisualStateRequest;
 
         // Events related to loading and unloading tests.
         event TestFilesLoadingEventHandler TestsLoading;

--- a/src/GuiRunner/TestModel/TestEventArgs.cs
+++ b/src/GuiRunner/TestModel/TestEventArgs.cs
@@ -116,9 +116,4 @@ namespace TestCentric.Gui.Model
 
         public Exception Exception;
     }
-
-    public class VisualStateEventArgs : TestEventArgs
-    {
-        public VisualState VisualState;
-    }
 }

--- a/src/GuiRunner/TestModel/TestEventDispatcher.cs
+++ b/src/GuiRunner/TestModel/TestEventDispatcher.cs
@@ -59,13 +59,6 @@ namespace TestCentric.Gui.Model
             TestCentricProjectLoaded?.Invoke(new TestEventArgs());
         }
 
-        public VisualState RequestVisualState()
-        {
-            VisualStateEventArgs args = new VisualStateEventArgs();
-            VisualStateRequest?.Invoke(args);
-            return args.VisualState;
-        }
-
         public void FireTestCentricProjectUnloaded()
         {
             TestCentricProjectUnloaded?.Invoke(new TestEventArgs());
@@ -138,7 +131,6 @@ namespace TestCentric.Gui.Model
         // TestCentricProject loading events
         public event TestEventHandler TestCentricProjectLoaded;
         public event TestEventHandler TestCentricProjectUnloaded;
-        public event VisualStateEventHandler VisualStateRequest;
 
         // Test loading events
         public event TestFilesLoadingEventHandler TestsLoading;


### PR DESCRIPTION
As follow-up to #1455, move the VisualState class back to the gui assembly, reversing an earlier change.