### PR TITLE
Add nullability checks in project NUnit.UIException

### DIFF
--- a/src/GuiRunner/NUnit.UiException.Tests/CodeFormatters/TestPlainTextCodeFormatter.cs
+++ b/src/GuiRunner/NUnit.UiException.Tests/CodeFormatters/TestPlainTextCodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -39,7 +39,7 @@ namespace NUnit.UiException.Tests.CodeFormatters
             Assert.That(_formatter.PreProcess("hello\tworld"), Is.EqualTo("hello    world"));
 
             // test to fail: passing null has no effect.
-            Assert.That(_formatter.PreProcess(null), Is.Null);
+            Assert.That(_formatter.PreProcess(null), Is.Empty);
 
             return;
         }

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/CSCode.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/CSCode.cs
@@ -1,10 +1,11 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
 using System.Collections.Generic;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/CSParser.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/CSParser.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System.Text;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/CSToken.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/CSToken.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/CSTokenCollection.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/CSTokenCollection.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/LexToken.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/LexToken.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/Lexer.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/Lexer.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/TokenClassifier.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/TokenClassifier.cs
@@ -1,10 +1,11 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
 using System.Collections.Generic;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CSharpParser/TokenDictionary.cs
+++ b/src/GuiRunner/NUnit.UiException/CSharpParser/TokenDictionary.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#nullable disable
 
 namespace NUnit.UiException.CodeFormatters
 {

--- a/src/GuiRunner/NUnit.UiException/CodeFormatters/CodeFormatterCollection.cs
+++ b/src/GuiRunner/NUnit.UiException/CodeFormatters/CodeFormatterCollection.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NUnit.UiException.CodeFormatters
 {
@@ -72,7 +73,7 @@ namespace NUnit.UiException.CodeFormatters
         /// </summary>
         /// <param name="language">A file extension such as: "cs".</param>
         /// <returns>True if there is such formatter, false otherwise.</returns>
-        public bool HasExtension(string extension)
+        public bool HasExtension([NotNullWhen(true)] string? extension)
         {
             if (extension == null)
                 return (false);

--- a/src/GuiRunner/NUnit.UiException/CodeFormatters/GeneralCodeFormatter.cs
+++ b/src/GuiRunner/NUnit.UiException/CodeFormatters/GeneralCodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -151,7 +151,7 @@ namespace NUnit.UiException.CodeFormatters
             return (DefaultFormatter.Format(code));
         }
 
-        public string LanguageFromExtension(string extension)
+        public string LanguageFromExtension(string? extension)
         {
             if (_formatters.HasExtension(extension))
                 return (_formatters.GetFromExtension(extension).Language);

--- a/src/GuiRunner/NUnit.UiException/CodeFormatters/IFormatterCatalog.cs
+++ b/src/GuiRunner/NUnit.UiException/CodeFormatters/IFormatterCatalog.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -27,6 +27,6 @@ namespace NUnit.UiException.CodeFormatters
         /// </summary>
         /// <param name="extension">An extension without the dot, like 'cs'</param>
         /// <returns>A language name, like 'C#'</returns>
-        string LanguageFromExtension(string extension);
+        string LanguageFromExtension(string? extension);
     }
 }

--- a/src/GuiRunner/NUnit.UiException/CodeFormatters/PlainTextCodeFormatter.cs
+++ b/src/GuiRunner/NUnit.UiException/CodeFormatters/PlainTextCodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -81,7 +81,7 @@ namespace NUnit.UiException.CodeFormatters
         public string PreProcess(string text)
         {
             if (text == null)
-                return (null);
+                return string.Empty;
 
             // this replace tabulation by space sequences. The reason is
             // that the technique used to measure strings at rendering time

--- a/src/GuiRunner/NUnit.UiException/Controls/CodeBox.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/CodeBox.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Windows.Forms;
 using NUnit.UiException.CodeFormatters;
@@ -199,6 +200,7 @@ namespace NUnit.UiException.Controls
             return;
         }
 
+        [MemberNotNull(nameof(_workingContext))]
         private void createGraphics()
         {
             Graphics gCurrent = CreateGraphics();

--- a/src/GuiRunner/NUnit.UiException/Controls/CodeRenderingContext.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/CodeRenderingContext.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -42,6 +42,10 @@ namespace NUnit.UiException.Controls
                 new ColorMaterial(Color.White),        // current line fore color                
             };
 
+            // These members are not initialized within the constructor.
+            // Clients are expected to initialize via properties after construction
+            _graphics = null!;
+            _font = null!;
             return;
         }
 

