### PR TITLE
Add TestGroup specific property view

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Gui.Presenters
             _model.Events.TestLoaded += (ea) => _view.Visible = true;
             _model.Events.TestReloaded += (ea) => _view.TestPackageSubView.InvokeIfRequired(() => _view.Visible = true);
             _model.Events.TestUnloaded += (ea) => _view.Visible = false;
-            _model.Events.RunFinished += (ea) => DisplaySelectedItem();
+            _model.Events.RunFinished += (ea) => _view.TestPackageSubView.InvokeIfRequired(() => DisplaySelectedItem());
             _model.Events.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
             _view.DisplayHiddenPropertiesChanged += () => DisplaySelectedItem();
             _view.Resize += (s, e) => DisplaySelectedItem();
@@ -60,6 +60,7 @@ namespace TestCentric.Gui.Presenters
                 switch (_selectedItem)
                 {
                     case TestNode testNode:
+                        _view.TestGroupPropertiesSubView.Hide();
                         _view.TestPropertiesSubView.Show();
                         InitializeTestPackageSubView(testNode);
                         InitializeTestPropertiesSubView(testNode);
@@ -68,8 +69,10 @@ namespace TestCentric.Gui.Presenters
 
                         break;
                     case TestGroup testGroup:
+                        _view.TestGroupPropertiesSubView.Show();
                         _view.TestPackageSubView.Hide();
                         _view.TestPropertiesSubView.Hide();
+                        InitializeTestGroupPropertiesSubView(testGroup);
                         break;
                 }
             }
@@ -117,6 +120,12 @@ namespace TestCentric.Gui.Presenters
             _view.Properties = GetTestProperties(testNode);
 
             _view.TestPropertiesSubView.Visible = true;
+        }
+
+        private void InitializeTestGroupPropertiesSubView(TestGroup testGroup)
+        {
+            _view.TestGroupPropertiesSubView.FullName = testGroup.Name;
+            _view.TestGroupPropertiesSubView.TestCount = testGroup.TestNodes.Count().ToString();
         }
 
         private void AdjustSubViewHeights()

--- a/src/GuiRunner/TestCentric.Gui/Views/ITestPropertiesVIew.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/ITestPropertiesVIew.cs
@@ -30,6 +30,9 @@ namespace TestCentric.Gui.Views
 
         TestPackageSubView TestPackageSubView { get; }
         TestPropertiesSubView TestPropertiesSubView { get; }
+
+        TestGroupPropertiesSubView TestGroupPropertiesSubView { get; }
+
         TestPropertiesView.SubView[] SubViews { get; }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.Designer.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.Designer.cs
