### PR TITLE
Improve test run performance for NUnit tree display

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -63,7 +63,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.Events.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(testNode));
             _model.Events.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(resultNode));
 
-            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, true);
+            _view.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex, false);
         }
     }
 }

--- a/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
+++ b/src/GuiRunner/TestCentric.Gui/Presenters/DisplayStrategy.cs
@@ -126,8 +126,9 @@ namespace TestCentric.Gui.Presenters
             {
                 int imageIndex = CalcImageIndex(result);
 
+                bool updateParentNodes = this.StrategyID == "TEST_LIST";
                 foreach (TreeNode treeNode in GetTreeNodesForTest(result))
-                    _view.SetImageIndex(treeNode, imageIndex, true);
+                    _view.SetImageIndex(treeNode, imageIndex, updateParentNodes);
             });
         }
 

--- a/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/TestTreeView.cs
@@ -326,6 +326,10 @@ namespace TestCentric.Gui.Views
 
         public void SetImageIndex(TreeNode treeNode, int imageIndex, bool applyToParents = false) 
         {
+            // If imageIndex is already applied, avoid any flickering or performance delays
+            if (imageIndex == treeNode.ImageIndex && imageIndex == treeNode.SelectedImageIndex)
+                return;
+
             InvokeIfRequired(() => treeNode.ImageIndex = treeNode.SelectedImageIndex = imageIndex);
 
             if (applyToParents)


### PR DESCRIPTION
This PR resolves #1569 by adding two quick wins for the test run performance.
It turns out that all performance delay was caused by updating the tree nodes icons over and over again, We do this repeatedly when starting a test case (recently added 'running icon') and repeatedly when finishing a test case.

So, besides reducing the flickering, also the execution time drops:
from original 83s, to 53s by applying the first fix and finally to 18s by applying the 2nd fix. 😄 

The fix in method `TestTreeView.SetImageIndex()` probably needs no further explanation. I actually would have expected WinForms to have implemented this on its own.

The 2nd fix in method `DisplayStrategy.OnTestFinished()` is specific to the NUnit tree display. I recall that we needed to set the applyToParent to true for the Test list display, to update the top most grouping nodes and also to update the running icons. But for the NUnit tree display this parameter can be set to false. And as a result, far fewer TreeNode icons are updated, improving the performance further.
But I expect that this solution is not final. I assume when analyzing the Test list display performance we'll stumple over this issue again. Maybe we find a solution to set the parameter in general to false or find another approach.
But that's beyond my current idea of a 'quick win' and want to tackle the Test list performance on a separate issue.