### PR TITLE
Update TestSelection of a all TestGroups when regrouping a test node during a test run

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -158,17 +158,16 @@ namespace TestCentric.Gui.Presenters
                         newGroup = newGroup.GetOrAddSubGroup(fixtureName);
                 }
                 else // ShowFixtures only
-                {
                     newGroup = topLevelGroup.GetOrAddSubGroup(fixtureName);
-                }
             }
 
             // If the group didn't change, we can get out of here
             if (oldGroup == newGroup)
                 return;
 
-            newGroup.Add(result);
-            oldGroup.TestNodes.RemoveId(result.Id);
+            TestNode testNode = _model.GetTestById(result.Id);
+            AddTestToGroups(newGroup, testNode);
+            RemoveTestFromGroups(oldGroup, testNode);
             var newParent = newGroup.TreeNode;
 
             _view.InvokeIfRequired(() =>
@@ -182,6 +181,22 @@ namespace TestCentric.Gui.Presenters
                 newParent.Text = GroupDisplayName(newGroup);
                 ExpandNewParentNodes(newParent);
             });
+        }
+
+        private void AddTestToGroups(TestGroup testGroup, TestNode testNode)
+        {
+            testGroup.Add(testNode);
+            TestGroup parentGroup = testGroup.ParentGroup;
+            if (parentGroup != null)
+                AddTestToGroups(parentGroup, testNode);
+        }
+
+        private void RemoveTestFromGroups(TestGroup testGroup, TestNode testNode)
+        {
+            testGroup.TestNodes.RemoveId(testNode.Id);
+            TestGroup parentGroup = testGroup.ParentGroup;
+            if (parentGroup != null)
+                RemoveTestFromGroups(parentGroup, testNode);
         }
 
         #endregion


### PR DESCRIPTION
I'm back with this small PR which fixes #1535. I'm curious to know whether the pipeline is up again and running successfully. 😄 

The fix itself takes care that a TestNode is added to all new TestGroups in the hierarchy whenever regrouping is required. And also that it's removed from all old TestGroups in the hierarchy. Previously, the TestNode was only added+removed from one single TestGroup (the direct parent), all other TestGroups in the hierarchy remains unchanged. This works fine if test assembly and fixtures nodes are not shown, because the hierarchy consists only of one level.