@@ -1,0 +1,119 @@
+using TestCentric.Gui.Controls;
+
+namespace TestCentric.Gui.Views
+{
+    partial class TestGroupPropertiesSubView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.testCaseCountLabel = new System.Windows.Forms.Label();
+            this.testCaseCount = new System.Windows.Forms.Label();
+            this.fullNameLabel = new System.Windows.Forms.Label();
+            this.fullName = new TestCentric.Gui.Controls.ExpandingLabel();
+            this.testType = new System.Windows.Forms.Label();
+            this.testTypeLabel = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // testCaseCountLabel
+            // 
+            this.testCaseCountLabel.Location = new System.Drawing.Point(5, 44);
+            this.testCaseCountLabel.Name = "testCaseCountLabel";
+            this.testCaseCountLabel.Size = new System.Drawing.Size(65, 13);
+            this.testCaseCountLabel.TabIndex = 24;
+            this.testCaseCountLabel.Text = "Test Count:";
+            // 
+            // testCaseCount
+            // 
+            this.testCaseCount.Location = new System.Drawing.Point(74, 45);
+            this.testCaseCount.Name = "testCaseCount";
+            this.testCaseCount.Size = new System.Drawing.Size(71, 13);
+            this.testCaseCount.TabIndex = 25;
+            // 
+            // fullNameLabel
+            // 
+            this.fullNameLabel.Location = new System.Drawing.Point(5, 24);
+            this.fullNameLabel.Name = "fullNameLabel";
+            this.fullNameLabel.Size = new System.Drawing.Size(65, 13);
+            this.fullNameLabel.TabIndex = 18;
+            this.fullNameLabel.Text = "Full Name:";
+            // 
+            // fullName
+            // 
+            this.fullName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.fullName.AutoEllipsis = true;
+            this.fullName.BackColor = System.Drawing.Color.LightYellow;
+            this.fullName.Location = new System.Drawing.Point(73, 23);
+            this.fullName.Name = "fullName";
+            this.fullName.Size = new System.Drawing.Size(399, 18);
+            this.fullName.TabIndex = 19;
+            // 
+            // testType
+            // 
+            this.testType.Location = new System.Drawing.Point(74, 4);
+            this.testType.Name = "testType";
+            this.testType.Text = "Test group";
+            this.testType.Size = new System.Drawing.Size(117, 13);
+            this.testType.TabIndex = 3;
+            // 
+            // testTypeLabel
+            // 
+            this.testTypeLabel.Location = new System.Drawing.Point(5, 4);
+            this.testTypeLabel.Name = "testTypeLabel";
+            this.testTypeLabel.Size = new System.Drawing.Size(58, 13);
+            this.testTypeLabel.TabIndex = 2;
+            this.testTypeLabel.Text = "Test Type:";
+            // 
+            // TestGroupPropertiesSubView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.Controls.Add(this.testCaseCountLabel);
+            this.Controls.Add(this.testCaseCount);
+            this.Controls.Add(this.fullNameLabel);
+            this.Controls.Add(this.fullName);
+            this.Controls.Add(this.testType);
+            this.Controls.Add(this.testTypeLabel);
+            this.MinimumSize = new System.Drawing.Size(2, 80);
+            this.Name = "TestGroupPropertiesSubView";
+            this.Size = new System.Drawing.Size(476, 80);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label testTypeLabel;
+        private System.Windows.Forms.Label testType;
+        private System.Windows.Forms.Label fullNameLabel;
+        private ExpandingLabel fullName;
+        private System.Windows.Forms.Label testCaseCountLabel;
+        private System.Windows.Forms.Label testCaseCount;
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.cs
@@ -1,0 +1,40 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using TestCentric.Gui.Elements;
+
+namespace TestCentric.Gui.Views
+{
+    public partial class TestGroupPropertiesSubView : TestPropertiesView.SubView
+    {
+        public TestGroupPropertiesSubView()
+        {
+            InitializeComponent();
+        }
+
+        public override int FullHeight => testCaseCount.Top + HeightNeededForControl(testCaseCount) + 8;
+
+        public string FullName
+        {
+            get { return fullName.Text; }
+            set { this.InvokeIfRequired(() => { fullName.Text = value; }); }
+        }
+
+        public string TestCount
+        {
+            get { return testCaseCount.Text; }
+            set { this.InvokeIfRequired(() => { testCaseCount.Text = value; }); }
+        }
+    }
+}

--- a/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.resx
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestGroupPropertiesSubView.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/GuiRunner/TestCentric.Gui/Views/TestPropertiesView.Designer.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestPropertiesView.Designer.cs
@@ -32,6 +32,7 @@ namespace TestCentric.Gui.Views
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.testPackageSubView = new TestCentric.Gui.Views.TestPackageSubView();
             this.testPropertiesSubView = new TestCentric.Gui.Views.TestPropertiesSubView();
+            this.testGroupPropertiesSubView = new TestCentric.Gui.Views.TestGroupPropertiesSubView();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -52,6 +53,7 @@ namespace TestCentric.Gui.Views
             this.flowLayoutPanel1.Controls.Add(this.header);
             this.flowLayoutPanel1.Controls.Add(this.testPackageSubView);
             this.flowLayoutPanel1.Controls.Add(this.testPropertiesSubView);
+            this.flowLayoutPanel1.Controls.Add(this.testGroupPropertiesSubView);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
@@ -88,6 +90,18 @@ namespace TestCentric.Gui.Views
             this.testPropertiesSubView.TestCount = "";
             this.testPropertiesSubView.TestType = "";
             // 
+            // testGroupPropertiesSubView
+            // 
+            this.testGroupPropertiesSubView.BackColor = System.Drawing.SystemColors.Control;
+            this.testGroupPropertiesSubView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.testGroupPropertiesSubView.Location = new System.Drawing.Point(3, 98);
+            this.testGroupPropertiesSubView.MinimumSize = new System.Drawing.Size(2, 62);
+            this.testGroupPropertiesSubView.Name = "testGroupPropertiesSubView";
+            this.testGroupPropertiesSubView.Size = new System.Drawing.Size(516, 65);
+            this.testGroupPropertiesSubView.TabIndex = 31;
+            this.testGroupPropertiesSubView.FullName = "";
+            this.testGroupPropertiesSubView.TestCount = "";
+            // 
             // TestPropertiesView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -106,6 +120,7 @@ namespace TestCentric.Gui.Views
         private System.Windows.Forms.Label header;
         private TestPackageSubView testPackageSubView;
         private TestCentric.Gui.Views.TestPropertiesSubView testPropertiesSubView;
+        private TestCentric.Gui.Views.TestGroupPropertiesSubView testGroupPropertiesSubView;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Views/TestPropertiesView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestPropertiesView.cs
@@ -35,6 +35,7 @@ namespace TestCentric.Gui.Views
             header.Width = subViewWidth;
             testPackageSubView.Width = subViewWidth;
             testPropertiesSubView.Width = subViewWidth;
+            testGroupPropertiesSubView.Width = subViewWidth;
         }
 
         public int ClientHeight => ClientRectangle.Height - TestPackageSubView.Top - 40; // Value of 40 allows for non-client areas and spacing
@@ -49,7 +50,10 @@ namespace TestCentric.Gui.Views
 
         public TestPropertiesSubView TestPropertiesSubView => testPropertiesSubView;
 
-        public SubView[] SubViews => new SubView[] { TestPackageSubView, TestPropertiesSubView }; 
+        public TestGroupPropertiesSubView TestGroupPropertiesSubView => testGroupPropertiesSubView;
+
+
+        public SubView[] SubViews => new SubView[] { TestPackageSubView, TestPropertiesSubView, TestGroupPropertiesSubView }; 
 
         public string TestType
         {


### PR DESCRIPTION
This PR contributes to #1478 by providing a new subview in the properties view for `TestGroups`.
Here's a screenshot of this subview:

<img width="800" src="https://github.com/user-attachments/assets/9dd95040-ca33-4937-a066-1efe1b2e5b9e" />

The layout is aligned to the existing TestProperties subview and package subview and it displays these properties:

- Test type: This value is set fixed to "Test group"
- Full name: I intended to display a full name here. But the ParentGroup property of the TestGroup is not set, so I cannot traverse the group hierarchy. Nor can I access the associated TestNode to access its fullname. So, I only display a simple name here. But this can be changed later on.
- Test count: The number of test cases - retrieved by the TestGroup.TestNodes property.
