### PR TITLE
Use different running image indices depending on the test results of the child nodes

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
         }
 
-        [TestCaseSource("resultData")]
+        [TestCaseSource(nameof(resultData))]
         public void TreeShowsProperResult(ResultState resultState, int expectedIndex)
         {
             var result = resultState.Status.ToString();
@@ -62,7 +62,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Framework;
+using System.Windows.Forms;
 using NSubstitute;
+using NUnit.Framework;
 using TestCentric.Gui.Model;
+using TestCentric.Gui.Views;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
@@ -14,12 +16,44 @@ namespace TestCentric.Gui.Presenters.TestTree
         [SetUp]
         public void SimulateTestRunCompletion()
         {
+            _presenter = new TreeViewPresenter(_view, _model, new TreeDisplayStrategyFactory());
+            _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
+
             ClearAllReceivedCalls();
 
             _model.HasTests.Returns(true);
             _model.HasResults.Returns(true);
+        }
 
-            FireRunFinishedEvent(new ResultNode("<test-run id='XXX' result='Failed' />"));
+        static object[] resultData = new object[] {
+            new object[] { TestTreeView.RunningIndex_Success, TestTreeView.SuccessIndex },
+            new object[] { TestTreeView.RunningIndex_Failure, TestTreeView.FailureIndex },
+            new object[] { TestTreeView.RunningIndex_Ignored, TestTreeView.IgnoredIndex },
+            new object[] { TestTreeView.RunningIndex_Warning, TestTreeView.WarningIndex },
+            new object[] { TestTreeView.RunningIndex, TestTreeView.SkippedIndex },
+            new object[] { TestTreeView.PendingIndex, TestTreeView.SkippedIndex },
+        };
+
+        [TestCaseSource(nameof(resultData))]
+        public void RunningIcons_AreUpdated_WhenTestRunFinish(int runningIndex, int expectedIndex)
+        {
+            var testNode = new TestNode("<test-run id='1'><test-suite id='100'><test-case id='200'/></test-suite></test-run>");
+
+            // Make it look like the view loaded
+            _view.Load += Raise.Event<System.EventHandler>(_view, new System.EventArgs());
+
+            TreeView treeView = new TreeView();
+            _view.TreeView.Returns(treeView);
+
+            // We can't construct a TreeNodeCollection, so we fake it
+            var nodes = new TreeNode().Nodes;
+            nodes.Add(new TreeNode("test.dll") { ImageIndex = runningIndex });
+            _view.Nodes.Returns(nodes);
+
+            _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
+            FireRunFinishedEvent(new ResultNode("<test-run id='1' result='Passed' />"));
+
+            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             new object[] { ResultState.Cancelled, TestTreeView.FailureIndex }
         };
 
-        [TestCaseSource("resultData")]
+        [TestCaseSource(nameof(resultData))]
         public void TreeShowsProperResult(ResultState resultState, int expectedIndex)
         {
             var result = resultState.Status.ToString();
@@ -67,7 +67,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -8,10 +8,13 @@ using NSubstitute;
 
 namespace TestCentric.Gui.Presenters.TestTree
 {
+    using System.IO;
     using Model;
 
     public class WhenTestsAreReloaded : TreeViewPresenterTestBase
     {
+        string projectName = "MyProject";
+
         [SetUp]
         public void Setup()
         {
@@ -19,13 +22,18 @@ namespace TestCentric.Gui.Presenters.TestTree
 
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
+
+            // Delete VisualState file to prevent any unintended side effects
+            string fileName = VisualState.GetVisualStateFileName(projectName);
+            if (File.Exists(fileName))
+                File.Delete(fileName);
         }
 
         [Test]
         public void TestFilters_AreReset()
         {
             // Arrange
-            var project = new TestCentricProject(_model, "MyProject", "dummy.dll");
+            var project = new TestCentricProject(_model, projectName, "dummy.dll");
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);
@@ -43,7 +51,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void CategoryFilter_IsClosed_And_Init()
         {
             // Arrange
-            var project = new TestCentricProject(_model, "MyProject", "dummy.dll");
+            var project = new TestCentricProject(_model, projectName, "dummy.dll");
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);
@@ -63,7 +71,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             ITreeDisplayStrategy strategy = Substitute.For<ITreeDisplayStrategy>();
             _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
 
-            var project = new TestCentricProject(_model, "MyProject", "dummy.dll");
+            var project = new TestCentricProject(_model, projectName, "dummy.dll");
             TestNode testNode = new TestNode("<test-suite id='1'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -129,7 +129,7 @@ namespace TestCentric.Gui.Presenters
                 {
                     treeNode.Text = GetTreeNodeDisplayName(result);
                     treeNode.ToolTipText = result.Label != null ? result.Label : result.Status.ToString();
-                    _view.SetImageIndex(treeNode, imageIndex, true);
+                    _view.SetImageIndex(treeNode, imageIndex, false);
                 }
             });
         }
@@ -451,11 +451,28 @@ namespace TestCentric.Gui.Presenters
 
         protected void ResetTestRunningIcons(TreeNodeCollection treeNodes)
         {
-            // Only required for exceptional use case 'force stop test run'
+            // Update all running icons to their corresponding non-running icons (required for TestList view)
             foreach (TreeNode treeNode in treeNodes)
             {
-                if (treeNode.ImageIndex == TestTreeView.PendingIndex || treeNode.ImageIndex == TestTreeView.RunningIndex)
-                    _view.SetImageIndex(treeNode, TestTreeView.SkippedIndex);
+                switch (treeNode.ImageIndex)
+                {
+                    case TestTreeView.RunningIndex_Success:
+                        _view.SetImageIndex(treeNode, TestTreeView.SuccessIndex);
+                        break;
+                    case TestTreeView.RunningIndex_Failure:
+                        _view.SetImageIndex(treeNode, TestTreeView.FailureIndex);
+                        break;
+                    case TestTreeView.RunningIndex_Warning:
+                        _view.SetImageIndex(treeNode, TestTreeView.WarningIndex);
+                        break;
+                    case TestTreeView.RunningIndex_Ignored:
+                        _view.SetImageIndex(treeNode, TestTreeView.IgnoredIndex);
+                        break;
+                    case TestTreeView.PendingIndex:
+                    case TestTreeView.RunningIndex:
+                        _view.SetImageIndex(treeNode, TestTreeView.SkippedIndex);
+                        break;
+                }
 
                 ResetTestRunningIcons(treeNode.Nodes);
             }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 
 namespace TestCentric.Gui.Presenters
 {
+    using System;
     using Model;
     using Model.Settings;
     using Views;
@@ -116,7 +117,7 @@ namespace TestCentric.Gui.Presenters
         public virtual void OnTestStarting(TestNode testNode)
         {
             foreach (TreeNode treeNode in GetTreeNodesForTest(testNode))
-                _view.SetImageIndex(treeNode, TestTreeView.RunningIndex, true);
+                SetRunningImageIndex(treeNode);
         }
 
         public virtual void OnTestFinished(ResultNode result)
@@ -384,6 +385,49 @@ namespace TestCentric.Gui.Presenters
                 }
 
                 _view.SetImageIndex(treeNode, imageIndex);
+            }
+        }
+
+        private void SetRunningImageIndex(TreeNode treeNode)
+        {
+            // Test execution is starting for the tree node, so set the image index to "Running" 
+            // The exact type of the “running” image index is determined by the strictest image index of all child nodes
+            int imageIndex = TestTreeView.RunningIndex;
+            foreach (TreeNode childNode in treeNode.Nodes)
+                imageIndex = Math.Max(imageIndex, GetRunningImageIndex(childNode));
+
+            _view.SetImageIndex(treeNode, imageIndex, false);
+
+            // Determine image index for parent nodes as well
+            if (treeNode.Parent != null)
+                SetRunningImageIndex(treeNode.Parent);
+        }
+
+        /// <summary>
+        /// Map the image index of a tree node to the corresponding "running" image index
+        /// </summary>
+        private int GetRunningImageIndex(TreeNode treeNode)
+        {
+            switch (treeNode.ImageIndex)
+            {
+                case TestTreeView.SuccessIndex:
+                case TestTreeView.SuccessIndex_NotLatestRun:
+                case TestTreeView.RunningIndex_Success:
+                    return TestTreeView.RunningIndex_Success;
+                case TestTreeView.FailureIndex:
+                case TestTreeView.FailureIndex_NotLatestRun:
+                case TestTreeView.RunningIndex_Failure:
+                    return TestTreeView.RunningIndex_Failure;
+                case TestTreeView.WarningIndex:
+                case TestTreeView.WarningIndex_NotLatestRun:
+                case TestTreeView.RunningIndex_Warning:
+                    return TestTreeView.RunningIndex_Warning;
+                case TestTreeView.IgnoredIndex:
+                case TestTreeView.IgnoredIndex_NotLatestRun:
+                case TestTreeView.RunningIndex_Ignored:
+                    return TestTreeView.RunningIndex_Ignored;
+                default:
+                    return TestTreeView.RunningIndex;
             }
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
@@ -22,7 +22,7 @@ namespace TestCentric.Gui.Views
         /// indices are correct. These are ordered so that the higher values 
         /// are those that propagate upwards in the tree.
         /// </summary>
-        private static readonly string[] IMAGE_NAMES = { "Skipped", "Pending", "Running",
+        private static readonly string[] IMAGE_NAMES = { "Skipped", "Pending", "Running", "Running_Success", "Running_Ignored", "Running_Warning", "Running_Failure",
             "Inconclusive_NotLatestRun", "Success_NotLatestRun", "Ignored_NotLatestRun", "Warning_NotLatestRun", "Failure_NotLatestRun", 
             "Inconclusive", "Success", "Ignored", "Warning", "Failure" };
 
@@ -31,16 +31,20 @@ namespace TestCentric.Gui.Views
         public const int SkippedIndex = 0;
         public const int PendingIndex = 1;
         public const int RunningIndex = 2;
-        public const int InconclusiveIndex_NotLatestRun = 3;
-        public const int SuccessIndex_NotLatestRun = 4;
-        public const int IgnoredIndex_NotLatestRun = 5;
-        public const int WarningIndex_NotLatestRun = 6;
-        public const int FailureIndex_NotLatestRun = 7;
-        public const int InconclusiveIndex = 8;
-        public const int SuccessIndex = 9;
-        public const int IgnoredIndex = 10;
-        public const int WarningIndex = 11;
-        public const int FailureIndex = 12;
+        public const int RunningIndex_Success = 3;
+        public const int RunningIndex_Ignored = 4;
+        public const int RunningIndex_Warning = 5;
+        public const int RunningIndex_Failure = 6;
+        public const int InconclusiveIndex_NotLatestRun = 7;
+        public const int SuccessIndex_NotLatestRun = 8;
+        public const int IgnoredIndex_NotLatestRun = 9;
+        public const int WarningIndex_NotLatestRun = 10;
+        public const int FailureIndex_NotLatestRun = 11;
+        public const int InconclusiveIndex = 12;
+        public const int SuccessIndex = 13;
+        public const int IgnoredIndex = 14;
+        public const int WarningIndex = 15;
+        public const int FailureIndex = 16;
 
         public event TreeNodeActionHandler SelectedNodeChanged;
         public event TreeNodeActionHandler AfterCheck;


### PR DESCRIPTION
I decided to create a PR for #1515 already now, although there's one flaw which must be fixed by another commit. But before I take on too much at once, I’d like to pause for a moment and discuss with you to see if everything’s okay so far.

I extended the TestTreeView ImageIndex numbers and inserted the new values next to existing RunningIndex number. Which means these are low numbers, which is important when discussing about the flaw.

Whenever a a test is starting (e.g. `DisplayStrategy.OnTestStarting`) we determine the exact type of running index by iterating through all child nodes and getting the most severe running image index. This is done recursive to handle the entire parent hierarchy - each parent node is also in running state now, but the exact type of running index might be different.

Actually, this code part works as intended. However, at the end of the test run there are some incorrect image indices applied to the nodes. This only happens in the TestList view; the NUnit view works correctly.
Here's a screenshot from the flaw:
<img width="350" src="https://github.com/user-attachments/assets/b00d3ca8-8459-4ab4-91e8-873920272b5f" />

Although there is a failed test case, the image index of the parent nodes are set to success! This happens whether the test list view is grouped or ungrouped.

The root cause of this issue is the method `DisplayStrategy.OnTestFinished()`. It takes the test result of the finished test and applies it to all parent nodes recursively. However, an ImageIndex is only applied if the new value is larger than the existing one. But unfortunately, that's the case now: the image index of the parent nodes is set to Running_Failure, which is a low number. When the last test case finished with 'success', the success image index is larger than Running_Failure and therefore 'success' is applied to all parents.

Therefore I think we should no longer apply the test result recursively to all parent nodes in method `DisplayStrategy.OnTestFinished()`. That can be easily be switched off, but the result is still not correct. Now, the running image indices of the parent nodes are never updated and after a test run the tree would look like this:
<img width="350" src="https://github.com/user-attachments/assets/03034708-1b0a-4015-88ca-d6759c12833b" />

Here is my proposed solution:
There's a OnTestFinished event also for the fixture and test assembly node. In the NUnit view this event ensures that the ImageIndex is correctly updated for the fixture/assembly node. And that's exactly how I'd like to handle it in the TestList view as well. Right now, the test list view isn't working because the `_nodeIndex` mapping <TestId, <List<TreeNode>> is incomplete. For all treeNodes created for TestGroups the `_nodeIndex `mapping isn't updated. (see method MakeTreeNode(TestNode) vs MakeTreeNode(TestGroup)). Which basically means, that in the TestList view the OnTestFinished does nothing.
So overall, I want to populate the _nodeIndex mapping for TestGroups as well, so that the OnTestFinished event can detect the relevant TreeNodes. Each TestGroup is representing a certain TestNode which can be used for the mapping. There will be no mapping for the root TestGroups (category, ...)

But before I get started on the implementation, let’s discuss this so that everything goes into the right direction.