### PR TITLE
Show number of test cases in tree node name

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
@@ -97,7 +97,7 @@ namespace TestCentric.Gui.Presenters
         {
             // 1. Arrange
             TestNode testNode = new TestNode("<test-case id='1' />");
-            testNode.IsVisible = false;
+            testNode.FilteredOut = false;
             ITestModel model = Substitute.For<ITestModel>();
 
             // 2. Act

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -218,7 +218,7 @@ namespace TestCentric.Gui.Presenters
 
         private string GetTreeNodeNameCountSuffix(int count)
         {
-            return $" ({count} " + (count > 1 ? "tests)" : "test)");
+            return $" ({count} " + (count == 1 ? "test)" : "tests)");
         }
 
         private string GetTreeNodeDisplayName(TestNode testNode)
@@ -237,8 +237,12 @@ namespace TestCentric.Gui.Presenters
 
         private static int GetTestCount(TestNode testNode)
         {
-            // Check if the node is a test case, and it's not filtered out (e.g. by outcome filter)
-            if (!testNode.IsSuite && testNode.IsVisible)
+            // If TestNode is filtered out (e.g. by outcome filter)
+            if (!testNode.IsVisible)
+                return 0;
+
+            // Check if the node is a test case
+            if (!testNode.IsSuite)
                 return 1;
 
             // Iterate through all child nodes

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -128,7 +128,7 @@ namespace TestCentric.Gui.Presenters
 
                 foreach (TreeNode treeNode in GetTreeNodesForTest(result))
                 {
-                    treeNode.Text = GetTreeNodeDisplayName(result);
+                    UpdateTreeNodeName(treeNode);
                     _view.SetImageIndex(treeNode, imageIndex, true);
                 }
             });
@@ -213,17 +213,19 @@ namespace TestCentric.Gui.Presenters
 
         public string GroupDisplayName(TestGroup group)
         {
-            return string.Format("{0} ({1})", group.Name, group.TestNodes.Count());
+            return $"{group.Name}{GetTreeNodeNameCountSuffix(group.TestNodes.Count())}";
         }
 
-        protected virtual string GetTreeNodeName(TestNode testNode)
+        private string GetTreeNodeNameCountSuffix(int count)
         {
-            return testNode.Name;
+            return $" ({count} " + (count > 1 ? "tests)" : "test)");
         }
 
-        protected string GetTreeNodeDisplayName(TestNode testNode)
+        private string GetTreeNodeDisplayName(TestNode testNode)
         {
-            string treeNodeName = GetTreeNodeName(testNode);
+            string treeNodeName = testNode.Name;
+            if (testNode.IsSuite)
+                treeNodeName += GetTreeNodeNameCountSuffix(GetTestCount(testNode));
 
             // Check if test result is available for this node
             ResultNode result = testNode as ResultNode ?? _model.TestResultManager.GetResultForTest(testNode.Id);
@@ -231,6 +233,16 @@ namespace TestCentric.Gui.Presenters
                 treeNodeName += $" [{result.Duration:0.000}s]";
 
             return treeNodeName;
+        }
+
+        private static int GetTestCount(TestNode testNode)
+        {
+            // Check if the node is a test case, and it's not filtered out (e.g. by outcome filter)
+            if (!testNode.IsSuite && testNode.IsVisible)
+                return 1;
+
+            // Iterate through all child nodes
+            return testNode.Children.Sum(GetTestCount);
         }
 
         /// <summary>
@@ -242,7 +254,7 @@ namespace TestCentric.Gui.Presenters
             UpdateTreeNodeNames(_view.Nodes);
         }
 
-        private void UpdateTreeNodeNames(TreeNodeCollection nodes)
+        protected void UpdateTreeNodeNames(TreeNodeCollection nodes)
         {
             _treeView.BeginUpdate();
             foreach (TreeNode treeNode in nodes)
@@ -253,13 +265,7 @@ namespace TestCentric.Gui.Presenters
             _treeView.EndUpdate();
         }
 
