### PR TITLE
Disable user defined font selection

### DIFF
--- a/src/GuiRunner/TestCentric.Gui/TestCentric.Gui.csproj
+++ b/src/GuiRunner/TestCentric.Gui/TestCentric.Gui.csproj
@@ -11,11 +11,11 @@
     </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);DISABLE_MINI_GUI</DefineConstants>
+	  <DefineConstants>$(DefineConstants);DISABLE_MINI_GUI;DISABLE_FONT_SETTING</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);DISABLE_MINI_GUI;USE_TIPWINDOW</DefineConstants>
+	  <DefineConstants>$(DefineConstants);DISABLE_MINI_GUI;USE_TIPWINDOW;DISABLE_FONT_SETTING</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestCentricMainView.cs
@@ -60,8 +60,16 @@ namespace TestCentric.Gui.Views
             DecreaseFixedFontCommand = new CommandMenuElement(decreaseFixedFontMenuItem);
             RestoreFixedFontCommand = new CommandMenuElement(restoreFixedFontMenuItem);
 
+#if DISABLE_FONT_SETTING
+            guiFontMenuItem.Visible = fixedFontMenuItem.Visible = false;
+#endif
+
 #if DISABLE_MINI_GUI
             miniGuiMenuItem.Visible = fullGuiMenuItem.Visible = toolStripSeparator8.Visible = false;
+#endif
+
+#if DISABLE_FONT_SETTING && DISABLE_MINI_GUI
+            viewMenu.Visible = false;
 #endif
 
             // Initialize Tools Menu Comands


### PR DESCRIPTION
This PR contributes to #1487 by disabling the menu items to select a user defined font for the UI.
I decided to take a soft approach by introducing a compiler constant (DISABLE_FONT_SETTING), similar to what we did with MiniGui. This means that all the FontSetting code is still there, and I haven't removed it yet. The compiler constant controls the visibility of the corresponding menu items.

All of this assumes that we still do not want to support individual font settings. However, the user can still use the general Windows setting 'scaling' to adapt the font size to his display.