### PR TITLE
Apply full path for recent file setting

### DIFF
--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -473,7 +473,8 @@ namespace TestCentric.Gui.Model
                 foreach (var subPackage in TopLevelPackage.SubPackages)
                     RecentFiles.Latest = subPackage.FullName;
             else if (TestCentricProject.ProjectPath.EndsWith(".dll.tcproj"))
-                RecentFiles.Latest = Path.GetFileNameWithoutExtension(TestCentricProject.ProjectPath);
+                RecentFiles.Latest = Path.Combine(Path.GetDirectoryName(TestCentricProject.ProjectPath),
+                                                  Path.GetFileNameWithoutExtension(TestCentricProject.ProjectPath));
             else
                 RecentFiles.Latest = TestCentricProject.ProjectPath;
         }


### PR DESCRIPTION
This PR fixes #1472.

All entries in the recent file list must be a full path - otherwise we won't manage to find and load them again. There was one code location which inserted only the file name (without path) into the list. That was wrong - so I adapted this statement accordingly.