-        public void UpdateTreeNodeNames(IEnumerable<TestGroup> groups)
-        {
-            foreach (TestGroup group in groups)
-                UpdateTreeNodeName(group.TreeNode);
-        }
-
-        private void UpdateTreeNodeName(TreeNode treeNode)
+        protected void UpdateTreeNodeName(TreeNode treeNode)
         {
             string treeNodeName = "";
             TestNode testNode = treeNode.Tag as TestNode; 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -94,7 +94,7 @@ namespace TestCentric.Gui.Presenters
 
         protected void AddTreeNodeToCollection(TestNode testNode, TreeNodeCollection treeNodes)
         {
-            if (ShowTreeNodeType(testNode) && testNode.IsVisible)
+            if (ShowTreeNodeType(testNode) && testNode.FilteredOut)
             {
                 var treeNode = MakeTreeNode(testNode, false);
                 treeNodes.Add(treeNode);
@@ -238,7 +238,7 @@ namespace TestCentric.Gui.Presenters
         private static int GetTestCount(TestNode testNode)
         {
             // If TestNode is filtered out (e.g. by outcome filter)
-            if (!testNode.IsVisible)
+            if (!testNode.FilteredOut)
                 return 0;
 
             // Check if the node is a test case

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -271,7 +271,7 @@ namespace TestCentric.Gui.Presenters
         private TestSelection GetTestCases(TestNode testNode)
         {
             return new TestSelection(testNode
-                .Select(n => !n.IsSuite && n.IsVisible)
+                .Select(n => !n.IsSuite && n.FilteredOut)
                 .OrderBy(s => s.Name));
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -63,6 +63,7 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
 
             ApplyResultsToTree();
+            UpdateTreeNodeNames();
 
             _view.EnableTestFilter(true);
 
@@ -186,6 +187,7 @@ namespace TestCentric.Gui.Presenters
         private void AddTestToGroups(TestGroup testGroup, TestNode testNode)
         {
             testGroup.Add(testNode);
+            UpdateTreeNodeName(testGroup.TreeNode);
             TestGroup parentGroup = testGroup.ParentGroup;
             if (parentGroup != null)
                 AddTestToGroups(parentGroup, testNode);
@@ -194,6 +196,7 @@ namespace TestCentric.Gui.Presenters
         private void RemoveTestFromGroups(TestGroup testGroup, TestNode testNode)
         {
             testGroup.TestNodes.RemoveId(testNode.Id);
+            UpdateTreeNodeName(testGroup.TreeNode);
             TestGroup parentGroup = testGroup.ParentGroup;
             if (parentGroup != null)
                 RemoveTestFromGroups(parentGroup, testNode);

--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestResultCounts.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestResultCounts.cs
@@ -74,7 +74,7 @@ namespace TestCentric.Gui.Presenters
             ResultNode result = model.TestResultManager.GetResultForTest(testNode.Id);
 
             // Only consider outcome from test cases; and check if testNode is filtered out
-            if (!testNode.IsProject && !testNode.IsSuite && !testNode.IsAssembly && testNode.IsVisible)
+            if (!testNode.IsProject && !testNode.IsSuite && !testNode.IsAssembly && testNode.FilteredOut)
             {
                 if (result != null)
                 {

--- a/src/GuiRunner/TestModel.Tests/Filter/TestCentricTestFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/Filter/TestCentricTestFilterTests.cs
@@ -204,7 +204,7 @@ namespace TestCentric.Gui.Model.Filter
             foreach (string testId in expectedVisibleNodes)
             {
                 TestNode node = GetTestNode(testNode, testId);
-                Assert.That(node.IsVisible, Is.True);
+                Assert.That(node.FilteredOut, Is.True);
             }
         }
 
@@ -253,7 +253,7 @@ namespace TestCentric.Gui.Model.Filter
             foreach (string testId in expectedVisibleNodes)
             {
                 TestNode node = GetTestNode(testNode, testId);
-                Assert.That(node.IsVisible, Is.True);
+                Assert.That(node.FilteredOut, Is.True);
             }
         }
 
@@ -302,7 +302,7 @@ namespace TestCentric.Gui.Model.Filter
             foreach (string testId in expectedVisibleNodes)
             {
                 TestNode node = GetTestNode(testNode, testId);
-                Assert.That(node.IsVisible, Is.True);
+                Assert.That(node.FilteredOut, Is.True);
             }
         }
 
@@ -353,7 +353,7 @@ namespace TestCentric.Gui.Model.Filter
             foreach (TestNode node in nodes)
             {
                 bool expectedIsVisible = expectedVisibleNodes.Contains(node.Id);
-                Assert.That(node.IsVisible, Is.EqualTo(expectedIsVisible));
+                Assert.That(node.FilteredOut, Is.EqualTo(expectedIsVisible));
             }
         }
 
@@ -405,7 +405,7 @@ namespace TestCentric.Gui.Model.Filter
             foreach (string testId in expectedVisibleNodes)
             {
                 TestNode node = GetTestNode(testNode, testId);
-                Assert.That(node.IsVisible, Is.True);
+                Assert.That(node.FilteredOut, Is.True);
             }
         }
 
@@ -497,7 +497,7 @@ namespace TestCentric.Gui.Model.Filter
 
         private void AssertTestNodeIsInvisible(TestNode testNode)
         {
-            Assert.That(testNode.IsVisible, Is.False, $"TestNode {testNode.Id} is not invisible.");
+            Assert.That(testNode.FilteredOut, Is.False, $"TestNode {testNode.Id} is not invisible.");
             foreach (TestNode child in testNode.Children)
                 AssertTestNodeIsInvisible(child);
         }

--- a/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
+++ b/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
@@ -94,8 +94,8 @@ namespace TestCentric.Gui.Model.Filter
 
             // 2. Check if node itself is visible
             bool isVisible = _filters.All(f => f.IsMatching(testNode));
-            testNode.IsVisible = isVisible || childIsVisible;
-            return testNode.IsVisible;
+            testNode.FilteredOut = isVisible || childIsVisible;
+            return testNode.FilteredOut;
         }
 
         private IEnumerable<string> GetFilterCondition(string filterId)

--- a/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
+++ b/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
@@ -138,7 +138,7 @@ namespace TestCentric.Gui.Model.Filter
         private void GetAllTestcaseNodes(TestNode testNode, IList<TestNode> result)
         {
             // Only consider Visible nodes (e.g. nodes not filtered out by the UI filter)
-            if (!testNode.IsVisible)
+            if (!testNode.FilteredOut)
                 return;
 
             // Ignore explicit tests except those which were selected by the user actively 

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -33,7 +33,7 @@ namespace TestCentric.Gui.Model
 
         public TestNode(XmlNode xmlNode)
         {
-            IsVisible = true;
+            FilteredOut = true;
             Xml = xmlNode;
 
             // It's a quirk of the test engine that the test-run element does;
@@ -75,9 +75,11 @@ namespace TestCentric.Gui.Model
 
 
         /// <summary>
-        /// Controls if the TestNode should be visible or hidden in the TestTree
+        /// This property is set when applying a filter to the test tree (for example outcome filter)
+        /// It's used to control if TestNodes should be visible or hidden in the TestTree
         /// </summary>
-        public bool IsVisible { get; set; }
+        public bool FilteredOut { get; set; }
+
         public int TestCount => IsSuite ? GetAttribute("testcasecount", 0) : 1;
         public RunState RunState => GetRunState();
 


### PR DESCRIPTION
Work has continued to keep me very busy, so I haven't managed to carry on working in time. It wasn’t actually that complicated, as there were already methods available for updating a TreeNode or a tree of TreeNodes.

For the TestList view we need to update the tree node names:

- Once after the entire tree has been build up. So, that the number of tests within all TestGroups is finalized and we use the correct numbers.
- On TestFinished event and some regrouping has taken place. All tree nodes which previously contained the test case must be updated (count has decreased) and all tree nodes which newly got the test cases must be updated as well (count has increased).

For the NUnit view the number won't change during a run and can be applied when building up the tree. However, I cannot use the `TestNode.TestCount` property because some parts of the tree might be filtered out (for example outcome filter). So, I added a method to determine the number of test cases. One idea might be to move this method to the TestNode class or even replace the existing `TestCount` property.

It’s already working well, but I wasn’t entirely satisfied with the result. In particular, with generic fixtures, the tree node name contains two items in brackets - I think that makes the meaning unclear. Here's a screenshot.

<img width="350" src="https://github.com/user-attachments/assets/2508b46b-a614-4ad8-909a-d2573e5a22be" />

That is why I suggest we add a brief explanation (‘test or tests’). Here's also a screenshot:

<img width="350" src="https://github.com/user-attachments/assets/61094143-3340-42e9-99a9-a35b89f40458" />

(Fixes #1545)