### PR TITLE
Enable filtering toolbar

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
@@ -46,17 +46,19 @@ namespace TestCentric.Gui.Presenters
             _treeNodes = null;
         }
 
-        [Test]
-        public void OnStrategyCreated_OutcomeFilter_IsInvisible()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OnStrategyCreated_OutcomeFilter_IsInvisible(bool isVisible)
         {
             // 1. Arrange
             _model.TreeConfiguration.TestListGroupBy = "UNGROUPED";
+            _model.Settings.Gui.TestTree.ShowFilter.Returns(isVisible);
 
             // 2. Act           
             TestListDisplayStrategy strategy = new TestListDisplayStrategy(_view, _model);
 
             // 3. Assert
-            _view.Received().SetTestFilterVisibility(false);
+            _view.Received().SetTestFilterVisibility(isVisible);
         }
 
         [TestCase("", "", "", 1, 3, 0, 0, 0)]

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -91,7 +91,7 @@ namespace TestCentric.Gui.Presenters
 
         protected void AddTreeNodeToCollection(TestNode testNode, TreeNodeCollection treeNodes)
         {
-            if (ShowTreeNodeType(testNode))
+            if (ShowTreeNodeType(testNode) && testNode.IsVisible)
             {
                 var treeNode = MakeTreeNode(testNode, false);
                 treeNodes.Add(treeNode);

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -42,6 +42,8 @@ namespace TestCentric.Gui.Presenters
             _treeView = view.TreeView;
             _model = model;
             _settings = _model.Settings;
+
+            _view.SetTestFilterVisibility(_settings.Gui.TestTree.ShowFilter);
         }
 
         #endregion

--- a/src/GuiRunner/TestCentric.Gui/Presenters/GroupDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/GroupDisplayStrategy.cs
@@ -27,7 +27,6 @@ namespace TestCentric.Gui.Presenters
             : base(view, model)
         {
             _topLevelGrouping = CreateTestGrouping(GroupBy);
-            _view.SetTestFilterVisibility(false);
         }
 
         #endregion

--- a/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/NUnitTreeDisplayStrategy.cs
@@ -22,7 +22,6 @@ namespace TestCentric.Gui.Presenters
         public NUnitTreeDisplayStrategy(ITestTreeView view, ITestModel model)
             : base(view, model) 
         {
-            _view.SetTestFilterVisibility(model.Settings.Gui.TestTree.ShowFilter);
             _view.CollapseToFixturesCommand.Enabled = true;
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -250,7 +250,7 @@ namespace TestCentric.Gui.Presenters
         private TestSelection GetTestCases(TestNode testNode)
         {
             return new TestSelection(testNode
-                .Select(n => !n.IsSuite)
+                .Select(n => !n.IsSuite && n.IsVisible)
                 .OrderBy(s => s.Name));
         }
 


### PR DESCRIPTION
This PR contributes to #1500, but doesn't completely solve it.

It takes care that the filter toolbar buttons have again any effect on the displayed tree nodes. So, the tree nodes are successfully filtered according to the filter criteria. That's working fine for the NUnit and the test list display strategy.

What is missing and still needs to be restored:

- The tree node icons are not updated to the filtering operation, but still display the unfiltered state
- A test run doesn't consider the filtering. But also filtered out nodes are included in the test run. That applies for 'Run all' but also for a selected test run.


Although the filtering will not completely work right away, I thought it was a good idea to start with a small commit. Especially since we'll discuss about tree node icon state soon and the filtering will add an additional dimension. So, we can try out any effects in practice.

