### PR TITLE
Catch exceptions while reading invalid VisualState files

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/VisualStateSerializationTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/VisualStateSerializationTests.cs
@@ -131,6 +131,36 @@ namespace TestCentric.Gui
             }
         }
 
+        [Test]
+        public void LoadFrom_NonExistingFile_ReturnsNull()
+        {
+            var visualState = VisualState.LoadFrom("NotExistingFile.xml");
+
+            Assert.That(visualState, Is.Null);
+        }
+
+        [Test]
+        public void LoadFrom_EmptyFile_ReturnsNull()
+        {
+            File.WriteAllText("EmptyFile.xml", String.Empty);
+
+            var visualState = VisualState.LoadFrom("EmptyFile.xml");
+
+            Assert.That(visualState, Is.Null);
+        }
+
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?>")]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><VisualState>")]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><VisualState> <Nodes> </VisualState>")]
+        public void LoadFrom_InvalidXmlContent_ReturnsNull(string content)
+        {
+            File.WriteAllText("InvalidXmlContent.xml", content);
+
+            var visualState = VisualState.LoadFrom("InvalidXmlContent.xml");
+
+            Assert.That(visualState, Is.Null);
+        }
+
         public class VisualStateSerializationData : VisualStateTestBase, IEnumerable<TestCaseData>
         {
             public IEnumerator<TestCaseData> GetEnumerator()

--- a/src/GuiRunner/TestCentric.Gui/VisualState.cs
+++ b/src/GuiRunner/TestCentric.Gui/VisualState.cs
@@ -189,9 +189,19 @@ namespace TestCentric.Gui
 
         public static VisualState LoadFrom(string fileName)
         {
-            using (StreamReader reader = new StreamReader(fileName))
+            try
             {
-                return LoadFrom(reader);
+                using (StreamReader reader = new StreamReader(fileName))
+                {
+                    return LoadFrom(reader);
+                }
+            }
+            catch (Exception e)
+            {
+                // Catch all kind of exceptions while reading file (FileNotFound, XmlException, Security, IO-Exception, ...)
+                Logger log = InternalTrace.GetLogger(nameof(VisualState));
+                log.Error($"Failed to read VisualState file: {fileName}; {e.Message}");
+                return null;
             }
         }
 


### PR DESCRIPTION
This PR fixes #1450.

Basically I added a catch statement to handle all kind of exceptions while reading a VisualState file. In case of an exception the error is logged and null is returned as a return value.

I was tempted to move the `File.Exists(fileName)` statement into the `VisualState.LoadFrom(string)` method. Currently it's called outside before invoking this method. Also, I was tempted to return an empty, default VisualState object in case of an error. So, that callers don't need to care about the null return value. 

But that would require a few more changes – nothing too complicated, but before I get started, I’d like to hear your thoughts about it.

I ran all of our tests (Gui.Model.Tests and Gui.Tests) to detect any exceptions during VisualState file reading. But I didn't spot any occurrence or any workflow which creates corrupt VisualState file and which needs to be fixed. 