### PR TITLE
Fix crash when closing TestCentric without a project opened

### DIFF
--- a/src/GuiRunner/TestModel.Tests/TestModelTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestModelTests.cs
@@ -232,5 +232,36 @@ namespace TestCentric.Gui.Model
             runner.Received().Dispose();
             Assert.That(project.TopLevelPackage.SubPackages[0].Settings.GetValueOrDefault(SettingDefinitions.DebugTests), Is.False);
         }
+
+        [Test]
+        public void CloseProject_LastProject_IsSet_AsRecentFileLatest()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new GuiOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+            model.CreateNewProject("CloseProject_LastProjectTest");
+
+            // Act
+            model.CloseProject();
+
+            // Assert
+            Assert.That(model.Settings.Gui.RecentFiles.Latest, Contains.Substring("CloseProject_LastProjectTest"));
+        }
+
+        [Test]
+        public void CloseProject_NoProjectOpen_RecentFileLatest_IsEmpty()
+        {
+            // Arrange
+            var engine = new MockTestEngine();
+            var options = new GuiOptions("dummy.dll");
+            var model = TestModel.CreateTestModel(engine, options);
+
+            // Act
+            model.CloseProject();
+
+            // Assert
+            Assert.That(model.Settings.Gui.RecentFiles.Latest, Is.Null.Or.Empty);
+        }
     }
 }

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -430,7 +430,7 @@ namespace TestCentric.Gui.Model
             if (HasTests)
                 UnloadTests();
 
-            if (TestCentricProject.ProjectPath is not null)
+            if (TestCentricProject?.ProjectPath is not null)
                 SaveProject();
 
             TestCentricProject = null;


### PR DESCRIPTION
This PR fixes #1470 by adding a null check.