### PR TITLE
Fix checking a TreeNode for a TestGroup

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -200,7 +200,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             var subTestNode2 = new TestNode("<test-case id='3' />");
             var testGroup = new TestGroup("Category_1", [subTestNode1, subTestNode2]);
 
-            var treeNode1 = new TreeNode() { Tag = testGroup.TestNodes };
+            var treeNode1 = new TreeNode() { Tag = testGroup };
 
             IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1 };
             _view.CheckedNodes.Returns(checkedNodes);

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TreeViewPresenter.cs
@@ -246,7 +246,9 @@ namespace TestCentric.Gui.Presenters
                 var selection = new TestSelection();
 
                 foreach (var node in checkedNodes)
-                    selection.Add(node.Tag as ITestItem);
+                    if (node.Tag is TestGroup testGroup)
+                        selection.Add(testGroup.TestNodes);
+                    else selection.Add(node.Tag as ITestItem);
                 
                 selection.AddExplicitChildTests();
                 _model.SelectedTests = selection;


### PR DESCRIPTION
We recently changed that a `TestGroup` is no longer a TestSelection but aggregates one. We missed to adapt this code part at that point in time.

In case the treeNode.Tag is a TestGroup we need to request the TestSelection from the TestGroup first to Add() all items to the new TestSelection.

Fixes #1521 