### PR TITLE
Display TestGroup full name in properties view

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
@@ -124,7 +124,7 @@ namespace TestCentric.Gui.Presenters
 
         private void InitializeTestGroupPropertiesSubView(TestGroup testGroup)
         {
-            _view.TestGroupPropertiesSubView.FullName = testGroup.Name;
+            _view.TestGroupPropertiesSubView.FullName = GetTestGroupFullName(testGroup);
             _view.TestGroupPropertiesSubView.TestCount = testGroup.TestNodes.Count().ToString();
         }
 
@@ -202,6 +202,19 @@ namespace TestCentric.Gui.Presenters
                 sb.Append(item);
             }
             return sb.ToString();
+        }
+
+        private string GetTestGroupFullName(TestGroup testGroup)
+        {
+            string fullName = testGroup.Name;
+            while (testGroup.ParentGroup != null)
+            {
+                testGroup = testGroup.ParentGroup;
+                string separator = testGroup.ParentGroup != null ? "." : ": ";
+                fullName = testGroup.Name + separator + fullName;
+            }
+
+            return fullName;
         }
 
         #endregion

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestPropertiesPresenter.cs
@@ -207,11 +207,12 @@ namespace TestCentric.Gui.Presenters
         private string GetTestGroupFullName(TestGroup testGroup)
         {
             string fullName = testGroup.Name;
-            while (testGroup.ParentGroup != null)
+            testGroup = testGroup.ParentGroup;
+            while (testGroup != null)
             {
+                string separator = testGroup.ParentGroup == null ? ": " : ".";
+                fullName = $"{testGroup.Name}{separator}{fullName}";
                 testGroup = testGroup.ParentGroup;
-                string separator = testGroup.ParentGroup != null ? "." : ": ";
-                fullName = testGroup.Name + separator + fullName;
             }
 
             return fullName;


### PR DESCRIPTION
This PR fixes #1478. 

The only remaining issue was that we wanted to display the full name for a test group. Since the `TestGroup.ParentGroup` property is now available, the full name can be assembled by navigating through the parent hierarchy.
Here's a screenshot:

<img width="400" src="https://github.com/user-attachments/assets/1b756765-f6d7-4a54-8eeb-24a75cd7ecf7" />

The root TestGroup node (Category, Duration, Outcome or 'all tests' in case of none grouping) is included in the full name. It's separated by a ':' however.
