### PR TITLE
Upgrade NSubstitute 5.3.0 => 6.0.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -48,7 +48,7 @@
     <!-- Default versions for targets not listed above -->
 	<PropertyGroup>
 		<NUnitVersion Condition="'$(NUnitVersion)'==''">4.4.0</NUnitVersion>
-		<NSubstituteVersion Condition="'$(NSubstituteVersion)'==''">5.3.0</NSubstituteVersion>
+		<NSubstituteVersion Condition="'$(NSubstituteVersion)'==''">6.0.0</NSubstituteVersion>
 		<NUnitEngineVersion Condition="'$(NUnitEngineVersion)'==''">4.0.0-beta.2.3</NUnitEngineVersion>
 	</PropertyGroup>
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -341,7 +341,7 @@ namespace TestCentric.Gui.Presenters
         {
             // NOTE: We only verify that something was sent, not the content
             if (shouldDisplay)
-                _view.Received().AddResult(Arg.Compat.Any<string>(), Arg.Compat.Any<string>(), Arg.Compat.Any<string>(), Arg.Compat.Any<string>());
+                _view.Received().AddResult(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
             else
                 _view.DidNotReceiveWithAnyArgs().AddResult(null, null, null, null);
         }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -55,8 +55,8 @@ namespace TestCentric.Gui.Presenters.TestTree
                 null);
 
             _view.Received().Clear();
-            _view.Received().Add(Arg.Compat.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "42"));
-            _view.Received().Add(Arg.Compat.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "99"));
+            _view.Received().Add(Arg.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "42"));
+            _view.Received().Add(Arg.Is<TreeNode>((tn) => (tn.Tag as TestNode).Id == "99"));
         }
 
         [Test]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -63,7 +63,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -54,7 +54,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             FireRunFinishedEvent(new ResultNode("<test-run id='1' result='Passed' />"));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, false);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Compat.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
@@ -392,7 +392,7 @@ namespace TestCentric.Gui.Presenters
         /// </summary>
         private void VerifyNothingWasWritten()
         {
-            _view.DidNotReceiveWithAnyArgs().Write(Arg.Compat.Any<string>(), Arg.Compat.Any<Color>());
+            _view.DidNotReceiveWithAnyArgs().Write(Arg.Any<string>(), Arg.Any<Color>());
         }
 
         /// <summary>


### PR DESCRIPTION
Luckily, it worked this time 😄 
Even though I definitely didn't choose the smartest way to upgrade to NSubstitute 6.0.0
Only a few minor adjustments were needed in the test code, which I actually intended to apply to the DependABot branch. However, I managed to push to a separate branch first, close the DependABot branch next while sending a '@dependabot rebase' command (probably because I created a PR in advance) and finally got pipeline errors in my branch. 😟 

Finally, I solved all of this by applying these changes to a new and up-to-date branch.
Next time, I'll get it right the first time