### PR TITLE
Align progress bar width to window size

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.Designer.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.Designer.cs
@@ -653,7 +653,7 @@ namespace TestCentric.Gui.Views
             this.progressBar.Location = new System.Drawing.Point(0, 2);
             this.progressBar.Name = "progressBar";
             this.progressBar.Progress = 0;
-            this.progressBar.Size = new System.Drawing.Size(996, 24);
+            this.progressBar.Size = new System.Drawing.Size(498, 24);
             this.progressBar.Status = TestCentric.Gui.Views.ProgressBarStatus.Success;
             this.progressBar.TabIndex = 3;
             // 


### PR DESCRIPTION
I simply restored the width of the progress bar which were present sometime back. This value is aligned to the size of the window and other controls. Now, the text in the progress bar is centered again.
<img width="600" src="https://github.com/user-attachments/assets/1373f4bd-d5f0-4777-967b-2f83a148671f" />

I assume that the width was accidently changed in commit 
https://github.com/TestCentric/TestCentric-Gui/commit/93f7fdb1a180f41bbe79ba40744e5bbace5c7742

This PR fixes #1558.