### PR TITLE
Activate nullability checks for project TestCentric.Gui.Model

### DIFF
--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/CategoryGroupingTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/CategoryGroupingTests.cs
@@ -72,7 +72,7 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
             
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             var tests = new List<TestNode> { testNode };
 
             // 2. Act
@@ -92,7 +92,7 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var testNode = new TestNode($"<test-case id='1'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
             var tests = new List<TestNode> { testNode };
 
             // 2. Act
@@ -114,11 +114,11 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var testNode1 = new TestNode($"<test-case id='1'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
-            var testNode2 = new TestNode($"<test-case id='2'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
-            var testNode3 = new TestNode($"<test-case id='3'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
-            var testNode4 = new TestNode($"<test-case id='4'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
-            var testNode5 = new TestNode($"<test-case id='5'> </test-case>");
+            var testNode1 = new TestNode($"<test-case id='1' name='TestA'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var testNode2 = new TestNode($"<test-case id='2' name='TestB'> <properties> <property name='Category' value='Feature_1' /> </properties> </test-case>");
+            var testNode3 = new TestNode($"<test-case id='3' name='TestC'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
+            var testNode4 = new TestNode($"<test-case id='4' name='TestD'> <properties> <property name='Category' value='Feature_2' /> </properties> </test-case>");
+            var testNode5 = new TestNode($"<test-case id='5' name='TestE'> </test-case>");
             var tests = new List<TestNode> { testNode1, testNode2, testNode3, testNode4, testNode5 };
 
             // 2. Act
@@ -150,7 +150,7 @@ namespace TestCentric.Gui.Presenters
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
-            ResultNode result = new ResultNode("<test-case id='1'/>");
+            ResultNode result = new ResultNode("<test-case id='1' name='TestA'/>");
 
             // 2. Act
             CategoryGrouping grouping = new CategoryGrouping(strategy, false);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/DisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/DisplayStrategyTests.cs
@@ -24,7 +24,7 @@ namespace TestCentric.Gui.Presenters
         public void CalcImageIndex_ReturnsExpectedIndex(string result, bool isLatestRun, int expectedImageIndex)
         {
             // Arrange
-            var resultNode = new ResultNode($"<test-case id='1' result='{result}'/>");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' result='{result}'/>");
             resultNode.IsLatestRun = isLatestRun;
 
             // Act
@@ -39,7 +39,7 @@ namespace TestCentric.Gui.Presenters
         public void CalcImageIndex_IgnoreTest_ReturnsExpectedIndex(bool isLatestRun, int expectedImageIndex)
         {
             // Arrange
-            var resultNode = new ResultNode($"<test-case id='1' result='Skipped' label='Ignored' />");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' result='Skipped' label='Ignored' />");
             resultNode.IsLatestRun = isLatestRun;
 
             // Act

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/DurationGroupingTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/DurationGroupingTests.cs
@@ -73,9 +73,9 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var resultNode = new ResultNode($"<test-case id='1' duration='{duration}'/>");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' duration='{duration}'/>");
 
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             var tests = new List<TestNode> { testNode };
 
             model.TestResultManager.GetResultForTest("1").Returns(resultNode);
@@ -97,7 +97,7 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             var tests = new List<TestNode> { testNode };
 
             model.TestResultManager.GetResultForTest("1").Returns((ResultNode)null);
@@ -118,7 +118,7 @@ namespace TestCentric.Gui.Presenters
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
-            ResultNode result = new ResultNode("<test-case id='1'/>");
+            ResultNode result = new ResultNode("<test-case id='1' name='TestA'/>");
 
             // 2. Act
             DurationGrouping grouping = new DurationGrouping(strategy);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -16,7 +16,7 @@ namespace TestCentric.Gui.Presenters
 
     public class ErrorsAndFailuresPresenterTests : PresenterTestBase<IErrorsAndFailuresView>
     {
-        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-suite id='1' testcasecount='1234' name='TestRun'/>");
+        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-run id='1' testcasecount='1234'/>");
         ITestResultSubViewPresenter _testResultPresenter;
 
         [SetUp]

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ErrorsAndFailuresPresenterTests.cs
@@ -16,7 +16,7 @@ namespace TestCentric.Gui.Presenters
 
     public class ErrorsAndFailuresPresenterTests : PresenterTestBase<IErrorsAndFailuresView>
     {
-        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-suite id='1' testcasecount='1234' />");
+        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-suite id='1' testcasecount='1234' name='TestRun'/>");
         ITestResultSubViewPresenter _testResultPresenter;
 
         [SetUp]
@@ -67,6 +67,9 @@ namespace TestCentric.Gui.Presenters
         [TestCase("Inconclusive", FailureSite.Test, false)]
         public void WhenTestCaseFinishes_FailuresAndErrorsAreDisplayed(string resultState, FailureSite site, bool shouldDisplay)
         {
+            var testNode = new TestNode("<test-case id='0' name='MyTest' />");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
             FireTestFinishedEvent("MyTest", resultState, site);
 
             VerifyDisplay(shouldDisplay);
@@ -91,6 +94,9 @@ namespace TestCentric.Gui.Presenters
         [TestCase("Inconclusive", FailureSite.Test, false)]
         public void WhenTestSuiteFinishes_FailuresAndErrorsAreDisplayed(string resultState, FailureSite site, bool shouldDisplay)
         {
+            var testNode = new TestNode("<test-case id='0' name='MyTest'  />");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
             FireSuiteFinishedEvent("MyTest", resultState, site, 1);
 
             VerifyDisplay(shouldDisplay);
@@ -100,6 +106,9 @@ namespace TestCentric.Gui.Presenters
         [TestCase(2, false)]
         public void WhenTestSuiteFinishes_WithFailures_TestCount_FailuresAndErrorsAreDisplayed(int testCount, bool shouldDisplay)
         {
+            var testNode = new TestNode("<test-case id='0' name='MyTest'  />");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
             FireSuiteFinishedEvent("MyTest", "Failed", FailureSite.Test, testCount);
 
             VerifyDisplay(shouldDisplay);
@@ -229,7 +238,7 @@ namespace TestCentric.Gui.Presenters
         public void WhenSelectedItemChanged_ToTestNode_TestResultSubView_IsUpdated()
         {
             TestNode testItem = FAKE_TEST_RUN;
-            var resultNode = new ResultNode($"<test-case id='1'/>");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA'/>");
             _model.TestResultManager.GetResultForTest("1").Returns(resultNode);
 
             _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testItem));
@@ -274,7 +283,10 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseFinishes_TestContainsOutput_OutputView_IsVisible()
         {
-            var resultNode = new ResultNode($"<test-case id='1'> <output>Hello world</output> </test-case>");
+            var testNode = new TestNode($"<test-case id='1' name='1'>  </test-case>");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
+            var resultNode = new ResultNode($"<test-case id='1' name='1'> <output>Hello world</output> </test-case>");
             FireTestFinishedEvent(resultNode);
 
             _view.TestOutputSubView.Received().SetVisibility(true);
@@ -283,7 +295,10 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseFinishes_TestContainsNoOutput_OutputView_IsHidden()
         {
-            var resultNode = new ResultNode($"<test-case id='1'>  </test-case>");
+            var testNode = new TestNode($"<test-case id='1' name='1'>  </test-case>");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
+            var resultNode = new ResultNode(testNode.Xml);
             FireTestFinishedEvent(resultNode);
 
             _view.TestOutputSubView.Received().SetVisibility(false);
@@ -292,7 +307,10 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseFinishes_TestContainsOutput_OutputView_ShowsOutput()
         {
-            var resultNode = new ResultNode($"<test-case id='1'> <output>Hello world</output> </test-case>");
+            var testNode = new TestNode($"<test-case id='1' name='1'>  </test-case>");
+            _model.Events.SelectedItemChanged += Raise.Event<TestItemEventHandler>(new TestItemEventArgs(testNode));
+
+            var resultNode = new ResultNode($"<test-case id='1' name='1'> <output>Hello world</output> </test-case>");
             FireTestFinishedEvent(resultNode);
 
             _view.TestOutputSubView.Received().Output = "Hello world";

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestFilterData.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Filter/TestFilterData.cs
@@ -124,7 +124,7 @@ namespace TestCentric.Gui.Presenters.Filter
 
         private static string CreateTestRunXml(params string[] testSuites)
         {
-            string str = $"<test-run type='TestRun'> ";
+            string str = $"<test-run type='TestRun' id='0' name='TestRun'> ";
             foreach (string testSuite in testSuites)
                 str += testSuite;
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/CommandTests.cs
@@ -449,7 +449,7 @@ namespace TestCentric.Gui.Presenters.Main
         {
             // Arrange
             _model.HasTests.Returns(true);
-            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' />") }));
+            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' name='TestA'/>") }));
 
             // Act
             _model.Events.SelectedTestsChanged += Raise.Event<TestSelectionEventHandler>(new TestSelectionEventArgs(null));

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -22,7 +22,7 @@ namespace TestCentric.Gui.Presenters.Main
             _model.HasResults.Returns(true);
             _model.ResultSummary.Returns(new ResultSummary() { FailureCount = 1 });
             _model.IsTestRunning.Returns(false);
-            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' />") }));
+            _model.SelectedTests.Returns(new TestSelection(new[] { new TestNode("<test-case id='1' name='TestA'/>") }));
             _view.ResultTabs.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
 
             var resultNode = new ResultNode("<test-run id='XXX' result='Failed' />");

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -21,7 +21,7 @@ namespace TestCentric.Gui.Presenters.Main
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            TestNode testNode = new TestNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
             _model.LoadedTests.Returns(testNode);
             _model.SelectedTests.Returns(new TestSelection(new[] { testNode }));
             _view.ResultTabs.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -20,7 +20,7 @@ namespace TestCentric.Gui.Presenters.Main
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            TestNode testNode = new TestNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
             _model.LoadedTests.Returns(testNode);
             _model.SelectedTests.Returns(new TestSelection(new[] { testNode }));
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/NUnitTreeDisplayStrategyTests.cs
@@ -116,7 +116,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             // Arrange
             _model.TreeConfiguration.NUnitTreeShowNamespaces = false;
             string xml =
-                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                "<test-run id='0'> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
                     "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
                     "</test-suite>" +
                 "</test-suite> </test-run>";
@@ -135,7 +135,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             // Arrange
             _model.TreeConfiguration.NUnitTreeShowAssemblies = false;
             string xml =
-                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                "<test-run id='0'> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
                     "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
                     "</test-suite>" +
                 "</test-suite> </test-run>";
@@ -155,7 +155,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _model.TreeConfiguration.NUnitTreeShowFixtures = false;
 
             string xml =
-                "<test-run> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
+                "<test-run id='0'> <test-suite type='Assembly' id='1-1030' name='Library.Test.dll'>" +
                     "<test-suite type='TestSuite' id='1-1031' name='Library'>" +
                         "<test-suite type='TestFixture' id='1-1032' name='FixtureA'/>" +
                         "<test-suite type='TestFixture' id='1-1033' name='FixtureB'/>" +

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/OutcomeGroupingTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/OutcomeGroupingTests.cs
@@ -74,9 +74,9 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var resultNode = new ResultNode($"<test-case id='1' result='{resultState}' label='{outcomeLabel}'/>");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' result='{resultState}' label='{outcomeLabel}'/>");
 
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             var tests = new List<TestNode> { testNode };
 
             model.TestResultManager.GetResultForTest("1").Returns(resultNode);
@@ -132,7 +132,7 @@ namespace TestCentric.Gui.Presenters
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
 
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             var tests = new List<TestNode> { testNode };
 
             model.TestResultManager.GetResultForTest("1").Returns((ResultNode)null);
@@ -153,7 +153,7 @@ namespace TestCentric.Gui.Presenters
             ITestTreeView treeView = Substitute.For<ITestTreeView>();
             ITestModel model = Substitute.For<ITestModel>();
             GroupDisplayStrategy strategy = Substitute.For<GroupDisplayStrategy>(treeView, model);
-            ResultNode result = new ResultNode("<test-case id='1'/>");
+            ResultNode result = new ResultNode("<test-case id='1' name='TestA'/>");
 
             // 2. Act
             OutcomeGrouping grouping = new OutcomeGrouping(strategy);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/PresenterTestBase.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/PresenterTestBase.cs
@@ -187,11 +187,11 @@ namespace TestCentric.Gui.Presenters
             {
                 string status = result.Substring(0, colon);
                 string label = result.Substring(colon + 1);
-                xml = $"<{element} fullname='{testName}' result='{status}' label='{label}'/>";
+                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' result='{status}' label='{label}'/>";
             }
             else
             {
-                xml = $"<{element} fullname='{testName}' result='{result}'/>";
+                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' result='{result}'/>";
             }
 
             var xmlNode = XmlHelper.CreateXmlNode(xml);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/PresenterTestBase.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/PresenterTestBase.cs
@@ -116,13 +116,13 @@ namespace TestCentric.Gui.Presenters
 
         protected void FireTestStartingEvent(string testName)
         {
-            var start = new TestNode($"<test-start fullname='{testName}'/>");
+            var start = new TestNode($"<test-start fullname='{testName}' name='TestA' id='0'/>");
             _model.Events.TestStarting += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(start));
         }
 
         protected void FireSuiteStartingEvent(string testName)
         {
-            var start = new TestNode($"<suite-start fullname='{testName}'/>");
+            var start = new TestNode($"<suite-start id='0' name='{testName}' fullname='{testName}'/>");
             _model.Events.SuiteStarting += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(start));
         }
 
@@ -183,15 +183,17 @@ namespace TestCentric.Gui.Presenters
             int colon = result.IndexOf(':');
             string xml;
 
+            string nodeType = element == "test-case" ? "TestCase" : "TestFixture";
+
             if (colon > 0)
             {
                 string status = result.Substring(0, colon);
                 string label = result.Substring(colon + 1);
-                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' result='{status}' label='{label}'/>";
+                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' type='{nodeType}' result='{status}' label='{label}'/>";
             }
             else
             {
-                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' result='{result}'/>";
+                xml = $"<{element} id='0' name='{testName}' fullname='{testName}' type='{nodeType}' result='{result}'/>";
             }
 
             var xmlNode = XmlHelper.CreateXmlNode(xml);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ProgressBarPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/ProgressBarPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -22,7 +22,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestsAreLoaded_ProgressBar_IsInitialized()
         {
-            var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
+            var testNode = new TestNode("<test-suite id='1' testcasecount='1234' name='TestA' type='TestFixture'/>");
             FireTestLoadedEvent(testNode);
 
             _view.Received().Initialize(100);
@@ -39,7 +39,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestsAreReloaded_ProgressBar_IsInitialized()
         {
-            var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
+            var testNode = new TestNode("<test-suite id='1' testcasecount='1234' name='TestA' type='TestFixture'/>");
             FireTestReloadedEvent(testNode);
 
             _view.Received().Initialize(100);
@@ -56,7 +56,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseCompletes_ProgressIsIncremented()
         {
-            var result = new ResultNode("<test-case id='1'/>");
+            var result = new ResultNode("<test-case id='1' name='TestA'/>");
 
             FireTestFinishedEvent(result);
 
@@ -66,7 +66,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestSuiteCompletes_ProgressIsNotIncremented()
         {
-            var result = new ResultNode("<test-suite id='1'/>");
+            var result = new ResultNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
 
             FireSuiteFinishedEvent(result);
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/StatusBarPresenterTests.cs
@@ -65,7 +65,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCasePasses_CountIsIncremented()
         {
-            var result = new ResultNode("<test-case id='1' result='Passed' />");
+            var result = new ResultNode("<test-case id='1' name='TestA' result='Passed' />");
 
             for (int i = 1; i <= 3; i++)
                 FireTestFinishedEvent(result);
@@ -81,7 +81,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseHasWarning_CountIsIncremented()
         {
-            var result = new ResultNode("<test-case id='1' result='Warning' />");
+            var result = new ResultNode("<test-case id='1' name='TestA' result='Warning' />");
 
             for (int i = 1; i <= 3; i++)
                 FireTestFinishedEvent(result);
@@ -97,7 +97,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseIsInconclusive_CountIsIncremented()
         {
-            var result = new ResultNode("<test-case id='1' result='Inconclusive' />");
+            var result = new ResultNode("<test-case id='1' result='Inconclusive' name='TestA'/>");
 
             for (int i = 1; i <= 3; i++)
                 FireTestFinishedEvent(result);
@@ -113,7 +113,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestCaseFails_CountIsIncremented()
         {
-            var result = new ResultNode("<test-case id='1' result='Failed' />");
+            var result = new ResultNode("<test-case id='1' result='Failed' name='TestA'/>");
 
             for (int i = 1; i <= 3; i++)
                 FireTestFinishedEvent(result);
@@ -129,7 +129,7 @@ namespace TestCentric.Gui.Presenters
         [Test]
         public void WhenTestsFinish_DurationIsDisplayed()
         {
-            var result = new ResultNode("<test-run duration='1.234' />");
+            var result = new ResultNode("<test-run duration='1.234' id='0' name='TestA'/>");
             FireRunFinishedEvent(result);
 
             _view.Received().Text = "Completed";

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
@@ -164,7 +164,7 @@ namespace TestCentric.Gui.Presenters
 
             TestNode testNode = new TestNode(
                 "<test-suite type='TestFixture'> " +
-                    "<test-case  id='3-1000'> " +
+                    "<test-case  id='3-1000' name='testA'> " +
                         "<properties> " +
                             "<property name='Category' value='Category_1' /> " +
                             "<property name='Category' value='Category_2' /> " +
@@ -286,7 +286,7 @@ namespace TestCentric.Gui.Presenters
 
         private string CreateTestcaseXml(string testId, string category)
         {
-            string str = $"<test-case id='{testId}'> ";
+            string str = $"<test-case id='{testId}' name='{testId}' > ";
             if (!string.IsNullOrEmpty(category))
                 str += $"<properties> <property name='Category' value='{category}' /> </properties> ";
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestListDisplayStrategyTests.cs
@@ -77,8 +77,8 @@ namespace TestCentric.Gui.Presenters
             _model.TreeConfiguration.TestListGroupBy = "CATEGORY";
 
             TestNode testNode = new TestNode(
-                "<test-suite type='TestSuite'> " +
-                    "<test-suite type='TestFixture'>" +
+                "<test-suite id='0' type='TestSuite' name='Suite1'> " +
+                    "<test-suite id='1' type='TestFixture' name='Fixture1'>" +
                         CreateTestcaseXml("3-1000", categoryTestcase1) +
                         CreateTestcaseXml("3-1001", categoryTestcase2) +
                         CreateTestcaseXml("3-1002", categoryTestcase3) +
@@ -107,8 +107,8 @@ namespace TestCentric.Gui.Presenters
             // 1. Arrange
             _model.TreeConfiguration.TestListGroupBy = "CATEGORY";
 
-            string xmlText = "<test-suite type='TestSuite'> " + $"<properties> <property name='Category' value='{categoryTestFixture}' /> </properties> " +
-                                "<test-suite type='TestFixture'>" +
+            string xmlText = "<test-suite id='0' type='TestSuite' name='Suite1'> " + $"<properties> <property name='Category' value='{categoryTestFixture}' /> </properties> " +
+                                "<test-suite id='1' type='TestFixture' name='Fixture1'>" +
                                     CreateTestcaseXml("3-1000", categoryTestcase1) +
                                     CreateTestcaseXml("3-1001", categoryTestcase2) +
                                     CreateTestcaseXml("3-1002", categoryTestcase3) +
@@ -135,7 +135,7 @@ namespace TestCentric.Gui.Presenters
             _model.TreeConfiguration.TestListGroupBy = "CATEGORY";
 
             TestNode testNode = new TestNode(
-                        "<test-suite type='TestFixture' id='3-1000'> " +
+                        "<test-suite type='TestFixture' id='3-1000' name='Fixture1'> " +
                             "<properties> " +
                                 "<property name='Category' value='Category_1' /> " +
                                 "<property name='Category' value='Category_2' /> " +
@@ -163,7 +163,7 @@ namespace TestCentric.Gui.Presenters
             _model.TreeConfiguration.TestListGroupBy = "CATEGORY";
 
             TestNode testNode = new TestNode(
-                "<test-suite type='TestFixture'> " +
+                "<test-suite id='0' type='TestFixture' name='Fixture1'> " +
                     "<test-case  id='3-1000' name='testA'> " +
                         "<properties> " +
                             "<property name='Category' value='Category_1' /> " +
@@ -197,17 +197,17 @@ namespace TestCentric.Gui.Presenters
             _model.TreeConfiguration.TestListGroupBy = "DURATION";
 
             TestNode testNode = new TestNode(
-                "<test-suite type='TestSuite'> " +
-                    "<test-suite type='TestFixture'>" +
+                "<test-suite id='0' name='Suite1' type='TestSuite'> " +
+                    "<test-suite id='1' name='Fixture1' type='TestFixture'>" +
                         CreateTestcaseXml("3-1000", "") +
                         CreateTestcaseXml("3-1001", "") +
                         CreateTestcaseXml("3-1002", "") +
                     "</test-suite>" +
                 "</test-suite>");
 
-            _model.TestResultManager.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(duration1) ? null : new ResultNode($"<test-case id='3-1000' duration='{duration1}' />"));
-            _model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(duration2) ? null : new ResultNode($"<test-case id='3-1001' duration='{duration2}' />"));
-            _model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(duration3) ? null : new ResultNode($"<test-case id='3-1002' duration='{duration3}' />"));
+            _model.TestResultManager.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(duration1) ? null : new ResultNode($"<test-case id='3-1000' name='TestA' duration='{duration1}' />"));
+            _model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(duration2) ? null : new ResultNode($"<test-case id='3-1001' name='TestB' duration='{duration2}' />"));
+            _model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(duration3) ? null : new ResultNode($"<test-case id='3-1002' name='TestC' duration='{duration3}' />"));
 
             // 2. Act           
             TestListDisplayStrategy strategy = new TestListDisplayStrategy(_view, _model);
@@ -238,17 +238,17 @@ namespace TestCentric.Gui.Presenters
             _model.TreeConfiguration.TestListGroupBy = "OUTCOME";
 
             TestNode testNode = new TestNode(
-                "<test-suite type='TestSuite'> " +
-                    "<test-suite type='TestFixture'>" +
+                "<test-suite id='0' type='TestSuite' name='Suite1'> " +
+                    "<test-suite id='0' type='TestFixture' name='Fixture1'>" +
                         CreateTestcaseXml("3-1000", "") +
                         CreateTestcaseXml("3-1001", "") +
                         CreateTestcaseXml("3-1002", "") +
                     "</test-suite>" +
                 "</test-suite>");
 
-            _model.TestResultManager.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='3-1000' result='{resultState1}' />"));
-            _model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' result='{resultState2}' />"));
-            _model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' result='{resultState3}' />"));
+            _model.TestResultManager.GetResultForTest("3-1000").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='3-1000' name='TestA' result='{resultState1}' />"));
+            _model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' name='TestB' result='{resultState2}' />"));
+            _model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' name='TestC' result='{resultState3}' />"));
 
             // 2. Act           
             TestListDisplayStrategy strategy = new TestListDisplayStrategy(_view, _model);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestPropertiesPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestPropertiesPresenterTests.cs
@@ -39,7 +39,7 @@ namespace TestCentric.Gui.Presenters
         [TestCase("SomethingElse", "test.dll", "NotRunnable", ExpectedResult = "SomethingElse")]
         public string GetTestTypeTest(string type, string fullname, string runstate)
         {
-            TestNode testNode = new TestNode(XmlHelper.CreateXmlNode(string.Format("<test-suite id='1' type='{0}' fullname='{1}' runstate='{2}'><test-suite id='42'/></test-suite>", type, fullname, runstate)));
+            TestNode testNode = new TestNode(XmlHelper.CreateXmlNode(string.Format("<test-suite id='1' name='TestA' type='{0}' fullname='{1}' runstate='{2}'><test-suite id='42' name='TestB' type='TestFixture'/></test-suite>", type, fullname, runstate)));
 
             return TestPropertiesPresenter.GetTestType(testNode);
         }

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
@@ -21,8 +21,8 @@ namespace TestCentric.Gui.Presenters
         public void TestCaseNode_WithOutcome_ReturnsExpectedCount(string resultState, int expectedPassed, int expectedFailed, int expectedWarning, int expectedInconclusive)
         {
             // 1. Arrange
-            TestNode testNode = new TestNode("<test-case id='1' />");
-            ResultNode resultNode = new ResultNode($"<test-case id='1' result='{resultState}' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
+            ResultNode resultNode = new ResultNode($"<test-case id='1' name='TestA' result='{resultState}' />");
 
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns(resultNode);
@@ -48,8 +48,8 @@ namespace TestCentric.Gui.Presenters
         public void TestCaseNode_WithSkippedOutcome_ReturnsExpectedCount(string label, int expectedIgnore, int expectedExplicit)
         {
             // 1. Arrange
-            TestNode testNode = new TestNode("<test-case id='1' />");
-            ResultNode resultNode = new ResultNode($"<test-case id='1' result='Skipped' label='{label}' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
+            ResultNode resultNode = new ResultNode($"<test-case id='1' name='TestA' result='Skipped' label='{label}' />");
 
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns(resultNode);
@@ -73,7 +73,7 @@ namespace TestCentric.Gui.Presenters
         public void TestCaseNode_WithoutResult_ReturnsExpectedCount()
         {
             // 1. Arrange
-            TestNode testNode = new TestNode("<test-case id='1' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns((ResultNode)null);
 
@@ -96,7 +96,7 @@ namespace TestCentric.Gui.Presenters
         public void TestCaseNode_NotVisible_ReturnsExpectedCount()
         {
             // 1. Arrange
-            TestNode testNode = new TestNode("<test-case id='1' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
             testNode.FilteredOut = false;
             ITestModel model = Substitute.For<ITestModel>();
 
@@ -135,9 +135,9 @@ namespace TestCentric.Gui.Presenters
             "</test-suite>");
 
             ITestModel model = Substitute.For<ITestModel>();
-            model.TestResultManager.GetResultForTest("2-1001").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='2-1001' result='{resultState1}' />"));
-            model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' result='{resultState2}' />"));
-            model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' result='{resultState3}' />"));
+            model.TestResultManager.GetResultForTest("2-1001").Returns(string.IsNullOrEmpty(resultState1) ? null : new ResultNode($"<test-case id='2-1001' name='TestA' result='{resultState1}' />"));
+            model.TestResultManager.GetResultForTest("3-1001").Returns(string.IsNullOrEmpty(resultState2) ? null : new ResultNode($"<test-case id='3-1001' name='TestB' result='{resultState2}' />"));
+            model.TestResultManager.GetResultForTest("3-1002").Returns(string.IsNullOrEmpty(resultState3) ? null : new ResultNode($"<test-case id='3-1002' name='TestC' result='{resultState3}' />"));
 
             // 2. Act
             TestResultCounts resultCounts = TestResultCounts.GetResultCounts(model, testNode);
@@ -209,11 +209,11 @@ namespace TestCentric.Gui.Presenters
         public void TestGroupNode_WithOutcome_ReturnsExpectedCount()
         {
             // 1. Arrange
-            TestNode testNode1 = new TestNode("<test-case id='1' />");
-            ResultNode resultNode1 = new ResultNode($"<test-case id='1' result='Passed' asserts='2' duration='1.0'/>");
+            TestNode testNode1 = new TestNode("<test-case id='1' name='TestA'/>");
+            ResultNode resultNode1 = new ResultNode($"<test-case id='1' name='TestA' result='Passed' asserts='2' duration='1.0'/>");
 
-            TestNode testNode2 = new TestNode("<test-case id='2' />");
-            ResultNode resultNode2 = new ResultNode($"<test-case id='2' result='Failed' asserts='3' duration='1.0'/>");
+            TestNode testNode2 = new TestNode("<test-case id='2' name='TestB'/>");
+            ResultNode resultNode2 = new ResultNode($"<test-case id='2' name='TestB' result='Failed' asserts='3' duration='1.0'/>");
 
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns(resultNode1);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultCountsTests.cs
@@ -124,13 +124,13 @@ namespace TestCentric.Gui.Presenters
         {
             // 1. Arrange
             TestNode testNode = new TestNode(
-                "<test-suite type='TestSuite'> " +
-                    "<test-suite type='TestFixture' id='2-1000'> " +
-                        "<test-case id='2-1001' />" +
+                "<test-suite type='TestSuite' id='0' name='TestSuite'> " +
+                    "<test-suite type='TestFixture' id='2-1000'  name='FixtureA'> " +
+                        "<test-case id='2-1001'  name='testA'/>" +
                     "</test-suite>" +
-                    "<test-suite type='TestFixture' id='3-1000'> " +
-                        "<test-case id='3-1001' />" +
-                        "<test-case id='3-1002' />" +
+                    "<test-suite type='TestFixture' id='3-1000'  name='FixtureB'> " +
+                        "<test-case id='3-1001' name='testB'/>" +
+                        "<test-case id='3-1002' name='testC'/>" +
                     "</test-suite>" +
             "</test-suite>");
 
@@ -158,7 +158,7 @@ namespace TestCentric.Gui.Presenters
         public void TestGroupNode_WithoutResult_ReturnsExpectedCount()
         {
             // 1. Arrange
-            TestNode testNode = new TestNode("<test-case id='1' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
             TestGroup testGroup = new TestGroup("TestGroup");
             testGroup.TestNodes.Add(testNode);
             ITestModel model = Substitute.For<ITestModel>();

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultSubViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultSubViewPresenterTests.cs
@@ -35,8 +35,8 @@ namespace TestCentric.Gui.Presenters
             ITestResultSubView view = Substitute.For<ITestResultSubView>();
             ITestModel model = Substitute.For<ITestModel>();
 
-            TestNode testNode = new TestNode("<test-case id='1' />");
-            ResultNode resultNode = new ResultNode($"<test-case id='1' result='Passed' />");
+            TestNode testNode = new TestNode("<test-case id='1' name='TestA'/>");
+            ResultNode resultNode = new ResultNode($"<test-case id='1' name='TestA' result='Passed' />");
             model.TestResultManager.GetResultForTest("1").Returns(resultNode);
 
             // 2. Act

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultSubViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestResultSubViewPresenterTests.cs
@@ -56,7 +56,7 @@ namespace TestCentric.Gui.Presenters
             ITestResultSubView view = Substitute.For<ITestResultSubView>();
             ITestModel model = Substitute.For<ITestModel>();
 
-            TestNode testNode = new TestNode("<test-suite id='1' />");
+            TestNode testNode = new TestNode("<test-suite id='1' type='TestFixture' name='FixtureA'/>");
 
             // 2. Act
             TestResultSubViewPresenter presenter = new TestResultSubViewPresenter(view, model);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
@@ -22,7 +22,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             Tag = TEST_CASE_NODE
         };
 
-        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite/>"));
+        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite id='1' type='TestFixture' name='FixtureA'/>"));
         private static TreeNode TEST_SUITE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_SUITE_NODE

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestExecutionTests.cs
@@ -16,7 +16,7 @@ namespace TestCentric.Gui.Presenters.TestTree
 
     public class TestExecutionTests : TreeViewPresenterTestBase
     {
-        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case/>"));
+        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case id='0' name='TestA'/>"));
         private static TreeNode TEST_CASE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_CASE_NODE

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestSelection_WithCheckboxes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestSelection_WithCheckboxes.cs
@@ -17,13 +17,13 @@ namespace TestCentric.Gui.Presenters.TestTree
 
     public class TestSelection_WithCheckboxes : TreeViewPresenterTestBase
     {
-        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case/>"));
+        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case id='0' name='TestA'/>"));
         private static TreeNode TEST_CASE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_CASE_NODE
         };
 
-        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite/>"));
+        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite id='1' name='Suite1' type='TestFixture'/>"));
         private static TreeNode TEST_SUITE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_SUITE_NODE

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestSelection_WithoutCheckboxes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TestSelection_WithoutCheckboxes.cs
@@ -17,13 +17,13 @@ namespace TestCentric.Gui.Presenters.TestTree
 
     public class TestSelection_WithOutCheckboxes : TreeViewPresenterTestBase
     {
-        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case/>"));
+        private static TestNode TEST_CASE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-case id='0' name='TestA'/>"));
         private static TreeNode TEST_CASE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_CASE_NODE
         };
 
-        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite/>"));
+        private static TestNode TEST_SUITE_NODE = new TestNode(XmlHelper.CreateXmlNode("<test-suite id='0' name='TestA' type='TestFixture'/>"));
         private static TreeNode TEST_SUITE_TREE_NODE = new TreeNode()
         {
             Tag = TEST_SUITE_NODE

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/TreeViewPresenterTests.cs
@@ -178,8 +178,8 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void TreeCheckBoxClicked_TreeNodesAreSelected_AllTests_AreSelected()
         {
             // 1. Arrange
-            var treeNode1 = new TreeNode() { Tag = new TestNode("<test-case id='1' />") };
-            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='2' />") };
+            var treeNode1 = new TreeNode() { Tag = new TestNode("<test-case id='1' name='TestA'/>") };
+            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='2' name='TestB'/>") };
 
             IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1, treeNode2 };
             _view.CheckedNodes.Returns(checkedNodes);
@@ -196,8 +196,8 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void TreeCheckBoxClicked_GroupIsSelected_AllTestsOfGroup_AreSelected() 
         {
             // 1. Arrange
-            var subTestNode1 = new TestNode("<test-case id='2' />");
-            var subTestNode2 = new TestNode("<test-case id='3' />");
+            var subTestNode1 = new TestNode("<test-case id='2' name='TestB'/>");
+            var subTestNode2 = new TestNode("<test-case id='3' name='TestC'/>");
             var testGroup = new TestGroup("Category_1", [subTestNode1, subTestNode2]);
 
             var treeNode1 = new TreeNode() { Tag = testGroup };
@@ -217,12 +217,12 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void TreeCheckBoxClicked_TreeNodeAndGroupIsSelected_AllTests_AreSelected()
         {
             // 1. Arrange
-            var subTestNode1 = new TestNode("<test-case id='1' />");
-            var subTestNode2 = new TestNode("<test-case id='2' />");
+            var subTestNode1 = new TestNode("<test-case id='1' name='TestA'/>");
+            var subTestNode2 = new TestNode("<test-case id='2' name='TestB'/>");
             var testGroup = new TestGroup("Category_1", [subTestNode1, subTestNode2]);
 
             var treeNode1 = new TreeNode() { Tag = testGroup.TestNodes };
-            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='3' />") };
+            var treeNode2 = new TreeNode() { Tag = new TestNode("<test-case id='3' name='TestC'/>") };
 
             IList<TreeNode> checkedNodes = new List<TreeNode>() { treeNode1, treeNode2 };
             _view.CheckedNodes.Returns(checkedNodes);
@@ -239,8 +239,8 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void TreeCheckBoxClicked_TreeNodeInsideGroupIsSelected_AllTests_AreSelected()
         {
             // 1. Arrange
-            var subTestNode1 = new TestNode("<test-case id='1' />");
-            var subTestNode2 = new TestNode("<test-case id='2' />");
+            var subTestNode1 = new TestNode("<test-case id='1' name='TestA'/>");
+            var subTestNode2 = new TestNode("<test-case id='2' name='TestB'/>");
             var testGroup = new TestGroup("Category_1", [subTestNode1, subTestNode2]);
 
             var treeNode1 = new TreeNode() { Tag = testGroup.TestNodes };
@@ -475,7 +475,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         public void WhenContextMenuIsDisplayed_RemoveTestPackageCommandContextMenu_IsNotVisible(bool hasTests, bool isTestRunning, string testNodeType)
         {
             // 1. Arrange
-            TestNode testNode = new TestNode($"<test-suite id='1' type='{testNodeType}' />");
+            TestNode testNode = new TestNode($"<test-suite id='1' name='TestA' type='{testNodeType}' />");
             TreeNode treeNode = new TreeNode();
             treeNode.Tag = testNode;
             _view.ContextNode.Returns(treeNode);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestCaseCompletes.cs
@@ -42,10 +42,10 @@ namespace TestCentric.Gui.Presenters.TestTree
             var result = resultState.Status.ToString();
             var label = resultState.Label;
 
-            var testNode = new TestNode("<test-run id='1'><test-case id='123'/></test-run>");
+            var testNode = new TestNode("<test-run id='1'><test-case id='123' name='TestA'/></test-run>");
             var resultNode = new ResultNode(string.IsNullOrEmpty(label)
-                ? string.Format($"<test-case id='123' result='{result}'/>")
-                : string.Format($"<test-case id='123' result='{result}' label='{label}'/>"));
+                ? string.Format($"<test-case id='123' name='TestA' result='{result}'/>")
+                : string.Format($"<test-case id='123' name='TestA' result='{result}' label='{label}'/>"));
 
             _model.GetTestById("123").Returns(testNode.Children.First());
             _model.TestResultManager.GetResultForTest("123").Returns(resultNode);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         [TestCaseSource(nameof(resultData))]
         public void RunningIcons_AreUpdated_WhenTestRunFinishes(int runningIndex, int expectedIndex)
         {
-            var testNode = new TestNode("<test-run id='1'><test-suite id='100'><test-case id='200'/></test-suite></test-run>");
+            var testNode = new TestNode("<test-run id='1'><test-suite id='100' name='Fixture1' type='TestFixture'><test-case id='200' name='TestA'/></test-suite></test-run>");
 
             // Make it look like the view loaded
             _view.Load += Raise.Event<System.EventHandler>(_view, new System.EventArgs());

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestSuiteCompletes.cs
@@ -21,6 +21,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         [SetUp]
         public void Setup()
         {
+            _model.TreeConfiguration.NUnitTreeShowFixtures.Returns(true);
             _presenter = new TreeViewPresenter(_view, _model, new TreeDisplayStrategyFactory());
             _view.InvokeIfRequired(Arg.Do<MethodInvoker>(x => x.Invoke()));
         }
@@ -42,13 +43,13 @@ namespace TestCentric.Gui.Presenters.TestTree
             var result = resultState.Status.ToString();
             var label = resultState.Label;
 
-            var testNode = new TestNode("<test-run id='1'><test-suite id='100'><test-case id='200'/></test-suite></test-run>");
+            var testNode = new TestNode("<test-run id='1'><test-suite id='100' type='TestFixture' name='Fixture1'><test-case id='200' name='TestA'/></test-suite></test-run>");
             var resultNode = new ResultNode(string.IsNullOrEmpty(label)
-                ? string.Format("<test-suite id='100' result='{0}'/>", result)
-                : string.Format("<test-suite id='100' result='{0}' label='{1}'/>", result, label));
+                ? string.Format("<test-suite type='TestFixture' id='100' name='Fixture1' result='{0}'/>", result)
+                : string.Format("<test-suite type='TestFixture' id='100' name='Fixture1' result='{0}' label='{1}'/>", result, label));
             var testCaseResultNode = new ResultNode(string.IsNullOrEmpty(label)
-                                                ? string.Format("<test-suite id='200' result='{0}'/>", result)
-                                                : string.Format("<test-suite id='200' result='{0}' label='{1}'/>", result, label));
+                                                ? string.Format("<test-case id='200' name='TestA' result='{0}'/>", result)
+                                                : string.Format("<test-case id='200' name='TestA' result='{0}' label='{1}'/>", result, label));
 
             _model.GetTestById("100").Returns(testNode.Children.First());
             _model.TestResultManager.GetResultForTest("100").Returns(resultNode);

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -34,7 +34,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             // Arrange
             var project = new TestCentricProject(projectName, "dummy.dll");
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            TestNode testNode = new TestNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);
 
@@ -52,7 +52,7 @@ namespace TestCentric.Gui.Presenters.TestTree
         {
             // Arrange
             var project = new TestCentricProject(projectName, "dummy.dll");
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            TestNode testNode = new TestNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);
 
@@ -72,7 +72,7 @@ namespace TestCentric.Gui.Presenters.TestTree
             _treeDisplayStrategyFactory.Create(null, null, null).ReturnsForAnyArgs(strategy);
 
             var project = new TestCentricProject(projectName, "dummy.dll");
-            TestNode testNode = new TestNode("<test-suite id='1'/>");
+            TestNode testNode = new TestNode("<test-suite id='1' name='TestA' type='TestFixture'/>");
             _model.LoadedTests.Returns(testNode);
             _model.TestCentricProject.Returns(project);
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TextOutputPresenterTests.cs
@@ -15,7 +15,7 @@ namespace TestCentric.Gui.Presenters
 
     public class TextOutputPresenterTests : PresenterTestBase<ITextOutputView>
     {
-        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-suite id='1' testcasecount='1234' />");
+        private static readonly TestNode FAKE_TEST_RUN = new TestNode("<test-run id='1' testcasecount='1234' />");
 
         static readonly string NL = Environment.NewLine;
 

--- a/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TreeViewNodeComparerTests.cs
+++ b/src/GuiRunner/TestCentric.Gui.Tests/Presenters/TreeViewNodeComparerTests.cs
@@ -79,10 +79,10 @@ namespace TestCentric.Gui.Presenters
         public void Durationcompare_Ascending_ReturnsExpectedResult(string duration1, string duration2, int expectedCompareResult)
         {
             // Arrange
-            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
-            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
-            var resultNode1 = new ResultNode($"<test-case id='1' duration='{duration1}'/>");
-            var resultNode2 = new ResultNode($"<test-case id='2' duration='{duration2}'/>");
+            TestNode testNode1 = new TestNode($"<test-start id='1' name='TestA'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2' name='TestB'/>");
+            var resultNode1 = new ResultNode($"<test-case id='1' name='TestA' duration='{duration1}'/>");
+            var resultNode2 = new ResultNode($"<test-case id='2' name='TestB' duration='{duration2}'/>");
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns(resultNode1);
             model.TestResultManager.GetResultForTest("2").Returns(resultNode2);
@@ -106,10 +106,10 @@ namespace TestCentric.Gui.Presenters
         public void Durationcompare_Descending_ReturnsExpectedResult(string duration1, string duration2, int expectedCompareResult)
         {
             // Arrange
-            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
-            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
-            var resultNode1 = new ResultNode($"<test-case id='1' duration='{duration1}'/>");
-            var resultNode2 = new ResultNode($"<test-case id='2' duration='{duration2}'/>");
+            TestNode testNode1 = new TestNode($"<test-start id='1' name='TestA'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2' name='TestB'/>");
+            var resultNode1 = new ResultNode($"<test-case id='1' name='TestA' duration='{duration1}'/>");
+            var resultNode2 = new ResultNode($"<test-case id='2' name='TestB' duration='{duration2}'/>");
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns(resultNode1);
             model.TestResultManager.GetResultForTest("2").Returns(resultNode2);
@@ -131,8 +131,8 @@ namespace TestCentric.Gui.Presenters
         public void Durationcompare_NoTestResultAvailable_ReturnsExpectedResult(string text1, string text2, string sortDirection, int expectedCompareResult)
         {
             // Arrange
-            TestNode testNode1 = new TestNode($"<test-start id='1'/>");
-            TestNode testNode2 = new TestNode($"<test-start id='2'/>");
+            TestNode testNode1 = new TestNode($"<test-start id='1' name='TestA'/>");
+            TestNode testNode2 = new TestNode($"<test-start id='2' name='TestB'/>");
             ITestModel model = Substitute.For<ITestModel>();
             model.TestResultManager.GetResultForTest("1").Returns((ResultNode)null);
             model.TestResultManager.GetResultForTest("2").Returns((ResultNode)null);

--- a/src/GuiRunner/TestModel.Tests/Filter/CategoryFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/Filter/CategoryFilterTests.cs
@@ -160,7 +160,7 @@ namespace TestCentric.Gui.Model.Filter
 
         private string CreateTestcaseXml(string testId, string testName, IList<string> categories)
         {
-            string str = $"<test-case id='{testId}' fullname='{testName}'> ";
+            string str = $"<test-case id='{testId}' name='{testName}' fullname='{testName}'> ";
 
             str += "<properties> ";
             foreach (string category in categories)

--- a/src/GuiRunner/TestModel.Tests/Filter/OutcomeFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/Filter/OutcomeFilterTests.cs
@@ -38,8 +38,8 @@ namespace TestCentric.Gui.Model.Filter
             OutcomeFilter filter = new OutcomeFilter(testModel);
             filter.Condition = outcomeFilter;
 
-            TestNode testNode = new TestNode($"<test-case id='1' />");
-            var resultNode = new ResultNode($"<test-case id='1' result='{testOutcome}' />");
+            TestNode testNode = new TestNode($"<test-case id='1' name='TestA' />");
+            var resultNode = new ResultNode($"<test-case id='1' name='TestA' result='{testOutcome}' />");
             testModel.TestResultManager.GetResultForTest(testNode.Id).Returns(resultNode);
 
             // 2. Act
@@ -59,8 +59,8 @@ namespace TestCentric.Gui.Model.Filter
             OutcomeFilter filter = new OutcomeFilter(testModel);
             filter.Condition = outcomeFilter;
 
-            TestNode testNode = new TestNode($"<test-case id='1' />");
-            var resultNode = new ResultNode($"<test-case id='1' result='{testOutcome}' />");
+            TestNode testNode = new TestNode($"<test-case id='1' name='TestA' fullname='TestA'/>");
+            var resultNode = new ResultNode($"<test-case id='1' result='{testOutcome}' name='TestA' fullname='TestA'/>");
             testModel.TestResultManager.GetResultForTest(testNode.Id).Returns(resultNode);
 
             // 2. Act
@@ -78,7 +78,7 @@ namespace TestCentric.Gui.Model.Filter
             OutcomeFilter filter = new OutcomeFilter(testModel);
             filter.Condition = outcomeFilter;
 
-            TestNode testNode = new TestNode($"<test-case id='1' />");
+            TestNode testNode = new TestNode($"<test-case id='1' name='TestA' />");
             testModel.TestResultManager.GetResultForTest(testNode.Id).Returns((ResultNode)null);
 
             // 2. Act

--- a/src/GuiRunner/TestModel.Tests/Filter/TestCentricTestFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/Filter/TestCentricTestFilterTests.cs
@@ -29,7 +29,7 @@ namespace TestCentric.Gui.Model.Filter
         {
             // Arrange
             bool isCalled = false;
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             _model.LoadedTests.Returns(testNode);
 
             // Act
@@ -45,7 +45,7 @@ namespace TestCentric.Gui.Model.Filter
         {
             // Arrange
             bool isCalled = false;
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             _model.LoadedTests.Returns(testNode);
 
             // Act
@@ -61,7 +61,7 @@ namespace TestCentric.Gui.Model.Filter
         {
             // Arrange
             bool isCalled = false;
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             _model.LoadedTests.Returns(testNode);
 
             // Act
@@ -76,7 +76,7 @@ namespace TestCentric.Gui.Model.Filter
         public void AllCategories_NoCategoriesDefinedInModel_ReturnsDefaultCategory()
         {
             // Arrange
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA' />");
             _model.LoadedTests.Returns(testNode);
 
             // Act
@@ -93,7 +93,7 @@ namespace TestCentric.Gui.Model.Filter
         public void AllCategories_CategoriesDefinedInModel_ReturnsModelAndDefaultCategory()
         {
             // Arrange
-            var testNode = new TestNode($"<test-case id='1' />");
+            var testNode = new TestNode($"<test-case id='1' name='TestA'/>");
             _model.LoadedTests.Returns(testNode);
             _model.AvailableCategories.Returns(new List<string>() { "Feature_1" });
 
@@ -538,7 +538,7 @@ namespace TestCentric.Gui.Model.Filter
 
         private string CreateTestcaseXml(string testId, string testName, string outcome, IList<string> categories)
         {
-            string str = $"<test-case id='{testId}' fullname='{testName}'> ";
+            string str = $"<test-case id='{testId}' fullname='{testName}' name='{testName}'> ";
 
             str += "<properties> ";
             foreach (string category in categories)
@@ -548,7 +548,7 @@ namespace TestCentric.Gui.Model.Filter
             str += "</test-case> ";
 
             if (!string.IsNullOrEmpty(outcome))
-                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' />"));
+                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' name='{testName}'/>"));
             return str;
         }
 
@@ -559,7 +559,7 @@ namespace TestCentric.Gui.Model.Filter
 
         private string CreateTestFixtureXml(string testId, string testName, string outcome, IEnumerable<string> categories, params string[] testCases)
         {
-            string str = $"<test-suite type='TestFixture' id='{testId}'  fullname='{testName}'> ";
+            string str = $"<test-suite type='TestFixture' id='{testId}'  fullname='{testName}' name='{testName}'> ";
 
             str += "<properties> ";
             foreach (string category in categories)
@@ -572,21 +572,21 @@ namespace TestCentric.Gui.Model.Filter
             str += "</test-suite>";
 
             if (!string.IsNullOrEmpty(outcome))
-                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' />"));
+                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' name='{testName}'/>"));
 
             return str;
         }
 
         private string CreateTestSuiteXml(string testId, string testName, string outcome, params string[] testSuites)
         {
-            string str = $"<test-suite type='TestSuite' id='{testId}' fullname='{testName}'> ";
+            string str = $"<test-suite type='TestSuite' id='{testId}' fullname='{testName}' name='{testName}'> ";
             foreach (string testSuite in testSuites)
                 str += testSuite;
 
             str += "</test-suite>";
 
             if (!string.IsNullOrEmpty(outcome))
-                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' />"));
+                _model.TestResultManager.GetResultForTest(testId).Returns(new ResultNode($"<test-case id='{testId}' result='{outcome}' name='{testName}'/>"));
 
             return str;
         }

--- a/src/GuiRunner/TestModel.Tests/Filter/TextFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/Filter/TextFilterTests.cs
@@ -31,7 +31,7 @@ namespace TestCentric.Gui.Model.Filter
             // 1. Arrange
             TextFilter filter = new TextFilter();
             filter.Condition = new[] { filterText };
-            TestNode testNode = new TestNode($"<test-case id='1' fullname='${nodeName}' />");
+            TestNode testNode = new TestNode($"<test-case id='1' fullname='${nodeName}' name='${nodeName}'/>");
 
             // 2. Act
             bool isMatch = filter.IsMatching(testNode);
@@ -48,7 +48,7 @@ namespace TestCentric.Gui.Model.Filter
             // 1. Arrange
             TextFilter filter = new TextFilter();
             filter.Condition = new[] { filterText };
-            TestNode testNode = new TestNode($"<test-case id='1' fullname='${nodeName}' />");
+            TestNode testNode = new TestNode($"<test-case id='1' fullname='${nodeName}' name='${nodeName}'/>");
 
             // 2. Act
             bool isMatch = filter.IsMatching(testNode);

--- a/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
+++ b/src/GuiRunner/TestModel.Tests/ResultNodeTests.cs
@@ -17,7 +17,7 @@ namespace TestCentric.Gui.Model
         {
             TestDelegate newResultNode = () =>
             {
-                var resultNode = new ResultNode("<test-case duration='0.000'/>");
+                var resultNode = new ResultNode("<test-case id='0' name='TestA' duration='0.000'/>");
             };
             Assert.DoesNotThrow(newResultNode);
         }
@@ -26,7 +26,7 @@ namespace TestCentric.Gui.Model
         public void CreateResultNode_FromOldResult()
         {
             // Act
-            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Passed'/>");
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' name='TestB' result='Passed'/>");
 
             // Arrange
             ResultNode newResultNode = ResultNode.Create(resultNode.Xml, "100");
@@ -54,7 +54,7 @@ namespace TestCentric.Gui.Model
         public void CreateResultNode_FromOldResult_ReplaceResultState(ResultState resultState, TestStatus expectedTestStatus)
         {
             // Act
-            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Passed'/>");
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' name='TestB' result='Passed'/>");
 
             // Arrange
             ResultNode newResultNode = ResultNode.Create(resultNode.Xml, resultState);
@@ -70,7 +70,7 @@ namespace TestCentric.Gui.Model
         public void CreateResultNode_FromOldResult_ReplaceResultState2(ResultState resultState, TestStatus expectedTestStatus)
         {
             // Act
-            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' result='Skipped' label='Ignored' />");
+            var resultNode = new ResultNode("<test-case id='1' fullname='Assembly.Folder1.TestB' name='TestB' result='Skipped' label='Ignored' />");
 
             // Arrange
             ResultNode newResultNode = ResultNode.Create(resultNode.Xml, resultState);
@@ -85,7 +85,7 @@ namespace TestCentric.Gui.Model
         [Test]
         public void IsLatestRun_NewResultNode_IsTrue()
         {
-            var resultNode = new ResultNode("<test-case id='1'/>");
+            var resultNode = new ResultNode("<test-case id='1' name='TestA'/>");
             
             Assert.That(resultNode.IsLatestRun, Is.True);
         }

--- a/src/GuiRunner/TestModel.Tests/ResultSummaryCreatorTests.cs
+++ b/src/GuiRunner/TestModel.Tests/ResultSummaryCreatorTests.cs
@@ -17,7 +17,7 @@ namespace TestCentric.Gui.Model
             Assert.That(() => CreateResultSummary("<anything-other-than-test-run/>"),
                 Throws.InstanceOf<InvalidOperationException>());
 
-            Assert.That(() => CreateResultSummary("<test-run/>"),
+            Assert.That(() => CreateResultSummary("<test-run id='10'/>"),
                 Throws.Nothing);
         }
 
@@ -25,7 +25,7 @@ namespace TestCentric.Gui.Model
         public void ResultOfTestRunIsValueOfOverallResult()
         {
             var innerXml = "<test-case result='Passed'/>";
-            var summary = CreateResultSummary($"<test-run result='Failed'>{innerXml}</test-run>");
+            var summary = CreateResultSummary($"<test-run id='10' result='Failed'>{innerXml}</test-run>");
 
             Assert.That(summary.OverallResult, Is.EqualTo("Failed"));
         }
@@ -34,7 +34,7 @@ namespace TestCentric.Gui.Model
         public void WhenResultIsNotSpecified_PassedIsDefault()
         {
             var innerXml = "<test-case result='Failed'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.OverallResult, Is.EqualTo("Passed"));
         }
@@ -42,8 +42,8 @@ namespace TestCentric.Gui.Model
         [Test]
         public void DurationOfTestRunIsValueOfDuration()
         {
-            var innerXml = "<test-case duration='999'/>";
-            var summary = CreateResultSummary($"<test-run duration='1.9'>{innerXml}</test-run>");
+            var innerXml = "<test-case duration='999' id='100' name='TestA' />";
+            var summary = CreateResultSummary($"<test-run id='0' duration='1.9'>{innerXml}</test-run>");
 
             Assert.That(summary.Duration, Is.EqualTo(1.9));
         }
@@ -51,8 +51,8 @@ namespace TestCentric.Gui.Model
         [Test]
         public void WhenDurationIsNotSpecified_ZeroIsDefault()
         {
-            var innerXml = "<test-case duration='999'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var innerXml = "<test-case duration='999' id='100' name='TestA' />";
+            var summary = CreateResultSummary($"<test-run id='0' > {innerXml}</test-run>");
 
             Assert.That(summary.Duration, Is.EqualTo(0.0));
         }
@@ -61,8 +61,8 @@ namespace TestCentric.Gui.Model
         public void StartTimeOfTestRunIsValueOfStartTime()
         {
             var expectedDate = new DateTime(2017, 7, 8, 6, 19, 23);
-            var innerXml = $"<test-case start-time='{DateTime.MinValue:u}'/>";
-            var summary = CreateResultSummary($"<test-run start-time='{expectedDate:u}'>{innerXml}</test-run>");
+            var innerXml = $"<test-case start-time='{DateTime.MinValue:u}' id='100' name='TestA' fullname='TestA'/>";
+            var summary = CreateResultSummary($"<test-run id='0' start-time='{expectedDate:u}'>{innerXml}</test-run>");
 
             Assert.That(summary.StartTime, Is.EqualTo(expectedDate));
         }
@@ -70,8 +70,8 @@ namespace TestCentric.Gui.Model
         [Test]
         public void WhenStartTimeIsNotSpecified_DateTimeMinValueIsDefault()
         {
-            var innerXml = $"<test-case start-time='{DateTime.MaxValue:u}'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var innerXml = $"<test-case start-time='{DateTime.MaxValue:u}' id='100' name='TestA' />";
+            var summary = CreateResultSummary($"<test-run id='0' >{innerXml}</test-run>");
 
             Assert.That(summary.StartTime, Is.EqualTo(DateTime.MinValue));
         }
@@ -80,8 +80,8 @@ namespace TestCentric.Gui.Model
         public void EndTimeOfTestRunIsValueOfEndTime()
         {
             var expectedDate = new DateTime(2017, 7, 8, 6, 19, 23);
-            var innerXml = $"<test-case end-time='{DateTime.MaxValue:u}'/>";
-            var summary = CreateResultSummary($"<test-run end-time='{expectedDate:u}'>{innerXml}</test-run>");
+            var innerXml = $"<test-case end-time='{DateTime.MaxValue:u}' id='100' name='TestA' />";
+            var summary = CreateResultSummary($"<test-run id='0' end-time='{expectedDate:u}'>{innerXml}</test-run>");
 
             Assert.That(summary.EndTime, Is.EqualTo(expectedDate));
         }
@@ -89,8 +89,8 @@ namespace TestCentric.Gui.Model
         [Test]
         public void WhenEndTimeIsNotSpecified_DateTimeMaxValueIsDefault()
         {
-            var innerXml = $"<test-case end-time='{DateTime.MinValue:u}'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var innerXml = $"<test-case end-time='{DateTime.MinValue:u}' id='100' name='TestA'/>";
+            var summary = CreateResultSummary($"<test-run id='0' >{innerXml}</test-run>");
 
             Assert.That(summary.EndTime, Is.EqualTo(DateTime.MaxValue));
         }
@@ -99,13 +99,13 @@ namespace TestCentric.Gui.Model
         public void TestCountIsCountOfEachNestedTestCase()
         {
             var innerXml =
-                "<test-case/>" +
-                "<test-case/>" +
-                "<test-suite>" +
-                    "<test-case/>" +
-                    "<test-case/>" +
+                "<test-case id='0' name='TestA'/>" +
+                "<test-case id='1' name='TestB'/>" +
+                "<test-suite id='20' name='Suite1' type='Assembly'>" +
+                    "<test-case id='2' name='TestC'/>" +
+                    "<test-case id='3' name='TestD'/>" +
                 "</test-suite>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.TestCount, Is.EqualTo(4));
         }
@@ -114,9 +114,9 @@ namespace TestCentric.Gui.Model
         public void WhenNoResultIsSpecifiedInTestCase_SkipCountIsIncremented()
         {
             var innerXml =
-                "<test-case result='Passed'/>" +
+                "<test-case result='Passed' id='0' name='TestA'/>" +
                 "<test-case/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+            var summary = CreateResultSummary($"<test-run id ='10'>{innerXml}</test-run>");
 
             Assert.That(summary.TestCount, Is.EqualTo(2));
             Assert.That(summary.PassCount, Is.EqualTo(1));
@@ -127,11 +127,11 @@ namespace TestCentric.Gui.Model
         public void ExtendedFailureInformationAreBasedOnLabel()
         {
             var innerXml =
-                "<test-case result='Failed'/>" +
-                "<test-case result='Failed' label='Invalid'/>" +
-                "<test-case result='Failed' label='Anything else increases ErrorCount'/>" +
-                "<test-case result='Failed' label='I am not null'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+                "<test-case id='0' name='TestA' result='Failed'/>" +
+                "<test-case id='1' name='TestB' result='Failed' label='Invalid'/>" +
+                "<test-case id='2' name='TestC' result='Failed' label='Anything else increases ErrorCount'/>" +
+                "<test-case id='3' name='TestD' result='Failed' label='I am not null'/>";
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.TestCount, Is.EqualTo(4));
             Assert.That(summary.FailedCount, Is.EqualTo(4));
@@ -144,12 +144,12 @@ namespace TestCentric.Gui.Model
         public void ExtendedSkipInformationAreBasedOnLabel()
         {
             var innerXml =
-                "<test-case result='Skipped'/>" +
-                "<test-case result='Skipped' label='Ignored'/>" +
-                "<test-case result='Skipped' label='Explicit'/>" +
-                "<test-case result='Skipped' label='Anything else increases SkippedCount'/>" +
-                "<test-case result='Skipped' label='I am not null'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+                "<test-case id='0' name='TestA' result='Skipped'/>" +
+                "<test-case id='1' name='TestB' result='Skipped' label='Ignored'/>" +
+                "<test-case id='2' name='TestC' result='Skipped' label='Explicit'/>" +
+                "<test-case id='3' name='TestD' result='Skipped' label='Anything else increases SkippedCount'/>" +
+                "<test-case id='4' name='TestE' result='Skipped' label='I am not null'/>";
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.TestCount, Is.EqualTo(5));
             Assert.That(summary.TotalSkipCount, Is.EqualTo(5));
@@ -162,9 +162,9 @@ namespace TestCentric.Gui.Model
         public void InvalidTestSuitesAreTracked()
         {
             var innerXml =
-                "<test-suite result='Failed' label='Invalid'/>" +
-                "<test-suite result='Failed' label='Invalid' type='Assembly'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+                "<test-suite id='0' name='TestA' result='Failed' label='Invalid' type='TestFixture'/>" +
+                "<test-suite id='1' name='TestB' result='Failed' label='Invalid' type='Assembly'/>";
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.InvalidTestFixtures, Is.EqualTo(1));
             Assert.That(summary.InvalidAssemblies, Is.EqualTo(1));
@@ -175,9 +175,9 @@ namespace TestCentric.Gui.Model
         public void ErrorAssembliesMarkSummaryAsUnexpectedError()
         {
             var innerXml =
-                "<test-suite result='Failed' label='Invalid' type='Assembly'/>" +
-                "<test-suite result='Failed' label='Error' type='Assembly'/>";
-            var summary = CreateResultSummary($"<test-run>{innerXml}</test-run>");
+                "<test-suite id='0' name='TestA' result='Failed' label='Invalid' type='Assembly'/>" +
+                "<test-suite id='1' name='TestB' result='Failed' label='Error' type='Assembly'/>";
+            var summary = CreateResultSummary($"<test-run id='10'>{innerXml}</test-run>");
 
             Assert.That(summary.InvalidAssemblies, Is.EqualTo(2));
             Assert.That(summary.UnexpectedError, Is.True);

--- a/src/GuiRunner/TestModel.Tests/TestFilterTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestFilterTests.cs
@@ -15,7 +15,7 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_TestRunNode_ReturnsEmptyFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-run type='TestRun' />");
+            var testNode = new TestNode("<test-run type='TestRun' id='0'/>");
 
             // Act
             TestFilter filter = TestFilter.MakeIdFilter(testNode);
@@ -28,7 +28,7 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_Testcase_ReturnsIdFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-case id='1' />");
+            var testNode = new TestNode("<test-case id='1' name='TestA' />");
 
             // Act
             TestFilter filter = TestFilter.MakeIdFilter(testNode);
@@ -41,7 +41,7 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_TestFixture_ReturnsIdFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-suite type='TestFixture' id='100' />");
+            var testNode = new TestNode("<test-suite type='TestFixture' id='100' name='Fixture1'/>");
 
             // Act
             TestFilter filter = TestFilter.MakeIdFilter(testNode);
@@ -54,7 +54,7 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_TestSelection_SingleTestRunNode_ReturnsEmptyFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-run type='TestRun' />");
+            var testNode = new TestNode("<test-run type='TestRun' id='0' />");
             var testSelection = new TestSelection(new[] { testNode });
 
             // Act
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_TestSelection_SingleTestcase_ReturnsIdFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-case id='1' />");
+            var testNode = new TestNode("<test-case id='1' name='TestA'/>");
             var testSelection = new TestSelection(new[] { testNode });
 
             // Act
@@ -82,8 +82,8 @@ namespace TestCentric.Gui.Model
         public void MakeIdFilter_TestSelection_MultipleTests_ReturnsIdFilter()
         {
             // Arrange
-            var testNode1 = new TestNode("<test-case id='1' />");
-            var testNode2 = new TestNode("<test-suite type='TestFixture' id='100' />");
+            var testNode1 = new TestNode("<test-case id='1' name='TestA'/>");
+            var testNode2 = new TestNode("<test-suite type='TestFixture' id='100' name='Fixture1'/>");
 
             var testSelection = new TestSelection(new[] { testNode1, testNode2 });
 
@@ -142,7 +142,7 @@ namespace TestCentric.Gui.Model
         public void MakeAndFilter_OfFilters_ReturnsAndFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-case id='1' />");
+            var testNode = new TestNode("<test-case id='1' name='TestA'/>");
             var filter1 = TestFilter.MakeIdFilter(testNode);
 
             // Act
@@ -156,10 +156,10 @@ namespace TestCentric.Gui.Model
         public void MakeAndFilter_OfFilters2_ReturnsAndFilter()
         {
             // Arrange
-            var testNode1 = new TestNode("<test-case id='1' />");
+            var testNode1 = new TestNode("<test-case id='1' name='TestA' />");
             var filter1 = TestFilter.MakeIdFilter(testNode1);
 
-            var testNode2 = new TestNode("<test-case id='2' />");
+            var testNode2 = new TestNode("<test-case id='2'  name='TestB' />");
             var filter2 = TestFilter.MakeIdFilter(testNode2);
 
             // Act
@@ -195,7 +195,7 @@ namespace TestCentric.Gui.Model
         public void MakeOrFilter_OfFilters_ReturnsOrFilter()
         {
             // Arrange
-            var testNode = new TestNode("<test-case id='1' />");
+            var testNode = new TestNode("<test-case id='1' name='TestA' />");
             var filter1 = TestFilter.MakeIdFilter(testNode);
 
             // Act
@@ -209,10 +209,10 @@ namespace TestCentric.Gui.Model
         public void MakeOrFilter_OfFilters2_ReturnsAndFilter()
         {
             // Arrange
-            var testNode1 = new TestNode("<test-case id='1' />");
+            var testNode1 = new TestNode("<test-case id='1' name='TestA'/>");
             var filter1 = TestFilter.MakeIdFilter(testNode1);
 
-            var testNode2 = new TestNode("<test-case id='2' />");
+            var testNode2 = new TestNode("<test-case id='2' name='TestB' />");
             var filter2 = TestFilter.MakeIdFilter(testNode2);
 
             // Act

--- a/src/GuiRunner/TestModel.Tests/TestModelTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestModelTests.cs
@@ -79,7 +79,7 @@ namespace TestCentric.Gui.Model
         public void IsInTestRun_TestNode_ReturnsTrue()
         {
             // Arrange
-            var xmlNode = XmlHelper.CreateXmlNode($"<test-case id='1' />");
+            var xmlNode = XmlHelper.CreateXmlNode($"<test-case id='1' name='TestA'/>");
             var testNode = new TestNode(xmlNode);
 
             var runner = Substitute.For<ITestRunner>();
@@ -175,8 +175,8 @@ namespace TestCentric.Gui.Model
             model.CreateNewProject("MyProject");
             model.LoadTests(new[] { "dummy.dll" });
 
-            ResultNode resultNode1 = new ResultNode("<test-case id='1' />");
-            ResultNode resultNode2 = new ResultNode("<test-case id='2' />");
+            ResultNode resultNode1 = new ResultNode("<test-case id='1' name='TestA'/>");
+            ResultNode resultNode2 = new ResultNode("<test-case id='2' name='TestB'/>");
             model.TestResultManager.AddResult(resultNode1);
             model.TestResultManager.AddResult(resultNode2);
 

--- a/src/GuiRunner/TestModel.Tests/TestResultManagerTests.cs
+++ b/src/GuiRunner/TestModel.Tests/TestResultManagerTests.cs
@@ -33,7 +33,7 @@ namespace TestCentric.Gui.Model
         {
             // Arrange
             ITestModel model = Substitute.For<ITestModel>();
-            ResultNode resultNode = new ResultNode("<test-suite id='1' result='Passed'/>");
+            ResultNode resultNode = new ResultNode("<test-suite id='1' result='Passed' name='TestA' type='TestFixture'/>");
 
             var manager = new TestResultManager(model);
             manager.AddResult(resultNode);
@@ -51,7 +51,7 @@ namespace TestCentric.Gui.Model
         {
             // Arrange
             ITestModel model = Substitute.For<ITestModel>();
-            ResultNode resultNode = new ResultNode("<test-suite id='1' result='Passed'/>");
+            ResultNode resultNode = new ResultNode("<test-suite id='1' result='Passed' name='TestA' type='TestFixture'/>");
 
             var manager = new TestResultManager(model);
             manager.AddResult(resultNode);
@@ -69,8 +69,8 @@ namespace TestCentric.Gui.Model
         {
             // Arrange
             ITestModel model = Substitute.For<ITestModel>();
-            ResultNode resultNode1 = new ResultNode("<test-suite id='1' result='Passed'/>");
-            ResultNode resultNode2 = new ResultNode("<test-suite id='2' result='Passed'/>");
+            ResultNode resultNode1 = new ResultNode("<test-suite id='1' result='Passed' name='TestA' type='TestFixture'/>");
+            ResultNode resultNode2 = new ResultNode("<test-suite id='2' result='Passed' name='TestB' type='TestFixture'/>");
 
             var manager = new TestResultManager(model);
             manager.AddResult(resultNode1);
@@ -109,11 +109,11 @@ namespace TestCentric.Gui.Model
             string oldOutcome, string oldLabel, string newOutcome, string newLabel, TestStatus expectedTestStatus)
         {
             // Arrange
-            ResultNode oldResult = new ResultNode($"<test-suite id='1' result='{oldOutcome}' label='{oldLabel}' />");
-            ResultNode childResult1 = new ResultNode($"<test-suite id='2' result='{newOutcome}' label='{newLabel}' />");
-            ResultNode childResult2 = new ResultNode($"<test-suite id='3' result='{oldOutcome}' label='{oldLabel}' />");
+            ResultNode oldResult = new ResultNode($"<test-suite id='1' result='{oldOutcome}' label='{oldLabel}' name='TestA' fullname='TestA' type='TestFixture'/>");
+            ResultNode childResult1 = new ResultNode($"<test-suite id='2' result='{newOutcome}' label='{newLabel}' name='TestB' fullname='TestB' type='TestFixture'/>");
+            ResultNode childResult2 = new ResultNode($"<test-suite id='3' result='{oldOutcome}' label='{oldLabel}' name='TestC' fullname='TestC' type='TestFixture'/>");
 
-            TestNode testNode1 = new TestNode($"<test-suite id='1'> <test-case id='2' />  <test-case id='3' /> </test-suite>");
+            TestNode testNode1 = new TestNode($"<test-suite id='1' name='TestA' type='TestFixture'> <test-case id='2' name='TestB' />  <test-case id='3' name='TestC' /> </test-suite>");
             
             ITestModel model = Substitute.For<ITestModel>();
             model.GetTestById("1").Returns(testNode1);
@@ -123,7 +123,7 @@ namespace TestCentric.Gui.Model
 
             // Act
             manager.TestRunStarting();
-            ResultNode newResult = new ResultNode($"<test-suite id='1' result='{newOutcome}' label='{newLabel}' />");
+            ResultNode newResult = new ResultNode($"<test-suite id='1' result='{newOutcome}' label='{newLabel}' name='TestA' type='TestFixture'/>");
             manager.AddResult(childResult1);
             manager.AddResult(newResult);
 
@@ -142,11 +142,11 @@ namespace TestCentric.Gui.Model
             string oldOutcome, string oldLabel, string newOutcome, string newLabel, TestStatus expectedTestStatus)
         {
             // Arrange
-            ResultNode oldResult = new ResultNode($"<test-suite id='1' result='{oldOutcome}' label='{oldLabel}' />");
-            ResultNode childResult1 = new ResultNode($"<test-suite id='2' result='{newOutcome}' label='{newLabel}' />");
-            ResultNode childResult2 = new ResultNode($"<test-suite id='3' result='{oldOutcome}' label='{oldLabel}' />");
+            ResultNode oldResult = new ResultNode($"<test-suite id='1' result='{oldOutcome}' label='{oldLabel}' name='TestA' type='TestFixture'/>");
+            ResultNode childResult1 = new ResultNode($"<test-suite id='2' result='{newOutcome}' label='{newLabel}' name='TestB' type='TestFixture'/>");
+            ResultNode childResult2 = new ResultNode($"<test-suite id='3' result='{oldOutcome}' label='{oldLabel}' name='TestC' type='TestFixture'/>");
 
-            TestNode testNode1 = new TestNode($"<test-suite id='1'> <test-case id='2' />  <test-case id='3' /> </test-suite>");
+            TestNode testNode1 = new TestNode($"<test-suite id='1' name='TestA' type='TestFixture'> <test-case id='2' name='TestB'/>  <test-case id='3' name='TestC'/> </test-suite>");
 
             ITestModel model = Substitute.For<ITestModel>();
             model.GetTestById("1").Returns(testNode1);
@@ -156,7 +156,7 @@ namespace TestCentric.Gui.Model
 
             // Act
             manager.TestRunStarting();
-            ResultNode newResult = new ResultNode($"<test-suite id='1' result='{newOutcome}' label='{newLabel}' />");
+            ResultNode newResult = new ResultNode($"<test-suite id='1' type='TestFixture' name='TestA' result='{newOutcome}' label='{newLabel}' />");
             manager.AddResult(childResult1);
             ResultNode addedResult = manager.AddResult(newResult);
 
@@ -190,16 +190,16 @@ namespace TestCentric.Gui.Model
             string outcome1stRun, string label1stRun, string outcome2ndRun, string label2ndRun, TestStatus expectedTestStatus)
         {
             // Arrange
-            TestNode testNode1 = new TestNode($"<test-suite id='1' type='TestSuite'> <test-suite id='2' type='TestFixture'> <test-case id='3' />  <test-case id='4' /> </test-suite> </test-suite>");
+            TestNode testNode1 = new TestNode($"<test-suite id='1' name='Suite1' type='TestSuite'> <test-suite id='2' type='TestFixture' name='Fixture1'> <test-case id='3' name='TestA'/>  <test-case id='4' name='TestB'/> </test-suite> </test-suite>");
 
             // Simulate 2 test runs in which only one part of the tests are executed.: 1st run executes test case '3'; 2nd run executes test case '4'
-            ResultNode resultNode1_1stRun = new ResultNode($"<test-suite id='1' type='TestSuite' result='{outcome1stRun}' label='{label1stRun}' />");
-            ResultNode resultNode2_1stRun = new ResultNode($"<test-suite id='2' type='TestFixture' result='{outcome1stRun}' label='{label1stRun}' />");
-            ResultNode resultNode3_1stRun = new ResultNode($"<test-suite id='3' result='{outcome1stRun}' label='{label1stRun}' />");
+            ResultNode resultNode1_1stRun = new ResultNode($"<test-suite id='1' type='TestSuite' name='Suite1' result='{outcome1stRun}' label='{label1stRun}' />");
+            ResultNode resultNode2_1stRun = new ResultNode($"<test-suite id='2' type='TestFixture' name='Fixture1' result='{outcome1stRun}' label='{label1stRun}' />");
+            ResultNode resultNode3_1stRun = new ResultNode($"<test-case id='3' name='TestA' result='{outcome1stRun}' label='{label1stRun}' />");
 
-            ResultNode resultNode1_2ndRun = new ResultNode($"<test-suite id='1' type='TestSuite' result='{outcome2ndRun}' label='{label2ndRun}' />");
-            ResultNode resultNode2_2ndRun = new ResultNode($"<test-suite id='2' type='TestFixture' result='{outcome2ndRun}' label='{label2ndRun}' />");
-            ResultNode resultNode4_2ndRun = new ResultNode($"<test-suite id='4' result='{outcome2ndRun}' label='{label2ndRun}' />");
+            ResultNode resultNode1_2ndRun = new ResultNode($"<test-suite id='1' type='TestSuite' name='Suite1' result='{outcome2ndRun}' label='{label2ndRun}' />");
+            ResultNode resultNode2_2ndRun = new ResultNode($"<test-suite id='2' type='TestFixture' name='Fixture1' result='{outcome2ndRun}' label='{label2ndRun}' />");
+            ResultNode resultNode4_2ndRun = new ResultNode($"<test-case id='4' name='TestA' result='{outcome2ndRun}' label='{label2ndRun}' />");
 
             ITestModel model = Substitute.For<ITestModel>();
             model.GetTestById("1").Returns(testNode1);
@@ -231,8 +231,8 @@ namespace TestCentric.Gui.Model
         public void AddResult_ExplicitResult_ReturnsResultFromPreviousRun()
         {
             // Arrange
-            ResultNode oldResult = new ResultNode($"<test-suite id='1' result='Passed' />");
-            ResultNode newResult = new ResultNode($"<test-suite id='1' result='Skipped' label='Explicit' />");
+            ResultNode oldResult = new ResultNode($"<test-suite id='1' name='TestA' type='TestFixture' result='Passed' />");
+            ResultNode newResult = new ResultNode($"<test-suite id='1' name='TestA' type='TestFixture' result='Skipped' label='Explicit' />");
 
             ITestModel model = Substitute.For<ITestModel>();
             var manager = new TestResultManager(model);
@@ -252,7 +252,7 @@ namespace TestCentric.Gui.Model
         {
             // Arrange
             string xmlReload = "<test-run id='1'>" +
-                               "<test-case id='2' fullname='Assembly.Folder1.TestB'/>" +
+                               "<test-case id='2' fullname='Assembly.Folder1.TestB' name='TestB'/>" +
                                "</test-run>";
 
             var reloadedTestNode = new TestNode(xmlReload);
@@ -261,7 +261,7 @@ namespace TestCentric.Gui.Model
             var manager = new TestResultManager(model);
             model.LoadedTests.Returns(reloadedTestNode);
 
-            var resultXml = "<test-case id='3' fullname='Assembly.Folder1.TestB' result='Passed'/>";
+            var resultXml = "<test-case id='3' fullname='Assembly.Folder1.TestB' name='TestB' result='Passed'/>";
             manager.AddResult(new ResultNode(resultXml));
 
             // Act

--- a/src/GuiRunner/TestModel/AssertionResult.cs
+++ b/src/GuiRunner/TestModel/AssertionResult.cs
@@ -4,6 +4,7 @@
 // ***********************************************************************
 
 using System.Xml;
+using NUnit;
 
 namespace TestCentric.Gui.Model
 {
@@ -17,12 +18,12 @@ namespace TestCentric.Gui.Model
 
         public AssertionResult(XmlNode assertion)
         {
-            Status = assertion.GetAttribute("label") ?? assertion.GetAttribute("result");
+            Status = (assertion.GetAttribute("label") ?? assertion.GetAttribute("result")).ShouldNotBeNull();
             Message = assertion.SelectSingleNode("message")?.InnerText;
             StackTrace = assertion.SelectSingleNode("stack-trace")?.InnerText;
         }
 
-        public string? Status { get; }
+        public string Status { get; }
         public string? Message { get; }
         public string? StackTrace { get; }
     }

--- a/src/GuiRunner/TestModel/AssertionResult.cs
+++ b/src/GuiRunner/TestModel/AssertionResult.cs
@@ -22,7 +22,7 @@ namespace TestCentric.Gui.Model
             StackTrace = assertion.SelectSingleNode("stack-trace")?.InnerText;
         }
 
-        public string Status { get; }
+        public string? Status { get; }
         public string? Message { get; }
         public string? StackTrace { get; }
     }

--- a/src/GuiRunner/TestModel/AssertionResult.cs
+++ b/src/GuiRunner/TestModel/AssertionResult.cs
@@ -23,7 +23,7 @@ namespace TestCentric.Gui.Model
         }
 
         public string Status { get; }
-        public string Message { get; }
-        public string StackTrace { get; }
+        public string? Message { get; }
+        public string? StackTrace { get; }
     }
 }

--- a/src/GuiRunner/TestModel/Filter/CategoryFilter.cs
+++ b/src/GuiRunner/TestModel/Filter/CategoryFilter.cs
@@ -21,6 +21,7 @@ namespace TestCentric.Gui.Model.Filter
         public CategoryFilter(ITestModel model)
         {
             TestModel = model;
+            AllCategories = new List<string>();
         }
 
         private ITestModel TestModel { get; }

--- a/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
+++ b/src/GuiRunner/TestModel/Filter/TestCentricTestFilter.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+using NUnit;
 
 namespace TestCentric.Gui.Model.Filter
 {
@@ -64,6 +66,8 @@ namespace TestCentric.Gui.Model.Filter
 
         public void ResetAll(bool suppressFilterChangedEvent = false)
         {
+            Guard.OperationValid(TestModel.LoadedTests != null, "No tests have been loaded");
+
             foreach (ITestFilter filter in _filters)
             {
                 filter.Reset();
@@ -106,6 +110,8 @@ namespace TestCentric.Gui.Model.Filter
 
         private void SetFilterCondition(string filterId, IEnumerable<string> filter)
         {
+            Guard.OperationValid(TestModel.LoadedTests != null, "No tests have been loaded");
+
             // 1. Get concrete filter by ID
             var testFilter = _filters.FirstOrDefault(f => f.FilterId == filterId);
             if (testFilter == null)

--- a/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
+++ b/src/GuiRunner/TestModel/Filter/TestFilterBuilder.cs
@@ -36,8 +36,6 @@ namespace TestCentric.Gui.Model.Filter
 
         private TestSelection SelectedTests { get; }
 
-        public Func<IEnumerable<TestNode>> AllTestCaseProvider { get; set; }
-
         private bool EmptyCategorySelected { get; set; }
 
 
@@ -123,10 +121,6 @@ namespace TestCentric.Gui.Model.Filter
         private IList<TestNode> GetAllTestcaseNodes()
         {
             IList<TestNode> result = new List<TestNode>();
-
-            // Use registered callback (if) to get all test cases
-            if (AllTestCaseProvider != null)
-                return AllTestCaseProvider().ToList();
 
             var selection = SelectedTests.ToList();
             foreach (TestNode testNode in selection)

--- a/src/GuiRunner/TestModel/GuiOptions.cs
+++ b/src/GuiRunner/TestModel/GuiOptions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -88,8 +89,8 @@ namespace TestCentric.Gui
             Add("trace", "Set internal trace {LEVEL}. Valid values are Off, Error, Warning, Info or Debug. Verbose is a synonym for Debug.", true,
                 v =>
                 {
-                if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
-                    InternalTraceLevel = v;
+                    if (CheckRequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"))
+                        InternalTraceLevel = v;
                 });
 
             Add("param|p", "Followed by a {KEY-VALUE PAIR} separated by an equals sign. Test code can access the value by name. This option may be repeated.", true,
@@ -114,7 +115,7 @@ namespace TestCentric.Gui
             Add("help|h", "Display the help message and exit.", false,
                 v => ShowHelp = true);
 
-            void Add(string pattern, string description, bool requiresValue, Action<string> action, bool debugOnly=false)
+            void Add(string pattern, string description, bool requiresValue, Action<string?> action, bool debugOnly = false)
             {
                 var option = new Option(pattern, description, requiresValue, action, debugOnly);
                 _options.Add(option);
@@ -128,8 +129,8 @@ namespace TestCentric.Gui
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                Option option;
-                string val;
+                Option? option;
+                string? val;
                 if (TryParseOption(arg, out option, out val))
                 {
                     if (option.RequiresValue)
@@ -152,7 +153,7 @@ namespace TestCentric.Gui
             }
         }
 
-        private bool TryParseOption(string arg, out Option option, out string value)
+        private bool TryParseOption(string arg, [NotNullWhen(true)] out Option? option, out string? value)
         {
             option = null;
             value = null;
@@ -162,7 +163,7 @@ namespace TestCentric.Gui
             string opt = arg.StartsWith("--")
                 ? arg.Substring(2)
                 : arg.Substring(1);
-            string val = null;
+            string? val = null;
             int delim = opt.IndexOfAny(['=', ':']);
             if (delim > 0)
             {
@@ -192,7 +193,7 @@ namespace TestCentric.Gui
         private void InvalidArgumentError(string arg) =>
             ErrorMessages.Add($"Invalid argument: {arg}");
 
-#endregion
+        #endregion
 
         #region Properties
 
@@ -208,15 +209,15 @@ namespace TestCentric.Gui
         private List<string> inputFiles = new List<string>();
         public IList<string> InputFiles { get { return inputFiles; } }
 
-        public string ActiveConfig { get; private set; }
+        public string? ActiveConfig { get; private set; }
 
         // How to Run Tests
 
-        public string GuiLayout { get; private set; }
+        public string? GuiLayout { get; private set; }
         public bool RunAsX86 { get; private set; }
         public int MaxAgents { get; private set; }
-        public string InternalTraceLevel { get; private set; }
-        public string WorkDirectory { get; private set; }
+        public string? InternalTraceLevel { get; private set; }
+        public string? WorkDirectory { get; private set; }
         public IDictionary<string, string> TestParameters { get; } = new Dictionary<string, string>();
         public bool DebugAgent { get; private set; }
 
@@ -291,7 +292,7 @@ namespace TestCentric.Gui
 
             public string Format { get; }
 
-            public string Transform { get; }
+            public string? Transform { get; }
         }
 
         // Error Processing
@@ -313,7 +314,7 @@ namespace TestCentric.Gui
             }
 
             return ErrorMessages.Count == 0;
-        
+
         }
 
         public string GetHelpText()
@@ -343,7 +344,7 @@ namespace TestCentric.Gui
 
         #region Helper Methods
 
-        private bool CheckRequiredValue(string val, string option, params string[] validValues)
+        private bool CheckRequiredValue([NotNullWhen(true)] string? val, string option, params string[] validValues)
         {
             if (string.IsNullOrEmpty(val))
                 ErrorMessages.Add($"Missing required value for option '{option}'");
@@ -364,7 +365,7 @@ namespace TestCentric.Gui
 
     internal class Option
     {
-        public Option(string aliases, string description, bool requiresValue, Action<string> action, bool debugOnly = false)
+        public Option(string aliases, string description, bool requiresValue, Action<string?> action, bool debugOnly = false)
         {
             Aliases = aliases.Split('|');
             Description = description;
@@ -376,7 +377,7 @@ namespace TestCentric.Gui
         public string[] Aliases { get; }
         public bool RequiresValue { get; }
         public string Description { get; }
-        public Action<string> Action { get; }
+        public Action<string?> Action { get; }
         public bool DebugOnly { get; }
         public string HelpText
         {
@@ -386,7 +387,7 @@ namespace TestCentric.Gui
                 var sb = new StringBuilder();
 
                 sb.Append($"{string.Join(", ", Aliases.Select(a => (a.Length == 1 ? "-" : "--") + a))}");
-               
+
                 if (RequiresValue)
                 {
                     var match = Regex.Match(Description, "\\{(.*?)\\}");

--- a/src/GuiRunner/TestModel/GuiOptions.cs
+++ b/src/GuiRunner/TestModel/GuiOptions.cs
@@ -129,9 +129,7 @@ namespace TestCentric.Gui
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                Option? option;
-                string? val;
-                if (TryParseOption(arg, out option, out val))
+                if (TryParseOption(arg, out Option? option, out string? val))
                 {
                     if (option.RequiresValue)
                     {

--- a/src/GuiRunner/TestModel/ITestModel.cs
+++ b/src/GuiRunner/TestModel/ITestModel.cs
@@ -54,7 +54,7 @@ namespace TestCentric.Gui.Model
         bool IsProjectLoaded { get; }
 
         // TestNode hierarchy representing the discovered tests
-        TestNode LoadedTests { get; }
+        TestNode? LoadedTests { get; }
 
         // See if tests are available
         bool HasTests { get; }

--- a/src/GuiRunner/TestModel/ITestModel.cs
+++ b/src/GuiRunner/TestModel/ITestModel.cs
@@ -47,9 +47,9 @@ namespace TestCentric.Gui.Model
 
         #region Current State of the Model
 
-        TestCentricProject TestCentricProject { get; }
+        TestCentricProject? TestCentricProject { get; }
 
-        TestPackage TopLevelPackage { get; }
+        TestPackage? TopLevelPackage { get; }
 
         bool IsProjectLoaded { get; }
 
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Model
         ITestResultManager TestResultManager { get; }
 
         // Summary of last test run
-        ResultSummary ResultSummary { get; }
+        ResultSummary? ResultSummary { get; }
 
         // Is ResultSummary available?
         bool HasResults { get; }
@@ -77,7 +77,7 @@ namespace TestCentric.Gui.Model
         /// Gets or sets the active test item. This is the item
         /// for which details are displayed in the various views.
         /// </summary>
-        ITestItem ActiveTestItem { get; set; }
+        ITestItem? ActiveTestItem { get; set; }
 
         /// <summary>
         ///  Gets or sets the list of selected tests.
@@ -139,7 +139,7 @@ namespace TestCentric.Gui.Model
         /// Open an existing TestCentricProject file.
         /// </summary>
         /// <param name="filePath">Path to the project file</param>
-        TestCentricProject OpenExistingProject(string filePath, GuiOptions options=null);
+        TestCentricProject OpenExistingProject(string filePath, GuiOptions? options=null);
 
         /// <summary>
         /// Open the most recently opened file that still exists, which may be
@@ -186,7 +186,7 @@ namespace TestCentric.Gui.Model
         /// This method is called by both the 'Save' and 'SaveAs' functions of the GUI.
         /// </remarks>
         /// <param name="filePath">The path where the project will be saved</param>
-        void SaveProject(string filePath = null);
+        void SaveProject(string? filePath = null);
 
         /// <summary>
         /// Close the currently open TestCentricProject.
@@ -224,11 +224,11 @@ namespace TestCentric.Gui.Model
         void TransformResults(string targetFile, string xsltFile);
 
         // Get a specific test given its id
-        TestNode GetTestById(string id);
+        TestNode? GetTestById(string id);
 
         // Get the TestPackage represented by a test,if available
-        NUnit.Engine.TestPackage GetPackageForTest(string id);
-        NUnit.Engine.PackageSettings GetPackageSettingsForTest(string id);
+        NUnit.Engine.TestPackage? GetPackageForTest(string id);
+        NUnit.Engine.PackageSettings? GetPackageSettingsForTest(string id);
 
         // Get Agents available for a package
         IList<string> GetAgentsForPackage(NUnit.Engine.TestPackage package);

--- a/src/GuiRunner/TestModel/ResultNode.cs
+++ b/src/GuiRunner/TestModel/ResultNode.cs
@@ -79,7 +79,7 @@ namespace TestCentric.Gui.Model
         /// </summary>
         public bool IsLatestRun { get; set; }
 
-        public string Message
+        public string? Message
         {
             get
             {
@@ -88,17 +88,17 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        public string StackTrace
+        public string? StackTrace
         {
             get { return GetTrimmedInnerText(Xml.SelectSingleNode("failure/stack-trace")); }
         }
 
-        public string Output
+        public string? Output
         {
             get { return GetTrimmedInnerText(Xml.SelectSingleNode("output")); }
         }
 
-        private List<AssertionResult> _assertions;
+        private List<AssertionResult>? _assertions;
         public List<AssertionResult> Assertions
         {
             get
@@ -176,7 +176,7 @@ namespace TestCentric.Gui.Model
 
         private static readonly char[] EOL_CHARS = new char[] { '\r', '\n' };
 
-        private static string GetTrimmedInnerText(XmlNode node)
+        private static string? GetTrimmedInnerText(XmlNode node)
         {
             // In order to control the format, we trim any line-end chars
             // from end of the strings we write and supply them via calls

--- a/src/GuiRunner/TestModel/ResultNode.cs
+++ b/src/GuiRunner/TestModel/ResultNode.cs
@@ -68,7 +68,7 @@ namespace TestCentric.Gui.Model
         #region Public Properties
 
         public TestStatus Status { get; }
-        public string Label { get; }
+        public string? Label { get; }
         public FailureSite Site { get; }
         public ResultState Outcome { get; }
         public int AssertCount { get; }
@@ -121,7 +121,7 @@ namespace TestCentric.Gui.Model
 
         private TestStatus GetStatus()
         {
-            string status = GetAttribute("result");
+            string? status = GetAttribute("result");
             switch (status)
             {
                 case "Passed":
@@ -157,7 +157,7 @@ namespace TestCentric.Gui.Model
 
         private FailureSite GetSite()
         {
-            string site = GetAttribute("site");
+            string? site = GetAttribute("site");
             switch (site)
             {
                 case "Test":

--- a/src/GuiRunner/TestModel/ResultState.cs
+++ b/src/GuiRunner/TestModel/ResultState.cs
@@ -37,7 +37,7 @@ namespace TestCentric.Gui.Model
         /// </summary>
         /// <param name="status">The TestStatus.</param>
         /// <param name="label">The label.</param>
-        public ResultState(TestStatus status, string label) : this(status, label, FailureSite.Test)
+        public ResultState(TestStatus status, string? label) : this(status, label, FailureSite.Test)
         {
         }
 
@@ -56,7 +56,7 @@ namespace TestCentric.Gui.Model
         /// <param name="status">The TestStatus.</param>
         /// <param name="label">The label.</param>
         /// <param name="site">The stage at which the result was produced</param>
-        public ResultState(TestStatus status, string label, FailureSite site)
+        public ResultState(TestStatus status, string? label, FailureSite site)
         {
             Status = status;
             Label = label == null ? string.Empty : label;

--- a/src/GuiRunner/TestModel/ResultSummary.cs
+++ b/src/GuiRunner/TestModel/ResultSummary.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Model
         /// <summary>
         /// overall result of the test run as returned by the engine
         /// </summary>
-        public string OverallResult { get; set; }
+        public string? OverallResult { get; set; }
 
         /// <summary>
         /// Total time in fractional seconds how long the test run lasted as returned by the engine

--- a/src/GuiRunner/TestModel/ResultSummaryCreator.cs
+++ b/src/GuiRunner/TestModel/ResultSummaryCreator.cs
@@ -28,9 +28,9 @@ namespace TestCentric.Gui.Model
 
         private static void Summarize(XmlNode node, ResultSummary summary)
         {
-            string type = node.GetAttribute("type");
-            string status = node.GetAttribute("result");
-            string label = node.GetAttribute("label");
+            string? type = node.GetAttribute("type");
+            string? status = node.GetAttribute("result");
+            string? label = node.GetAttribute("label");
 
             switch (node.Name)
             {
@@ -50,7 +50,7 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        private static void SummarizeTestCase(ResultSummary summary, string status, string label)
+        private static void SummarizeTestCase(ResultSummary summary, string? status, string? label)
         {
             switch (status)
             {
@@ -85,7 +85,7 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        private static void SummarizeTestSuite(XmlNodeList childNodes, ResultSummary summary, string type, string status, string label)
+        private static void SummarizeTestSuite(XmlNodeList childNodes, ResultSummary summary, string? type, string? status, string? label)
         {
             if (status == "Failed" && label == "Invalid")
             {

--- a/src/GuiRunner/TestModel/Services/AssemblyWatcher.cs
+++ b/src/GuiRunner/TestModel/Services/AssemblyWatcher.cs
@@ -12,16 +12,11 @@ namespace TestCentric.Gui.Model.Services
 {
     public class AssemblyWatcher : IAsemblyWatcher
     {
-        private List<FileSystemWatcher> fileWatchers;
-        private List<FileInfo> files;
+        private List<FileSystemWatcher>? fileWatchers;
+        private List<FileInfo>? files;
 
-        protected System.Timers.Timer timer;
-        protected string changedAssemblyPath;
-
-        protected FileInfo GetFileInfo(int index)
-        {
-            return files[index];
-        }
+        protected System.Timers.Timer? timer;
+        protected string? changedAssemblyPath;
 
         public void Setup(int delay, string assemblyFileName)
         {
@@ -30,7 +25,6 @@ namespace TestCentric.Gui.Model.Services
 
         public void Setup(int delay, IList<string> assemblies)
         {
-
             files = new List<FileInfo>();
             fileWatchers = new List<FileSystemWatcher>();
 
@@ -79,7 +73,6 @@ namespace TestCentric.Gui.Model.Services
 
         public void Dispose()
         {
-
             Stop();
 
             if (fileWatchers != null)
@@ -104,20 +97,19 @@ namespace TestCentric.Gui.Model.Services
             timer = null;
         }
 
-        public event AssemblyChangedHandler AssemblyChanged;
+        public event AssemblyChangedHandler? AssemblyChanged;
 
         protected void OnTimer(Object source, ElapsedEventArgs e)
         {
             lock (this)
             {
                 PublishEvent();
-                timer.Enabled = false;
+                timer!.Enabled = false;
             }
         }
 
         protected void OnChanged(object source, FileSystemEventArgs e)
         {
-
             changedAssemblyPath = e.FullPath;
             if (timer != null)
             {
@@ -138,7 +130,7 @@ namespace TestCentric.Gui.Model.Services
         {
             if (AssemblyChanged != null)
             {
-                AssemblyChanged(changedAssemblyPath);
+                AssemblyChanged(changedAssemblyPath!);
             }
         }
     }

--- a/src/GuiRunner/TestModel/Settings/RecentFiles.cs
+++ b/src/GuiRunner/TestModel/Settings/RecentFiles.cs
@@ -24,7 +24,7 @@ namespace TestCentric.Gui.Model.Settings
 
         public string Latest
         {
-            get { return Entries.Count == 0 ? null : Entries[0]; }
+            get { return Entries.Count == 0 ? "" : Entries[0]; }
             set
             {
                 if (Latest != value)

--- a/src/GuiRunner/TestModel/Settings/UserSettings.cs
+++ b/src/GuiRunner/TestModel/Settings/UserSettings.cs
@@ -27,7 +27,7 @@ namespace TestCentric.Gui.Model.Settings
     {
         private IDictionary<ApplicationSettingsBase, string> _settingGroups;
 
-        public event SettingsEventHandler Changed;
+        public event SettingsEventHandler? Changed;
 
         public UserSettings()
         {

--- a/src/GuiRunner/TestModel/TestCentric.Gui.Model.csproj
+++ b/src/GuiRunner/TestModel/TestCentric.Gui.Model.csproj
@@ -11,8 +11,13 @@
     <PropertyGroup>
       <DefineConstants>$(DefineConstants);DISABLE_MINI_GUI</DefineConstants>
     </PropertyGroup>
+
+    <PropertyGroup>
+       <Nullable>enable</Nullable>
+    </PropertyGroup>
 	
     <ItemGroup>
+      <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
 	    <PackageReference Include="NUnit.Common" Version="$(NUnitEngineVersion)" />
 	    <PackageReference Include="NUnit.Engine" Version="$(NUnitEngineVersion)" />
 	    <PackageReference Include="NUnit.Extensibility" Version="$(NUnitEngineVersion)" />

--- a/src/GuiRunner/TestModel/TestCentricProject.cs
+++ b/src/GuiRunner/TestModel/TestCentricProject.cs
@@ -18,7 +18,7 @@ namespace TestCentric.Gui.Model
         public static bool IsProjectFile(string path) => Path.GetExtension(path).ToLower() == ".tcproj";
 
         public string ProjectPath { get; internal set; }
-        internal string OriginalProjectPath { get; set; }
+        internal string? OriginalProjectPath { get; set; }
 
         public TestPackage TopLevelPackage { get; private set; }
 
@@ -54,14 +54,14 @@ namespace TestCentric.Gui.Model
             TopLevelPackage = MakeTestPackage(options);
         }
 
-        public static TestCentricProject LoadFrom(string path, GuiOptions options=null)
+        public static TestCentricProject LoadFrom(string path, GuiOptions? options=null)
         {
             var project = new TestCentricProject();
             project.Load(path);
 
             var workDir = options?.WorkDirectory;
             if (workDir != null)
-                project.ApplySetting(SettingDefinitions.WorkDirectory.WithValue(options.WorkDirectory));
+                project.ApplySetting(SettingDefinitions.WorkDirectory.WithValue(workDir));
 
             return project;
         }
@@ -112,6 +112,7 @@ namespace TestCentric.Gui.Model
         {
             TestFiles = [];
             TopLevelPackage = new TestPackage();
+            ProjectPath = null!;
         }
 
         private void Load(string path)
@@ -155,7 +156,8 @@ namespace TestCentric.Gui.Model
                     if (ProjectPath != OriginalProjectPath && !File.Exists(subPackage.FullName))
                     {
                         // Test file may have been moved as well
-                        var relPath = PathUtils.RelativePath(OriginalProjectPath, subPackage.FullName);
+                        string fullName = subPackage.FullName.ShouldNotBeNull("Subpackage fullname");
+                        var relPath = PathUtils.RelativePath(OriginalProjectPath, fullName);
                         if (relPath is not null)
                         {
                             var newFile = Path.Combine(ProjectPath, relPath);
@@ -165,7 +167,8 @@ namespace TestCentric.Gui.Model
                     }
 
                     // Add to TestFiles whether it exists or not
-                    TestFiles.Add(subPackage.FullName);
+                    string subPackageFullName = subPackage.FullName.ShouldNotBeNull("Subpackage fullname");
+                    TestFiles.Add(subPackageFullName);
                 }
 
                 bool FindTestCentricProjectElement()
@@ -217,7 +220,8 @@ namespace TestCentric.Gui.Model
             if (subPackage != null)
             {
                 TopLevelPackage.SubPackages.Remove(subPackage);
-                TestFiles.Remove(subPackage.FullName);
+                string subPackageFullName = subPackage.FullName.ShouldNotBeNull("Subpackage fullname");
+                TestFiles.Remove(subPackageFullName);
             }
         }
 
@@ -310,7 +314,7 @@ namespace TestCentric.Gui.Model
             {
                 string name = xmlReader.Name;
                 string value = xmlReader.Value;
-                SettingDefinition settingDefinition = SettingDefinitions.Lookup(name);
+                SettingDefinition? settingDefinition = SettingDefinitions.Lookup(name);
                 bool result2;
                 int result3;
                 if (settingDefinition != null)

--- a/src/GuiRunner/TestModel/TestCentricRunner.cs
+++ b/src/GuiRunner/TestModel/TestCentricRunner.cs
@@ -35,7 +35,7 @@ namespace TestCentric.Gui.Model
 
         private TestEventDispatcher TestEvents { get; }
 
-        private ITestRunner ActiveTestRun { get; set; }
+        private ITestRunner? ActiveTestRun { get; set; }
 
         public bool IsTestRunning => ActiveTestRun != null && ActiveTestRun.IsTestRunning;
 
@@ -47,7 +47,7 @@ namespace TestCentric.Gui.Model
         /// <summary>
         /// Explore tests from a package
         /// </summary>
-        public TestNode Explore(TestPackage package)
+        public TestNode? Explore(TestPackage package)
         {
             Guard.ArgumentNotNull(package, nameof(package));
 
@@ -55,7 +55,7 @@ namespace TestCentric.Gui.Model
             var runner = TestEngine.GetRunner(package);
             log.Debug($"Got {runner.GetType().Name} for package");
 
-            TestNode loadedTests = null;
+            TestNode? loadedTests = null;
             try
             {
                 log.Debug("Loading tests");
@@ -106,9 +106,9 @@ namespace TestCentric.Gui.Model
                 // up the line when it is more convenient to do so, replacing it with
                 // two separate methods as in the ITestRunner interface.
                 if (force)
-                    ActiveTestRun.ForcedStop();
+                    ActiveTestRun?.ForcedStop();
                 else
-                    ActiveTestRun.RequestStop();
+                    ActiveTestRun?.RequestStop();
                 ResetActiveTestRun();
             });
         }

--- a/src/GuiRunner/TestModel/TestEventArgs.cs
+++ b/src/GuiRunner/TestModel/TestEventArgs.cs
@@ -73,7 +73,7 @@ namespace TestCentric.Gui.Model
 
     public class TestOutputEventArgs : TestEventArgs
     {
-        public TestOutputEventArgs(string testName, string stream, string text)
+        public TestOutputEventArgs(string testName, string? stream, string text)
         {
             TestName = testName;
             Stream = stream;
@@ -81,7 +81,7 @@ namespace TestCentric.Gui.Model
         }
 
         public string TestName { get; }
-        public string Stream { get; }
+        public string? Stream { get; }
         public string Text { get; }
     }
 

--- a/src/GuiRunner/TestModel/TestEventDispatcher.cs
+++ b/src/GuiRunner/TestModel/TestEventDispatcher.cs
@@ -217,15 +217,15 @@ namespace TestCentric.Gui.Model
                     break;
 
                 case "test-output":
-                    string testName = xmlNode.GetAttribute("testname");
-                    string stream = xmlNode.GetAttribute("stream");
+                    string testName = xmlNode.GetAttribute("testname").ShouldNotBeNull("XML attribute testname");
+                    string? stream = xmlNode.GetAttribute("stream");
                     string text = xmlNode.InnerText;
                     InvokeHandler(TestOutput, new TestOutputEventArgs(testName, stream, text));
                     break;
 
                 case "unhandled-exception":
-                    string message = xmlNode.GetAttribute("message");
-                    string stackTrace = xmlNode.GetAttribute("stacktrace");
+                    string message = xmlNode.GetAttribute("message").ShouldNotBeNull("XML attribute message");
+                    string stackTrace = xmlNode.GetAttribute("stacktrace").ShouldNotBeNull("XML attribute stacktrace");
 
                     InvokeHandler(UnhandledException, new UnhandledExceptionEventArgs(message, stackTrace));
                     break;
@@ -274,7 +274,7 @@ namespace TestCentric.Gui.Model
                     foreach (var child in projectNode.Select((tn) => tn.Type == "Assembly"))
                     {
                         projectInfo.AssembliesToRun++;
-                        _projectLookup.Add(child.GetAttribute("id"), projectInfo);
+                        _projectLookup.Add(child.GetAttribute("id").ShouldNotBeNull("XML attribute id"), projectInfo);
                     }
                 }
                 catch (Exception ex)

--- a/src/GuiRunner/TestModel/TestEventDispatcher.cs
+++ b/src/GuiRunner/TestModel/TestEventDispatcher.cs
@@ -257,6 +257,8 @@ namespace TestCentric.Gui.Model
 
         private void InitializeProjectDictionary()
         {
+            Guard.OperationValid(_model.LoadedTests != null, "No tests have been loaded");
+
             // Initialize Dictionary to look up projects to which assemblies belong
             _projectLookup = new Dictionary<string, ProjectInfo>();
 

--- a/src/GuiRunner/TestModel/TestEventDispatcher.cs
+++ b/src/GuiRunner/TestModel/TestEventDispatcher.cs
@@ -35,6 +35,7 @@ namespace TestCentric.Gui.Model
         public TestEventDispatcher(TestModel model)
         {
             _model = model;
+            _projectLookup = new Dictionary<string, ProjectInfo>();
         }
 
         #region Public Methods to Fire Events
@@ -129,41 +130,41 @@ namespace TestCentric.Gui.Model
         #region ITestEvents Implementation
 
         // TestCentricProject loading events
-        public event TestEventHandler TestCentricProjectLoaded;
-        public event TestEventHandler TestCentricProjectUnloaded;
+        public event TestEventHandler? TestCentricProjectLoaded;
+        public event TestEventHandler? TestCentricProjectUnloaded;
 
         // Test loading events
-        public event TestFilesLoadingEventHandler TestsLoading;
-        public event TestEventHandler TestsReloading;
-        public event TestEventHandler TestsUnloading;
-        public event TestEventHandler TestChanged;
+        public event TestFilesLoadingEventHandler? TestsLoading;
+        public event TestEventHandler? TestsReloading;
+        public event TestEventHandler? TestsUnloading;
+        public event TestEventHandler? TestChanged;
 
-        public event TestNodeEventHandler TestLoaded;
-        public event TestNodeEventHandler TestReloaded;
-        public event TestEventHandler TestUnloaded;
+        public event TestNodeEventHandler? TestLoaded;
+        public event TestNodeEventHandler? TestReloaded;
+        public event TestEventHandler? TestUnloaded;
 
-        public event TestLoadFailureEventHandler TestLoadFailure;
+        public event TestLoadFailureEventHandler? TestLoadFailure;
 
         // Test running events
-        public event RunStartingEventHandler RunStarting;
-        public event TestResultEventHandler RunFinished;
+        public event RunStartingEventHandler? RunStarting;
+        public event TestResultEventHandler? RunFinished;
 
-        public event TestNodeEventHandler SuiteStarting;
-        public event TestResultEventHandler SuiteFinished;
+        public event TestNodeEventHandler? SuiteStarting;
+        public event TestResultEventHandler? SuiteFinished;
 
-        public event TestNodeEventHandler TestStarting;
-        public event TestResultEventHandler TestFinished;
+        public event TestNodeEventHandler? TestStarting;
+        public event TestResultEventHandler? TestFinished;
 
-        public event TestOutputEventHandler TestOutput;
+        public event TestOutputEventHandler? TestOutput;
 
-        public event UnhandledExceptionEventHandler UnhandledException;
+        public event UnhandledExceptionEventHandler? UnhandledException;
 
         // Test Selection Event
-        public event TestItemEventHandler SelectedItemChanged;
-        public event TestSelectionEventHandler SelectedTestsChanged;
+        public event TestItemEventHandler? SelectedItemChanged;
+        public event TestSelectionEventHandler? SelectedTestsChanged;
 
-        public event TestEventHandler CategorySelectionChanged;
-        public event TestEventHandler TestFilterChanged;
+        public event TestEventHandler? CategorySelectionChanged;
+        public event TestEventHandler? TestFilterChanged;
 
         #endregion
 
@@ -235,7 +236,7 @@ namespace TestCentric.Gui.Model
 
         #region Helper Methods
 
-        private void InvokeHandler(MulticastDelegate handlerList, EventArgs e)
+        private void InvokeHandler(MulticastDelegate? handlerList, EventArgs e)
         {
             if (handlerList == null)
                 return;
@@ -244,13 +245,13 @@ namespace TestCentric.Gui.Model
             foreach (Delegate handler in handlerList.GetInvocationList())
             {
                 object target = handler.Target;
-                System.Windows.Forms.Control control
+                System.Windows.Forms.Control? control
                     = target as System.Windows.Forms.Control;
 
                 if (control != null && control.InvokeRequired)
-                        control.Invoke(handler, args);
-                    else
-                        handler.Method.Invoke(target, args);
+                    control.Invoke(handler, args);
+                else
+                    handler.Method.Invoke(target, args);
             }
         }
 
@@ -274,7 +275,7 @@ namespace TestCentric.Gui.Model
                         _projectLookup.Add(child.GetAttribute("id"), projectInfo);
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     log.Error("Unexpected exception", ex);
                 }

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -41,7 +42,7 @@ namespace TestCentric.Gui.Model
 
         #region Constructor and Creation
 
-        public TestModel(ITestEngine testEngine, GuiOptions options = null)
+        public TestModel(ITestEngine testEngine, GuiOptions? options = null)
         {
             TestEngine = testEngine;
             Options = options ?? new GuiOptions();
@@ -56,6 +57,8 @@ namespace TestCentric.Gui.Model
             TestCentricRunner = new TestCentricRunner(this, testEngine, _events);
             TestCentricTestFilter = new TestCentricTestFilter(this, () => _events.FireTestFilterChanged());
             TestResultManager = new TestResultManager(this);
+            AvailableCategories = new List<string>();
+            SelectedCategories = new List<string>();
 
             _extensionService = Services.GetService<IExtensionService>();
             _extensionService.InstallExtensions();          
@@ -78,7 +81,7 @@ namespace TestCentric.Gui.Model
         }
 
         // Public for testing
-        public static ITestModel CreateTestModel(ITestEngine testEngine, GuiOptions options = null)
+        public static ITestModel CreateTestModel(ITestEngine testEngine, GuiOptions? options = null)
         {
             if (options is null)
                 options = new GuiOptions();
@@ -136,7 +139,7 @@ namespace TestCentric.Gui.Model
         public List<string> KnownProjectExtensions { get; } = new List<string>();
 
         // Runtime Support
-        private List<NUnit.Engine.IRuntimeFramework> _runtimes;
+        private List<NUnit.Engine.IRuntimeFramework>? _runtimes;
         public IList<NUnit.Engine.IRuntimeFramework> AvailableRuntimes
         {
             get
@@ -149,7 +152,7 @@ namespace TestCentric.Gui.Model
         }
 
         // Result Format Support
-        private List<string> _resultFormats;
+        private List<string>? _resultFormats;
         public IEnumerable<string> ResultFormats
         {
             get
@@ -170,13 +173,19 @@ namespace TestCentric.Gui.Model
         /// <summary>
         /// The current TestProject
         /// </summary>
-        public TestCentricProject TestCentricProject { get; set; }
+        public TestCentricProject? TestCentricProject { get; set; }
 
-        public TestPackage TopLevelPackage => TestCentricProject?.TopLevelPackage;
+        public TestPackage? TopLevelPackage => TestCentricProject?.TopLevelPackage;
 
+        [MemberNotNullWhen(true, nameof(TestCentricProject))]
+        [MemberNotNullWhen(true, nameof(TopLevelPackage))]
         public bool IsProjectLoaded => TestCentricProject != null;
 
         public TestNode? LoadedTests { get; private set; }
+
+        [MemberNotNullWhen(true, nameof(TestCentricProject))]
+        [MemberNotNullWhen(true, nameof(TopLevelPackage))]
+        [MemberNotNullWhen(true, nameof(LoadedTests))]
         public bool HasTests => LoadedTests != null;
 
         public IList<string> AvailableCategories { get; private set; }
@@ -185,19 +194,26 @@ namespace TestCentric.Gui.Model
 
         public ITestResultManager TestResultManager { get; }
 
-        public ResultSummary ResultSummary { get; internal set; }
+        public ResultSummary? ResultSummary { get; internal set; }
+
+        [MemberNotNullWhen(true, nameof(ResultSummary))]
         public bool HasResults => ResultSummary != null;
 
         /// <summary>
         /// Gets or sets the active test item. This is the item
         /// for which details are displayed in the various views.
         /// </summary>
-        public ITestItem ActiveTestItem
+        public ITestItem? ActiveTestItem
         {
             get { return _activeItem; }
-            set { _activeItem = value; _events.FireActiveItemChanged(_activeItem); }
+            set 
+            { 
+                Guard.OperationValid(value != null, "Cannot set ActiveTestItem to null");
+                _activeItem = value; 
+                _events.FireActiveItemChanged(_activeItem); 
+            }
         }
-        private ITestItem _activeItem;
+        private ITestItem? _activeItem;
 
         /// <summary>
         ///  Gets or sets the list of selected tests.
@@ -207,7 +223,7 @@ namespace TestCentric.Gui.Model
             get {  return _selectedTests; }
             set { _selectedTests = value; _events?.FireSelectedTestsChanged(_selectedTests); }
         }
-        private TestSelection _selectedTests;
+        private TestSelection _selectedTests = new TestSelection();
 
         public List<string> SelectedCategories { get; private set; }
 
@@ -233,20 +249,20 @@ namespace TestCentric.Gui.Model
 
             // A possibly empty filter to be applied to the selected tests.
             // NOTE: Currently, filter is always empty
-            public TestFilter CategoryFilter { get; }
+            public TestFilter? CategoryFilter { get; }
 
             public bool DebuggingRequested { get; }
 
             public bool IsEmpty => SelectedTests.Count() == 0;
 
-            public TestRunSpecification(TestSelection selectedTests, TestFilter filter, bool debuggingRequested)
+            public TestRunSpecification(TestSelection selectedTests, TestFilter? filter, bool debuggingRequested)
             {
                 SelectedTests = selectedTests;
                 CategoryFilter = filter;
                 DebuggingRequested = debuggingRequested;
             }
 
-            public TestRunSpecification(TestNode testNode, TestFilter filter, bool debuggingRequested)
+            public TestRunSpecification(TestNode testNode, TestFilter? filter, bool debuggingRequested)
             {
                 SelectedTests = new TestSelection { testNode };
                 CategoryFilter = filter;
@@ -359,7 +375,7 @@ namespace TestCentric.Gui.Model
                 : CreateNewProject(wrapperProjectPath, options);
         }
 
-        private HashSet<string>_knownTestFileExtensions;
+        private HashSet<string>?_knownTestFileExtensions;
         private HashSet<string> KnownTestFileExtensions
         {
             get
@@ -400,7 +416,7 @@ namespace TestCentric.Gui.Model
 
         public void RemoveTestPackage(NUnit.Engine.TestPackage subPackage)
         {
-            if (!IsProjectLoaded || IsTestRunning || subPackage == null || TopLevelPackage.SubPackages.Count <= 1)
+            if (!IsProjectLoaded || IsTestRunning || subPackage == null || TopLevelPackage?.SubPackages.Count <= 1)
                 return;
 
             TestCentricProject.RemoveSubPackage(subPackage);
@@ -409,7 +425,7 @@ namespace TestCentric.Gui.Model
             _events.FireTestCentricProjectLoaded();
         }
 
-        public TestCentricProject OpenExistingProject(string projectPath, GuiOptions options=null)
+        public TestCentricProject OpenExistingProject(string projectPath, GuiOptions? options=null)
         {
             if (IsProjectLoaded)
                 CloseProject();
@@ -486,8 +502,9 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        public void SaveProject(string filename = null)
+        public void SaveProject(string? filename = null)
         {
+            Guard.OperationValid(IsProjectLoaded, "Cannot save project");
             Guard.OperationValid(filename is not null || TestCentricProject.ProjectPath is not null,
                 "Cannot save a previously unsaved project without providing a file name.");
 
@@ -515,6 +532,7 @@ namespace TestCentric.Gui.Model
 
         public void LoadTests(IList<string> files)
         {
+            Guard.OperationValid(IsProjectLoaded, "No project created");
             log.Info($"Loading test files '{string.Join("', '", files.ToArray())}'");
             if (IsProjectLoaded && LoadedTests != null)
                 UnloadTests();
@@ -573,7 +591,7 @@ namespace TestCentric.Gui.Model
         private void MapTestsToPackages()
         {
             _packageMap.Clear();
-            MapTestToPackage(LoadedTests!, TopLevelPackage);
+            MapTestToPackage(LoadedTests!, TopLevelPackage!);
         }
 
         private void MapTestToPackage(TestNode test, NUnit.Engine.TestPackage package)
@@ -584,7 +602,7 @@ namespace TestCentric.Gui.Model
                 MapTestToPackage(test.Children[index], package.SubPackages[index]);
         }
 
-        public IList<string> GetAgentsForPackage(NUnit.Engine.TestPackage package = null)
+        public IList<string> GetAgentsForPackage(NUnit.Engine.TestPackage? package = null)
         {
             if (package == null)
                 package = TopLevelPackage;
@@ -603,7 +621,7 @@ namespace TestCentric.Gui.Model
 
             TestCentricTestFilter.ResetAll(true);
             LoadedTests = null;
-            AvailableCategories = null;
+            AvailableCategories = new List<string>();
             ClearResults();
             _assemblyWatcher.Stop();
 
@@ -612,7 +630,7 @@ namespace TestCentric.Gui.Model
 
         public void ReloadTests()
         {
-            Guard.OperationValid(LoadedTests != null, "No tests have been loaded");
+            Guard.OperationValid(HasTests, "No tests have been loaded");
 
             _events.FireTestsReloading();
 
@@ -725,7 +743,7 @@ namespace TestCentric.Gui.Model
             resultWriter?.WriteResultFile(results.Xml, targetFile);
         }
 
-        public TestNode GetTestById(string id)
+        public TestNode? GetTestById(string id)
         {
             return _testsById.TryGetValue(id, out var node) ? node : null;
         }
@@ -740,12 +758,12 @@ namespace TestCentric.Gui.Model
             return _lastTestRun.ContainTest(testNode);
         }
 
-        public NUnit.Engine.PackageSettings GetPackageSettingsForTest(string id)
+        public NUnit.Engine.PackageSettings? GetPackageSettingsForTest(string id)
         {
             return GetPackageForTest(id)?.Settings;
         }
 
-        public NUnit.Engine.TestPackage GetPackageForTest(string id)
+        public NUnit.Engine.TestPackage? GetPackageForTest(string id)
         {
             return _packageMap.ContainsKey(id) 
                 ? _packageMap[id] 
@@ -863,10 +881,9 @@ namespace TestCentric.Gui.Model
         private void RunTests(TestRunSpecification runSpec)
         {
             log.Debug("RunningTests");
-            if (runSpec == null)
-                throw new ArgumentNullException(nameof(runSpec));
-            if (_lastTestRun == null)
-                throw new InvalidOperationException("Field '_lastTestRun' is null");
+            Guard.ArgumentNotNull(runSpec, nameof(runSpec));
+            Guard.OperationValid(_lastTestRun != null, "Field '_lastTestRun' is null");
+            Guard.OperationValid(HasTests, "No tests loaded to run");
 
             // Create a test filter incorporating the selected tests, the tree grouping
             // and the UI tree filter (category, outcome or duration)

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -176,7 +176,7 @@ namespace TestCentric.Gui.Model
 
         public bool IsProjectLoaded => TestCentricProject != null;
 
-        public TestNode LoadedTests { get; private set; }
+        public TestNode? LoadedTests { get; private set; }
         public bool HasTests => LoadedTests != null;
 
         public IList<string> AvailableCategories { get; private set; }
@@ -557,7 +557,7 @@ namespace TestCentric.Gui.Model
         private void BuildTestIndex()
         {
             _testsById.Clear();
-            BuildTestIndex(LoadedTests);
+            BuildTestIndex(LoadedTests!);
         }
 
         private void BuildTestIndex(TestNode node)
@@ -573,7 +573,7 @@ namespace TestCentric.Gui.Model
         private void MapTestsToPackages()
         {
             _packageMap.Clear();
-            MapTestToPackage(LoadedTests, TopLevelPackage);
+            MapTestToPackage(LoadedTests!, TopLevelPackage);
         }
 
         private void MapTestToPackage(TestNode test, NUnit.Engine.TestPackage package)
@@ -612,6 +612,8 @@ namespace TestCentric.Gui.Model
 
         public void ReloadTests()
         {
+            Guard.OperationValid(LoadedTests != null, "No tests have been loaded");
+
             _events.FireTestsReloading();
 
             TestEngine.GetRunner(TopLevelPackage).Reload();
@@ -698,6 +700,8 @@ namespace TestCentric.Gui.Model
         // Called by the presenter when user clicks "Save Results As".
         public void SaveResults(string filePath, string format = "nunit3")
         {
+            Guard.OperationValid(LoadedTests != null, "No tests have been loaded");
+
             log.Debug($"Saving test results to {filePath} in {format} format");
 
             try
@@ -714,6 +718,8 @@ namespace TestCentric.Gui.Model
 
         public void TransformResults(string targetFile, string xsltFile)
         {
+            Guard.OperationValid(LoadedTests != null, "No tests have been loaded");
+
             var resultWriter = Services.GetService<IResultService>().GetResultWriter("user", [xsltFile]);
             var results = TestResultManager.GetResultForTest(LoadedTests.Id);
             resultWriter?.WriteResultFile(results.Xml, targetFile);
@@ -879,7 +885,8 @@ namespace TestCentric.Gui.Model
         public IList<string> GetAvailableCategories()
         {
             var categories = new Dictionary<string, string>();
-            CollectCategories(LoadedTests, categories);
+            if (LoadedTests != null)
+                CollectCategories(LoadedTests, categories);
 
             var list = new List<string>(categories.Values);
             list.Sort();

--- a/src/GuiRunner/TestModel/TestModel.cs
+++ b/src/GuiRunner/TestModel/TestModel.cs
@@ -707,7 +707,7 @@ namespace TestCentric.Gui.Model
             try
             {
                 var resultWriter = Services.GetService<IResultService>().GetResultWriter(format, []);
-                var results = TestResultManager.GetResultForTest(LoadedTests.Id);
+                var results = TestResultManager.GetResultForTest(LoadedTests.Id).ShouldNotBeNull("No test result exists");
                 resultWriter.WriteResultFile(results.Xml, Path.Combine(WorkDirectory, filePath));
             }
             catch(Exception ex)
@@ -721,7 +721,7 @@ namespace TestCentric.Gui.Model
             Guard.OperationValid(LoadedTests != null, "No tests have been loaded");
 
             var resultWriter = Services.GetService<IResultService>().GetResultWriter("user", [xsltFile]);
-            var results = TestResultManager.GetResultForTest(LoadedTests.Id);
+            var results = TestResultManager.GetResultForTest(LoadedTests.Id).ShouldNotBeNull("No test result exists");
             resultWriter?.WriteResultFile(results.Xml, targetFile);
         }
 

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -46,6 +46,14 @@ namespace TestCentric.Gui.Model
                 Xml.AddAttribute("type", "TestRun");
                 Xml.AddAttribute("runstate", "Runnable");
             }
+
+            // Initialize properties once, check mandatory properties for null values
+            IsSuite = Xml.Name == "test-suite" || Xml.Name == "test-run";
+            Id = GetAttribute("id").ShouldNotBeNull("XML attribute id");
+            Name = Xml.GetAttribute("name").ShouldNotBeNull("XML attribute name");
+            Type = IsSuite ? GetAttribute("type").ShouldNotBeNull("XML attribute type") : "TestCase";
+            FullName = GetAttribute("fullname") ?? Name;
+            TestCount = IsSuite ? GetAttribute("testcasecount", 0) : 1;
         }
 
         public TestNode(string xmlText) : this(XmlHelper.CreateXmlNode(xmlText)) { }
@@ -54,7 +62,7 @@ namespace TestCentric.Gui.Model
 
         #region ITestItem Implementation
 
-        public string Name => Xml.GetAttribute("name").ShouldNotBeNull("XML attribute name");
+        public string Name { get; }
 
         #endregion
 
@@ -62,10 +70,10 @@ namespace TestCentric.Gui.Model
 
         public XmlNode Xml { get; }
 
-        public bool IsSuite => Xml.Name == "test-suite" || Xml.Name == "test-run";
-        public string Id => GetAttribute("id").ShouldNotBeNull("XML attribute id");
-        public string FullName => GetAttribute("fullname") ?? Name;
-        public string Type => IsSuite ? GetAttribute("type").ShouldNotBeNull("XML attribute type") : "TestCase";
+        public bool IsSuite { get; }
+        public string Id { get; }
+        public string FullName { get; }
+        public string Type { get; }
         public bool IsAssembly => IsSuite && Type == "Assembly";
         public bool IsFixture => IsSuite && Type == "TestFixture";
         public bool IsProject => IsSuite && Type == "Project";
@@ -81,7 +89,7 @@ namespace TestCentric.Gui.Model
         /// </summary>
         public bool FilteredOut { get; set; }
 
-        public int TestCount => IsSuite ? GetAttribute("testcasecount", 0) : 1;
+        public int TestCount { get; }
         public RunState RunState => GetRunState();
 
         public TestNode? Parent { get; private set; }

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -83,9 +83,9 @@ namespace TestCentric.Gui.Model
         public int TestCount => IsSuite ? GetAttribute("testcasecount", 0) : 1;
         public RunState RunState => GetRunState();
 
-        public TestNode Parent { get; private set; }
+        public TestNode? Parent { get; private set; }
 
-        private List<TestNode> _children;
+        private List<TestNode>? _children;
         public IList<TestNode> Children
         {
             get
@@ -116,7 +116,7 @@ namespace TestCentric.Gui.Model
             return Xml.GetAttribute(name, defaultValue);
         }
 
-        public string GetProperty(string name)
+        public string? GetProperty(string name)
         {
             var propNode = Xml.SelectSingleNode("properties/property[@name='" + name + "']");
 

--- a/src/GuiRunner/TestModel/TestNode.cs
+++ b/src/GuiRunner/TestModel/TestNode.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using NUnit;
 
 namespace TestCentric.Gui.Model
 {
@@ -53,7 +54,7 @@ namespace TestCentric.Gui.Model
 
         #region ITestItem Implementation
 
-        public string Name => Xml.GetAttribute("name");
+        public string Name => Xml.GetAttribute("name").ShouldNotBeNull("XML attribute name");
 
         #endregion
 
@@ -62,9 +63,9 @@ namespace TestCentric.Gui.Model
         public XmlNode Xml { get; }
 
         public bool IsSuite => Xml.Name == "test-suite" || Xml.Name == "test-run";
-        public string Id => GetAttribute("id");
+        public string Id => GetAttribute("id").ShouldNotBeNull("XML attribute id");
         public string FullName => GetAttribute("fullname") ?? Name;
-        public string Type => IsSuite ? GetAttribute("type") : "TestCase";
+        public string Type => IsSuite ? GetAttribute("type").ShouldNotBeNull("XML attribute type") : "TestCase";
         public bool IsAssembly => IsSuite && Type == "Assembly";
         public bool IsFixture => IsSuite && Type == "TestFixture";
         public bool IsProject => IsSuite && Type == "Project";
@@ -106,7 +107,7 @@ namespace TestCentric.Gui.Model
 
         #region Additional Public Methods
 
-        public string GetAttribute(string name)
+        public string? GetAttribute(string name)
         {
             return Xml.GetAttribute(name);
         }
@@ -130,7 +131,11 @@ namespace TestCentric.Gui.Model
 
             var result = new List<string>();
             foreach (XmlNode propNode in propList)
-                result.Add(propNode.GetAttribute("value"));
+            {
+                string? propValue = propNode.GetAttribute("value");
+                if (propValue != null)
+                    result.Add(propValue);
+            }
 
             return result.ToArray();
         }

--- a/src/GuiRunner/TestModel/TestResultManager.cs
+++ b/src/GuiRunner/TestModel/TestResultManager.cs
@@ -6,6 +6,7 @@
 namespace TestCentric.Gui.Model
 {
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using NUnit;
 
@@ -14,7 +15,7 @@ namespace TestCentric.Gui.Model
         /// <summary>
         /// Get result by a test ID
         /// </summary>
-        ResultNode GetResultForTest(string id);
+        ResultNode? GetResultForTest(string id);
 
         /// <summary>
         /// Add one test result
@@ -64,7 +65,7 @@ namespace TestCentric.Gui.Model
         private ITestModel Model { get; }
 
         /// <inheritdoc />
-        public ResultNode GetResultForTest(string id)
+        public ResultNode? GetResultForTest(string id)
         {
             if (string.IsNullOrEmpty(id))
                 return null;
@@ -81,7 +82,7 @@ namespace TestCentric.Gui.Model
                 if (resultNode.Outcome.Equals(ResultState.Explicit))
                     return oldResult;
 
-                if (resultNode.IsSuite && UpdateResultFromPreviousTestRun(resultNode, out ResultState newTestResult))
+                if (resultNode.IsSuite && UpdateResultFromPreviousTestRun(resultNode, out ResultState? newTestResult))
                     resultNode = ResultNode.Create(resultNode.Xml, newTestResult);
             }
 
@@ -116,7 +117,7 @@ namespace TestCentric.Gui.Model
             // Search for TestFullName of all old results in new TestNodes
             foreach (ResultNode oldResult in oldResults)
             {
-                TestNode testNode = TryGetTestNode(Model.LoadedTests, oldResult.FullName);
+                TestNode? testNode = TryGetTestNode(Model.LoadedTests, oldResult.FullName);
                 if (testNode != null)
                 {
                     // Test for result still exists: Create new result by keeping result content, but use current test ID
@@ -126,14 +127,14 @@ namespace TestCentric.Gui.Model
             }
         }
 
-        private TestNode TryGetTestNode(TestNode testNode, string fullName)
+        private TestNode? TryGetTestNode(TestNode testNode, string fullName)
         {
             if (testNode.FullName == fullName)
                 return testNode;
 
             foreach (TestNode childNode in testNode.Children)
             {
-                TestNode foundNode = TryGetTestNode(childNode, fullName);
+                TestNode? foundNode = TryGetTestNode(childNode, fullName);
                 if (foundNode != null)
                     return foundNode;
             }
@@ -168,7 +169,7 @@ namespace TestCentric.Gui.Model
 
             foreach (TestNode child in node.Children)
             {
-                ResultNode childResult = GetResultForTest(child.Id);
+                ResultNode? childResult = GetResultForTest(child.Id);
                 if (childResult != null)
                     results.Add(childResult);
             }
@@ -180,7 +181,7 @@ namespace TestCentric.Gui.Model
         /// If a TestNode was not executed entirely in the current test run
         /// Some child TestNodes might contain contracting TestResults from a previous test run
         /// </summary>
-        private bool UpdateResultFromPreviousTestRun(ResultNode testResult, out ResultState newResultState)
+        private bool UpdateResultFromPreviousTestRun(ResultNode testResult, [NotNullWhen(true)] out ResultState? newResultState)
         {
             newResultState = null;
             IList<ResultNode> childResults = GetChildTestResults(testResult);

--- a/src/GuiRunner/TestModel/TestResultManager.cs
+++ b/src/GuiRunner/TestModel/TestResultManager.cs
@@ -7,6 +7,7 @@ namespace TestCentric.Gui.Model
 {
     using System.Collections.Generic;
     using System.Linq;
+    using NUnit;
 
     public interface ITestResultManager
     {
@@ -106,6 +107,8 @@ namespace TestCentric.Gui.Model
         /// <inheritdoc />
         public void ReloadTestResults()
         {
+            Guard.OperationValid(Model.LoadedTests != null, "No tests have been loaded");
+
             // Get all existing test results
             List<ResultNode> oldResults = Results.Values.ToList();
             ClearResults();

--- a/src/GuiRunner/TestModel/TestResultManager.cs
+++ b/src/GuiRunner/TestModel/TestResultManager.cs
@@ -151,8 +151,9 @@ namespace TestCentric.Gui.Model
             {
                 if (!result.IsSuite && result.Outcome.Status == TestStatus.Failed)
                 {
-                    TestNode testNode = Model.GetTestById(result.Id);
-                    failedTests.Add(testNode);
+                    TestNode? testNode = Model.GetTestById(result.Id);
+                    if (testNode != null)
+                        failedTests.Add(testNode);
                 }
             }
 
@@ -163,7 +164,7 @@ namespace TestCentric.Gui.Model
         {
             var results = new List<ResultNode>();
 
-            TestNode node = Model.GetTestById(resultNode.Id);
+            TestNode? node = Model.GetTestById(resultNode.Id);
             if (node == null)
                 return results;
 

--- a/src/GuiRunner/TestModel/TestStartNotice.cs
+++ b/src/GuiRunner/TestModel/TestStartNotice.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -16,8 +16,8 @@ namespace TestCentric.Gui.Model
             FullName = xmlNode.GetAttribute("fullname");
         }
 
-        public string Id { get; private set; }
-        public string Name { get; private set; }
-        public string FullName { get; private set; }
+        public string? Id { get; private set; }
+        public string? Name { get; private set; }
+        public string? FullName { get; private set; }
     }
 }

--- a/src/GuiRunner/TestModel/TreeConfiguration.cs
+++ b/src/GuiRunner/TestModel/TreeConfiguration.cs
@@ -33,7 +33,7 @@ namespace TestCentric.Gui.Model
     /// </summary>
     public class TreeConfiguration : ITreeConfiguration
     {
-        public event SettingsEventHandler Changed;
+        public event SettingsEventHandler? Changed;
 
         private string _displayFormat = "NUNIT_TREE";
         public string DisplayFormat

--- a/src/GuiRunner/TestModel/XmlHelper.cs
+++ b/src/GuiRunner/TestModel/XmlHelper.cs
@@ -82,7 +82,7 @@ namespace TestCentric
         /// <param name="result">The result.</param>
         /// <param name="name">The name.</param>
         /// <returns></returns>
-        public static string GetAttribute(this XmlNode result, string name)
+        public static string? GetAttribute(this XmlNode result, string name)
         {
             XmlAttribute attr = result.Attributes[name];
 
@@ -130,7 +130,7 @@ namespace TestCentric
         /// <returns></returns>
         public static DateTime GetAttribute(this XmlNode result, string name, DateTime defaultValue)
         {
-            string dateStr = GetAttribute(result, name);
+            string? dateStr = GetAttribute(result, name);
             if (dateStr == null)
                 return defaultValue;
 


### PR DESCRIPTION
This PR contributes to #1492 by activating nullability checks for project `TestCentric.Gui.Model`
It includes many code changes. Therefore, I splitted my work into separate commits to keep track of everything during the review.
Here some comments:

1. Commit:
Enabling Nullability and add nuget package Nullable

2. Commit:
Contains all simple fixes for nullability compile errors. Mainly by applying the `?` operator. The only exception is class `AssemblyResolver` in which I also used the `!` operator.

3. Commit:
All of the following commits are not just local fixes; they also affect other classes. This commit starts with adapting class `TestCentricRunner`, but that leads to property `TestModel.LoadedTests` which also needs to be adjusted. In some cases I applied a `Guard.OperationValid()` statement, in which I expect that LoadedTests should never be null.

4. Commit:
The actual code change is in the last file `XmlHelper.cs`. All other changes are resulting adjustments. For example, this includes adjustments to class `TestNode`. However, this commit was before your suggestion about moving the assignment and check into the constructor. So, I applied your suggestion in a subsequent commit.

5. Commit:
I took care about class TestResultManager in this commit. One idea for further improvement with respect to nullability might be method GetResultForTest. Currently the signature is
`ResultNode? GetResultForTest(string id)`
That means that every client needs to check for null. Using the nullability annotations it can be improved to:
bool TryGetResultForTest(string id, [NotNullIWhen(true)] out ResultNode resultNode)

6. Commit:
In class `TestCentricProject` I need to check the `subPackage.Fullname` property for null. My assumption is that it cannot be null at those locations.

7. Commit:
Finally class TestModel was in focus. Here I used the nullability attributes MemberNotNullWhen.
One remark regarding property TestModel.ActiveTestItem. While checking the code base, if this property might be null or not, I noticed that this property is no longer set anywhere. Therefore I suggest to remove it - but didn't want to mix this commit with other stuff at this point in time. 

8. Commit:
After fixing all compiler errors, I noticed that some tests are failing due to null checks in class TestNode. I needed to adapt test code to create accurate TestNode instances.

9. Commit:
Here I applied your suggestion to class TestNode - moving the assignment and null checks into the constructor. Afterwards quite a lot of tests needs to be adapted further to create accurate TestNodes again 😄 
