### PR TITLE
Tree node icons - ignore test case nodes without any test run result

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -345,12 +345,14 @@ namespace TestCentric.Gui.Presenters
             {
                 ResultNode resultNode = GetResultForTest(testNode);
                 if (resultNode != null)
+                {
                     treeNode.ImageIndex = treeNode.SelectedImageIndex = CalcImageIndex(resultNode);
 
-                // NOTE: the loop only executes at the point in the hierarchy where the current
-                // TreeNode represents a TestNode and the parent is a TestGroup;
-                for (var parent = treeNode.Parent; parent?.Tag is TestGroup; parent = parent.Parent)
-                    parent.ImageIndex = parent.SelectedImageIndex = Math.Max(parent.ImageIndex, treeNode.ImageIndex);
+                    // NOTE: the loop only executes at the point in the hierarchy where the current
+                    // TreeNode represents a TestNode and the parent is a TestGroup;
+                    for (var parent = treeNode.Parent; parent?.Tag is TestGroup; parent = parent.Parent)
+                        parent.ImageIndex = parent.SelectedImageIndex = Math.Max(parent.ImageIndex, treeNode.ImageIndex);
+                }
             }
 
             foreach (TreeNode childNode in treeNode.Nodes)
@@ -397,6 +399,11 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         private int GetRunningImageIndex(TreeNode treeNode)
         {
+            // Testcase tree nodes might get an ImageIndex by default without any test run: Ignored or NotRunnable for example
+            // Such kind of nodes should not add their ImageIndex to the calculation of the "running" image index.
+            if (treeNode.Tag is TestNode { IsSuite: false } testNode && _model.TestResultManager.GetResultForTest(testNode.Id) == null)
+                return TestTreeView.RunningIndex;
+
             switch (treeNode.ImageIndex)
             {
                 case TestTreeView.SuccessIndex:


### PR DESCRIPTION
This issue is caused by certain TreeNodes which get an ImageIndex by default when loading the test assembly. For example, Ignored test cases will get a dedicated ImageIndex and also NotRunnable nodes. This should help the user to quickly identify such kind of tests without even starting a test run.
However, in the NUnit view such kind of nodes doesn't contribute to the overall test result of any parent nodes as long as they were never executed.

We recently added that we calculate the icon of a TreeNode based on the ImageIndices of his child TreeNodes. This calculation considers only the WinForm TreeNodes hierarchy and ImageIndex values, but doesn't consider if an ImageIndex was set by default without any test run. As a result, these default ImageIndices were propagated to the parent nodes, leading to an inconsistent behavior compared with the NUnit view. This happens when calculating the 'running image index' and also when switching between NUnit and list view.

I fixed this by checking if any test result is present for a TestNode. If no test result is present, the node is ignored for the calculation. (Fixes #1536)