### PR TITLE
Remove outdated NSubstitute statements

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -48,7 +48,7 @@
     <!-- Default versions for targets not listed above -->
 	<PropertyGroup>
 		<NUnitVersion Condition="'$(NUnitVersion)'==''">4.4.0</NUnitVersion>
-		<NSubstituteVersion Condition="'$(NSubstituteVersion)'==''">5.3.0</NSubstituteVersion>
+		<NSubstituteVersion Condition="'$(NSubstituteVersion)'==''">6.0.0</NSubstituteVersion>
 		<NUnitEngineVersion Condition="'$(NUnitEngineVersion)'==''">4.0.0-beta.2.3</NUnitEngineVersion>
 	</PropertyGroup>
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -341,7 +341,7 @@ namespace TestCentric.Gui.Presenters
         {
             // NOTE: We only verify that something was sent, not the content
             if (shouldDisplay)
-                _view.Received().AddResult(Arg.Compat.Any<string>(), Arg.Compat.Any<string>(), Arg.Compat.Any<string>(), Arg.Compat.Any<string>());
+                _view.Received().AddResult(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
             else
                 _view.DidNotReceiveWithAnyArgs().AddResult(null, null, null, null);
         }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -55,8 +55,8 @@ namespace TestCentric.Gui.Presenters.TestTree
                 null);
 
             _view.Received().Clear();
-            _view.Received().Add(Arg.Compat.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "42"));
-            _view.Received().Add(Arg.Compat.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "99"));
+            _view.Received().Add(Arg.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "42"));
+            _view.Received().Add(Arg.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "99"));
         }
 
         [Test]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -534,7 +534,7 @@ namespace TestCentric.Gui.Presenters.TestTree
 
         //    _view.RunCommand.Execute += Raise.Event<CommandHandler>();
 
-        //    _model.Received().RunTests(Arg.Compat.Is<TestSelection>((sel) => sel.Count == 2 && sel[0].Id == "DUMMY-1" && sel[1].Id == "DUMMY-2"));
+        //    _model.Received().RunTests(Arg.Is<TestSelection>((sel) => sel.Count == 2 && sel[0].Id == "DUMMY-1" && sel[1].Id == "DUMMY-2"));
         //}
 
 
@@ -563,7 +563,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         //    TestNode testNode = new TestNode(XmlHelper.CreateXmlNode("<test-run id='1'><test-suite id='42'/></test-run>"));
         //    _model.Tests.Returns(testNode);
 
-        //    _view.Tree.Received().Add(Arg.Compat.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
+        //    _view.Tree.Received().Add(Arg.Is<TreeNode>((tn) => ((TestNode)tn.Tag).Id == "42"));
         //}
 
         //[Test, Combinatorial]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -63,7 +63,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -54,7 +54,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             FireRunFinishedEvent(new ResultNode("<test-run id='1' result='Passed' />"));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, false);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -243,7 +243,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         //    _model.TestFiles.Returns(new List<string>(new[] { "test.dll", "another.dll" }));
         //    FireTestLoadedEvent(testNode);
 
-        //    _view.Tree.Received().Load(Arg.Compat.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
+        //    _view.Tree.Received().Load(Arg.Is<TreeNode>((tn) => tn.Text == "TestRun" && tn.Nodes.Count == 2));
         //}
 
         // TODO: Version 1 Test - Make it work if needed.
@@ -255,7 +255,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         //    _model.TestFiles.Returns(new List<string>(new[] { "test.dll" }));
         //    FireTestLoadedEvent(testNode);
 
-        //    _view.Tree.Received().Load(Arg.Compat.Is<TreeNode>(tn => tn.Text == "another.dll"));
+        //    _view.Tree.Received().Load(Arg.Is<TreeNode>(tn => tn.Text == "another.dll"));
         //}
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
@@ -392,7 +392,7 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         private void VerifyNothingWasWritten()
         {
-            _view.DidNotReceiveWithAnyArgs().Write(Arg.Compat.Any<string>(), Arg.Compat.Any<Color>());
+            _view.DidNotReceiveWithAnyArgs().Write(Arg.Any<string>(), Arg.Any<Color>());
         }
 
         /// <summary>


### PR DESCRIPTION
I actually wanted to make this commit to the corresponding Dependabot branch, but it didn't work out.
But it's not a big deal: I can make the preparation for NSubstitute 6.0 in advance. It's all about replacing the outdated statement
`Arg.Compat.Any<>` with the general `Arg.Any<>` statement.