--- a/src/GuiRunner/NUnit.UiException/Controls/DefaultErrorListRenderer.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/DefaultErrorListRenderer.cs
@@ -1,9 +1,10 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using NUnit.UiException.Properties;
 
@@ -64,6 +65,7 @@ namespace NUnit.UiException.Controls
         public Font Font
         {
             get { return (_font); }
+            [MemberNotNull(nameof(_font), nameof(_fontUnderlined))]
             set
             {
                 _fontUnderlined = _font = value;
@@ -136,7 +138,7 @@ namespace NUnit.UiException.Controls
             return (new Size((int)w, items.Count * _itemHeight));
         }
 
-        public ErrorItem ItemAt(ErrorItemCollection items, Graphics g, Point point)
+        public ErrorItem? ItemAt(ErrorItemCollection items, Graphics g, Point point)
         {
             int idx = point.Y / _itemHeight;
 
@@ -282,12 +284,17 @@ namespace NUnit.UiException.Controls
         {
             public Graphics WorkingGraphics;
 
-            private ErrorItem _firstItem;
+            private ErrorItem? _firstItem;
             private ErrorItem selection;
             private Rectangle viewport;
             private Image _workingImage;
 
-            public PaintData() { }
+            public PaintData() 
+            {
+                WorkingGraphics = null!;
+                selection = null!;
+                _workingImage = null!;
+            }
 
             public PaintData(ErrorItemCollection items, ErrorItem item, Rectangle rectangle, Graphics g)
             {
@@ -323,7 +330,7 @@ namespace NUnit.UiException.Controls
 
             public bool Equals(ErrorItemCollection items, ErrorItem item, Rectangle rectangle)
             {
-                ErrorItem first = ((items.Count > 0) ? items[0] : null);
+                ErrorItem? first = ((items.Count > 0) ? items[0] : null);
 
                 return (viewport.Equals(rectangle) &&
                         object.ReferenceEquals(item, selection) &&

--- a/src/GuiRunner/NUnit.UiException/Controls/ErrorBrowser.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/ErrorBrowser.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -40,11 +40,11 @@ namespace NUnit.UiException.Controls
     /// </summary>
     public class ErrorBrowser : UserControl
     {
-        public event EventHandler StackTraceSourceChanged;
-        public event EventHandler StackTraceDisplayChanged;
+        public event EventHandler? StackTraceSourceChanged;
+        public event EventHandler? StackTraceDisplayChanged;
         private ErrorPanelLayout _layout;
 
-        private string _stackStace;
+        private string _stackStace = null!;
 
         /// <summary>
         /// Builds a new instance of ErrorBrowser.
@@ -96,7 +96,7 @@ namespace NUnit.UiException.Controls
         /// <summary>
         /// Gets the selected display.
         /// </summary>
-        public IErrorDisplay SelectedDisplay
+        public IErrorDisplay? SelectedDisplay
         {
             get { return (Toolbar.SelectedDisplay); }
             set { Toolbar.SelectedDisplay = value; }
@@ -121,22 +121,9 @@ namespace NUnit.UiException.Controls
             return;
         }
 
-        /// <summary>
-        /// Removes all display from ErrorBrowser.
-        /// </summary>
-        public void ClearAll()
-        {
-            Toolbar.Clear();
-
-            LayoutPanel.Option = null;
-            LayoutPanel.Content = null;
-
-            return;
-        }
-
         void Toolbar_SelectedRendererChanged(object sender, EventArgs e)
         {
-            LayoutPanel.Content = Toolbar.SelectedDisplay.Content;
+            LayoutPanel.Content = Toolbar.SelectedDisplay!.Content;
 
             if (StackTraceDisplayChanged != null)
                 StackTraceDisplayChanged(this, EventArgs.Empty);

--- a/src/GuiRunner/NUnit.UiException/Controls/ErrorList.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/ErrorList.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -16,11 +16,11 @@ namespace NUnit.UiException.Controls
         UserControl,
         IStackTraceView
     {
-        public event EventHandler SelectedItemChanged;
+        public event EventHandler? SelectedItemChanged;
 
         private ErrorListOrderPolicy _listOrder;
         private ErrorItemCollection _items;
-        private ErrorItem _selection;
+        private ErrorItem? _selection;
         private string _stackTrace;
         protected IErrorListRenderer _renderer;
         protected Graphics _workingGraphics;
@@ -58,7 +58,7 @@ namespace NUnit.UiException.Controls
             get { return (_stackTrace); }
             set
             {
-                ErrorItem candidate;
+                ErrorItem? candidate;
 
                 candidate = PopulateList(value);
 
@@ -76,7 +76,7 @@ namespace NUnit.UiException.Controls
             }
         }
 
-        public ErrorItem SelectedItem
+        public ErrorItem? SelectedItem
         {
             get { return (_selection); }
             set
@@ -122,7 +122,7 @@ namespace NUnit.UiException.Controls
 
             _renderer = renderer;
             _items = new ErrorItemCollection();
-            _stackTrace = null;
+            _stackTrace = null!;
             _selection = null;
             _workingGraphics = CreateGraphics();
             _hoveredIndex = -1;
@@ -151,7 +151,7 @@ namespace NUnit.UiException.Controls
 
             viewport = new Rectangle(-AutoScrollPosition.X, -AutoScrollPosition.Y,
                 ClientRectangle.Width, ClientRectangle.Height);
-            _renderer.DrawToGraphics(_items, _selection, e.Graphics, viewport);
+            _renderer.DrawToGraphics(_items, _selection!, e.Graphics, viewport);
 
             if (_hoveredIndex != -1)
                 _renderer.DrawItem(_items[_hoveredIndex], _hoveredIndex, true,
@@ -174,7 +174,7 @@ namespace NUnit.UiException.Controls
 
         protected override void OnMouseMove(MouseEventArgs e)
         {
-            ErrorItem item;
+            ErrorItem? item;
             int itemIndex;
 
             base.OnMouseMove(e);
@@ -235,10 +235,10 @@ namespace NUnit.UiException.Controls
             Invalidate();
         }
 
-        private ErrorItem PopulateList(string stackTrace)
+        private ErrorItem? PopulateList(string stackTrace)
         {
             StackTraceParser parser = new StackTraceParser();
-            ErrorItem candidate;
+            ErrorItem? candidate;
 
             _stackTrace = stackTrace;
             parser.Parse(stackTrace);

--- a/src/GuiRunner/NUnit.UiException/Controls/ErrorToolbar.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/ErrorToolbar.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -19,7 +19,7 @@ namespace NUnit.UiException.Controls
         ToolStrip,
         IEnumerable
     {
-        public event EventHandler SelectedRendererChanged;
+        public event EventHandler? SelectedRendererChanged;
 
         private List<IErrorDisplay> _displays;
 
@@ -45,7 +45,7 @@ namespace NUnit.UiException.Controls
         /// Create and configure a ToolStripButton.
         /// </summary>
         public static ToolStripButton NewStripButton(
-            bool canCheck, string text, Image image, EventHandler onClick)
+            bool canCheck, string text, Image image, EventHandler? onClick)
         {
             ToolStripButton button;
 
@@ -78,7 +78,7 @@ namespace NUnit.UiException.Controls
         /// <summary>
         /// Gets or sets the IErrorDisplay to be selected.
         /// </summary>
-        public IErrorDisplay SelectedDisplay
+        public IErrorDisplay? SelectedDisplay
         {
             get
             {
@@ -188,7 +188,7 @@ namespace NUnit.UiException.Controls
             return;
         }
 
-        private int IndexOf(IErrorDisplay renderer)
+        private int IndexOf(IErrorDisplay? renderer)
         {
             int i;
 
@@ -204,8 +204,8 @@ namespace NUnit.UiException.Controls
 
         private void item_Click(object sender, EventArgs e)
         {
-            ToolStripItem item = sender as ToolStripItem;
-            IErrorDisplay renderer;
+            ToolStripItem? item = sender as ToolStripItem;
+            IErrorDisplay? renderer;
 
             if (item == null || item.Tag == null)
                 return;

--- a/src/GuiRunner/NUnit.UiException/Controls/IErrorListRenderer.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/IErrorListRenderer.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -51,7 +51,7 @@ namespace NUnit.UiException.Controls
         /// <param name="g">The target graphics object</param>
         /// <param name="point">Some client coordinate values</param>
         /// <returns>One item in the collection or null the location doesn't match any item</returns>
-        ErrorItem ItemAt(ErrorItemCollection items, Graphics g, Point point);
+        ErrorItem? ItemAt(ErrorItemCollection items, Graphics g, Point point);
 
         /// <summary>
         /// Gets and sets the font for this renderer

--- a/src/GuiRunner/NUnit.UiException/Controls/IStackTraceView.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/IStackTraceView.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -39,7 +39,7 @@ namespace NUnit.UiException.Controls
         event EventHandler SelectedItemChanged;
 
         string StackTrace { get; set; }
-        ErrorItem SelectedItem { get; }
+        ErrorItem? SelectedItem { get; }
         bool AutoSelectFirstItem { get; set; }
         ErrorListOrderPolicy ListOrderPolicy { get; set; }
     }

--- a/src/GuiRunner/NUnit.UiException/Controls/PaintLineLocation.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/PaintLineLocation.cs
@@ -1,8 +1,9 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 namespace NUnit.UiException.Controls
@@ -68,13 +69,11 @@ namespace NUnit.UiException.Controls
 
         public override bool Equals(object obj)
         {
-            PaintLineLocation line;
-
             if (obj == null ||
                 !(obj is PaintLineLocation))
                 return (false);
 
-            line = obj as PaintLineLocation;
+            PaintLineLocation line = (PaintLineLocation)obj;
 
             return (line.LineIndex == LineIndex &&
                 line.Text == Text &&
@@ -101,6 +100,7 @@ namespace NUnit.UiException.Controls
             return;
         }
 
+        [MemberNotNull(nameof(_text))]
         protected void SetText(string text)
         {
             UiExceptionHelper.CheckNotNull(text, "text");

--- a/src/GuiRunner/NUnit.UiException/Controls/SourceCodeDisplay.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/SourceCodeDisplay.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -34,8 +34,8 @@ namespace NUnit.UiException.Controls
         private ToolStripButton _btnPlugin;
         private ToolStripButton _btnSwap;
 
-        public event EventHandler SplitOrientationChanged;
-        public event EventHandler SplitterDistanceChanged;
+        public event EventHandler? SplitOrientationChanged;
+        public event EventHandler? SplitterDistanceChanged;
 
         /// <summary>
         /// Builds a new instance of SourceCodeDisplay.
@@ -135,14 +135,14 @@ namespace NUnit.UiException.Controls
 
         protected void SelectedItemChanged(object sender, EventArgs e)
         {
-            ErrorItem item;
+            ErrorItem? item;
             IFormatterCatalog formatter;
 
             item = _stacktraceView.SelectedItem;
 
             if (item == null)
             {
-                _codeView.Text = null;
+                _codeView.Text = "";
                 return;
             }
 

--- a/src/GuiRunner/NUnit.UiException/Controls/SplitterBox.cs
+++ b/src/GuiRunner/NUnit.UiException/Controls/SplitterBox.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -81,8 +81,8 @@ namespace NUnit.UiException.Controls
         private Rectangle _rHorizontalDirection;
         private Rectangle _rHorizontalCollapse2;
 
-        public event EventHandler OrientationChanged;
-        public event EventHandler SplitterDistanceChanged;
+        public event EventHandler? OrientationChanged;
+        public event EventHandler? SplitterDistanceChanged;
 
         /// <summary>
         /// Creates a new SplitterBox.

--- a/src/GuiRunner/NUnit.UiException/DefaultTextManager.cs
+++ b/src/GuiRunner/NUnit.UiException/DefaultTextManager.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NUnit.UiException
 {
@@ -57,6 +58,7 @@ namespace NUnit.UiException
         public string Text
         {
             get { return (_text); }
+            [MemberNotNull(nameof(_text))]
             set
             {
                 if (value == null)

--- a/src/GuiRunner/NUnit.UiException/ExceptionItem.cs
+++ b/src/GuiRunner/NUnit.UiException/ExceptionItem.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -27,12 +27,12 @@ namespace NUnit.UiException
         /// <summary>
         /// An access path to the source file referred by this item.
         /// </summary>
-        private string _path;
+        private string? _path;
 
         /// <summary>
         /// The full qualified name of the member method referred by this item.
         /// </summary>
-        private string _fullyQualifiedMethodName;
+        private string? _fullyQualifiedMethodName;
 
         /// <summary>
         /// The line index where the exception occured.
@@ -42,7 +42,7 @@ namespace NUnit.UiException
         /// <summary>
         /// Store the content of the file pointed by _path.
         /// </summary>
-        private string _text;
+        private string? _text;
       
         /// <summary>
         /// Create an instance of ErrorItem that
@@ -64,7 +64,7 @@ namespace NUnit.UiException
         /// <param name="path">An absolute path to the source code file.</param>
         /// <param name="fullMethodName">A full qualified name of a member method.</param>
         /// <param name="lineNumber">A line index where the exception occured.</param>
-        public ErrorItem(string path, string fullMethodName, int lineNumber)
+        public ErrorItem(string? path, string? fullMethodName, int lineNumber)
         {
             _path = path;
             _fullyQualifiedMethodName = fullMethodName;
@@ -94,7 +94,7 @@ namespace NUnit.UiException
         /// <summary>
         /// Gets the absolute path to the source code file.
         /// </summary>
-        public string Path 
+        public string? Path 
         {
             get { return (_path); }
         }
@@ -103,7 +103,7 @@ namespace NUnit.UiException
         /// Returns the file language - e.g.: the string after
         /// the last dot or null -
         /// </summary>
-        public string FileExtension
+        public string? FileExtension
         {
             get 
             {
@@ -123,7 +123,7 @@ namespace NUnit.UiException
         /// <summary>
         /// Gets the full qualified name of the member method.
         /// </summary>
-        public string FullyQualifiedMethodName
+        public string? FullyQualifiedMethodName
         {
             get { return (_fullyQualifiedMethodName); }
         }
@@ -235,7 +235,7 @@ namespace NUnit.UiException
 
         public override bool Equals(object obj)
         {
-            ErrorItem item = obj as ErrorItem;
+            ErrorItem? item = obj as ErrorItem;
 
             if (item == null)
                 return (false);

--- a/src/GuiRunner/NUnit.UiException/NUnit.UiException.csproj
+++ b/src/GuiRunner/NUnit.UiException/NUnit.UiException.csproj
@@ -6,6 +6,14 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
+  </ItemGroup>
     
     <ItemGroup>
         <Compile Remove="data\TextCode.cs" />

--- a/src/GuiRunner/NUnit.UiException/data/StackTraceAnalysers/IErrorParser.cs
+++ b/src/GuiRunner/NUnit.UiException/data/StackTraceAnalysers/IErrorParser.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) Charlie Poole and TestCentric contributors.
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
@@ -7,8 +7,8 @@ namespace NUnit.UiException.StackTraceAnalyzers
 {
     public class RawError
     {
-        private string _function;
-        private string _path;
+        private string? _function;
+        private string? _path;
         private int _line;
         private string _input;
 
@@ -25,13 +25,13 @@ namespace NUnit.UiException.StackTraceAnalyzers
             get { return (_input); }
         }
 
-        public string Function
+        public string? Function
         {
             get { return (_function); }
             set { _function = value; }
         }
 
-        public string Path
+        public string? Path
         {
             get { return (_path); }
             set { _path = value; }

--- a/src/GuiRunner/TestCentric.Gui/Views/ErrorsAndFailuresView.cs
+++ b/src/GuiRunner/TestCentric.Gui/Views/ErrorsAndFailuresView.cs
@@ -175,7 +175,7 @@ namespace TestCentric.Gui.Views
         private void detailList_SelectedIndexChanged(object sender, System.EventArgs e)
         {
             TestResultItem resultItem = (TestResultItem)detailList.SelectedItem;
-            errorBrowser.StackTraceSource = resultItem.FilteredStackTrace;
+            errorBrowser.StackTraceSource = resultItem.FilteredStackTrace ?? "";
             detailList.ContextMenuStrip = detailListContextMenuStrip;
         }
 


### PR DESCRIPTION
Next project `NUnit.UIException` with enabled nullable checks - contributing to #1492

In most locations, I have inserted the `?` or `!` operator. That said, I took a cautious approach overall so as not to disrupt any behaviour. I even disabled nullable checks in the parser files because I didn't manage to get a good overview about the target state for certain properties and members (null allowed or not). However, I think that's fine for now. This code part hasn't changed for a while. If for some reasons new features need to be implemented, it's a good chance to activate those null checks at that point in time.