### PR TITLE
Add context menu to remove entries from recent files list

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestCentricPresenter.cs
@@ -420,16 +420,11 @@ namespace TestCentric.Gui.Presenters
                         entries.RemoveAt(index);
 
                 menuItems.Clear();
-                int num = 0;
-                foreach (string entry in entries)
+
+                for (int i=0; i<entries.Count; i++)
                 {
-                    var menuText = string.Format("{0} {1}", ++num, entry);
-                    var menuItem = new ToolStripMenuItem(menuText);
-                    menuItem.Click += (sender, ea) =>
-                    {
-                        string path = ((ToolStripMenuItem)sender).Text.Substring(2);
-                        _model.OpenExistingFile(path);
-                    };
+                    string menuItemText = $"{i + 1} {entries[i]}";
+                    ToolStripMenuItem menuItem = CreateRecentFileMenuItem(menuItemText, i, (index) => _model.OpenExistingFile(entries[index]), RemoveRecentFileEntry);
                     menuItems.Add(menuItem);
                 }
             };
@@ -678,6 +673,57 @@ namespace TestCentric.Gui.Presenters
 
                 if (dlg.ShowDialog(_view as IWin32Window) == DialogResult.OK)
                     SetPackageSettingAndReload(SettingDefinitions.TestParametersDictionary.WithValue(dlg.Parameters));
+            }
+        }
+
+        private ToolStripMenuItem CreateRecentFileMenuItem(string menuText, int tag, Action<int> recentFileClickedAction, Action<int> contextMenuAction)
+        {
+            var menuItem = new ToolStripMenuItem(menuText);
+            menuItem.Tag = tag;
+            menuItem.Click += (sender, ea) =>
+            {
+                int index = (int)((ToolStripMenuItem)sender).Tag;
+                recentFileClickedAction(index);
+            };
+            menuItem.MouseUp += (sender, ea) =>
+            {
+                if (ea.Button == MouseButtons.Right)
+                {
+                    var ctxMenuItem = new MenuItem("Remove item from list");
+                    ctxMenuItem.Click += (s, e) =>
+                    {
+                        int index = (int)((ToolStripMenuItem)sender).Tag;
+                        contextMenuAction(index);
+                    };
+
+                    var menuItem = sender as ToolStripMenuItem;
+                    Control ctrl = menuItem.Owner as Control;
+                    ContextMenu ctx = new ContextMenu(new[] { ctxMenuItem });
+                    ctx.Show(ctrl, ctrl.PointToClient(Cursor.Position));
+                }
+            };
+
+            return menuItem;
+        }
+
+        private void RemoveRecentFileEntry(int index)
+        {
+            // Remove entry from settings
+            var entries = _model.Settings.Gui.RecentFiles.Entries;
+            if (index >= 0 && index < entries.Count)
+                entries.RemoveAt(index);
+
+            // Remove entry from menu
+            var menuItems = _view.RecentFilesMenu.MenuItems;
+            if (index >= 0 && index < menuItems.Count)
+                menuItems.RemoveAt(index);
+
+            // Update menu item (tag and text) of all remaining menu items
+            for (int i=0; i < entries.Count; i++)
+            {
+                var menuItem = menuItems[i] as ToolStripMenuItem;
+                menuItem.Tag = i;
+                menuItem.Text = $"{i + 1} {entries[i]}";
             }
         }
 


### PR DESCRIPTION
This PR fixes #1458 by providing a context menu for the recent files menu items. Here's a screen shot:

<img width="600" src="https://github.com/user-attachments/assets/c38094a0-98ca-4f80-96f8-e374f2d2a611" />

From technical point of view WinForm provides two context menu approaches: the 'old' `ContextMenu` class and the 'new' `ContextMenuStrip` class, I decided to stick with the `ContextMenu` class, because opening a `ContextMenuStrip` forces all other menu items to close (especially the RecentFileList). The context menu looks a little lonely there - there are some tricks to keep the other menu items open, but it makes it more complex. There are no such effects using the `ContextMenu` class.

Another idea was to use the keyboard (Delete key) to remove an entry. However, a ToolStripMenuItem has no KeyDown/Up event. Instead you can register a KeyDown event on a parent element. Now you know which key is pressed on the menu, but you don't know which menu item is pointed with mouse cursor. That doesn't sound like a simple approach either, so I dropped it.

