### PR TITLE
Enable test duration features (show and sort) for TestList view

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/TestListDisplayStrategy.cs
@@ -63,7 +63,12 @@ namespace TestCentric.Gui.Presenters
             visualState?.ApplyTo(_view.TreeView);
 
             ApplyResultsToTree();
+            SetTestDurationOfGroups();
             UpdateTreeNodeNames();
+
+            // TestGroup duration is only available after entire tree is build up => sort tree now
+            if (_view.SortCommand.SelectedItem == TreeViewNodeComparer.Duration)
+                _view.Sort();
 
             _view.EnableTestFilter(true);
 
@@ -182,6 +187,36 @@ namespace TestCentric.Gui.Presenters
                 newParent.Text = GroupDisplayName(newGroup);
                 ExpandNewParentNodes(newParent);
             });
+        }
+
+        public override void OnTestRunFinished()
+        {
+            SetTestDurationOfGroups();
+            base.OnTestRunFinished();
+        }
+
+        private void SetTestDurationOfGroups()
+        {
+            foreach (var node in _treeView.Nodes)
+                SetTestDurationOfGroups(node as TreeNode);
+        }
+
+        private double SetTestDurationOfGroups(TreeNode treeNode)
+        {
+            if (treeNode.Tag is TestGroup testGroup)
+            {
+                // Duration of a Testgroup is sum of all child TreeNode durations 
+                testGroup.Duration = treeNode.Nodes.OfType<TreeNode>().Select(SetTestDurationOfGroups).Sum();
+                return testGroup.Duration.Value;
+            }
+            else if (treeNode.Tag is TestNode testNode)
+            {
+                // Duration of a TestNode is determined by the NUnit result
+                ResultNode result = _model.TestResultManager.GetResultForTest(testNode.Id);
+                return result != null ? result.Duration : 0;
+            }
+
+            return 0;
         }
 
         private void AddTestToGroups(TestGroup testGroup, TestNode testNode)


### PR DESCRIPTION
This PR fixes #1460 by enabling test duration features (show duration and sort by duration) also for the TestList view.

Actually we started a discussion in the issue whether we want to support test duration at all in the TestList view, but we haven't made (or wrote down) a final decision yet. We should continue this discussion, but as you can probably guess, I'm in favor to support it, if I'm already coming in with a PR. 😄 

Overall, I think the test duration is just as helpful in the TestList view as in the NUnit view. Regardless if it's the simple list view or if it's the duration grouping, showing the test duration or even sorting by duration gives a quick feedback which test cases run the slowest of all. So, after identifying the relevant tests quickly, the user can take care about these tests and try to optimize them.

From a technical point of view, the challenge is, of course, that we don’t have a test duration for TestGroups out-of-the-box. I try to solve it identically as we did with test results lately: iterate through all child tree nodes and sum up their test duration. That means that only leaf nodes (test case nodes) contribute with their test duration. The test duration of fixture or assembly nodes are not considered at all. I'm aware that the resulting number if not 100% accurate or identical to the NUnit view: for example if a [Setup] method contributes to the test duration of a fixture, it's considered and displayed in the NUnit view. But that number is completely ignored in the proposed approach for the TestList view. Nonetheless I think that the proposed approach will be helpful to identify the slowest test cases.

The test durations for TestGroups are calculated only at the end of a TestRun and when loading the tree.

