### PR TITLE
Issue 1500

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -127,10 +127,7 @@ namespace TestCentric.Gui.Presenters
                 int imageIndex = CalcImageIndex(result);
 
                 foreach (TreeNode treeNode in GetTreeNodesForTest(result))
-                {
-                    UpdateTreeNodeName(treeNode);
                     _view.SetImageIndex(treeNode, imageIndex, true);
-                }
             });
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -339,18 +339,17 @@ namespace TestCentric.Gui.Presenters
 
         private void ApplyResultsToTree(TreeNode treeNode)
         {
-            TestNode testNode = treeNode.Tag as TestNode;
-
-            if (testNode != null)
+            // Consider only treeNodes representing a test case. Test results from fixtures/assemblies might be inaccurate
+            // if some filters are applied (e.g. outcome filter) and some test case nodes are currently not displayed in the tree.
+            if (treeNode.Tag is TestNode testNode && !testNode.IsSuite)
             {
                 ResultNode resultNode = GetResultForTest(testNode);
                 if (resultNode != null)
                 {
                     treeNode.ImageIndex = treeNode.SelectedImageIndex = CalcImageIndex(resultNode);
 
-                    // NOTE: the loop only executes at the point in the hierarchy where the current
-                    // TreeNode represents a TestNode and the parent is a TestGroup;
-                    for (var parent = treeNode.Parent; parent?.Tag is TestGroup; parent = parent.Parent)
+                    // Calculate the ImageIndex of the parent hierarchy 
+                    for (var parent = treeNode.Parent; parent?.Tag is ITestItem; parent = parent.Parent)
                         parent.ImageIndex = parent.SelectedImageIndex = Math.Max(parent.ImageIndex, treeNode.ImageIndex);
                 }
             }


### PR DESCRIPTION
This PR fixes #1500. The filtering in general was already available, the remaining part was to update the tree icons based on the active filter.

Actually this worked already as expected for the TestList view and I just took care that the approach is applicable for the NUnit view as well. The relevant code is located in one single method DisplayStrategy.ApplyResultsToTree(): this method is called when the tree is build up (Project loaded, switch between TestList/Nunit view, but also when applying a filter). 

Only the leaf nodes (e.g. test case nodes) are associated with TestNodes in the TestList view (all other tree nodes are associated with TestGroups). If such a leaf node has a test result, it's applied to the node and afterwards the ImageIndex of all nodes in the parent hierarchy is calculated.

That's the existing approach for the TestList view. I adapted the code slightly, so that it's now a approach working for TestList and NUnit view. 

The 2nd commit is a bit off topic:
I noticed some kind of flickering when executing tests. It turns out that it's caused by the call `UpdateTreeNodeName` in  `OnTestFinished()` - we already noticed it sometime back that WinForms tree is suffering if we update a node's name too often.  Even if we're not changing anything at all, but just set the identical name anew. So, I first added a check that the name really changed at all. But finally dropped the entire call because the names kept constant here.